### PR TITLE
Add loop-aware SSA builder with phi-node insertion

### DIFF
--- a/loop_structure.py
+++ b/loop_structure.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
+
+from turing_provenance import ProvenanceGraph, ProvEdge, ProvNode
+
+
+@dataclass
+class LoopInfo:
+    """Container describing a natural loop."""
+
+    header: int
+    body: Set[int]
+    latch: int
+    preheader: int
+    loop_vars: List[Tuple[int, int, int]]  # (arg_pos, init_src, back_src)
+
+
+class LoopStructureAnalyzer:
+    """Analyse a ``ProvenanceGraph`` to find natural loops.
+
+    This is a *minimal* implementation tailored for the unit tests in this
+    kata.  It purposefully ignores many edge cases of full compiler loop
+    detection but follows the outline from the project brief:
+
+    * compute strongly connected components via Tarjan's algorithm
+    * for each non‑trivial SCC, identify header and latch via a back edge
+      ``u -> h`` where ``h`` dominates ``u``
+    * determine the preheader and loop carried variables feeding the header
+    """
+
+    def __init__(self, graph: ProvenanceGraph):
+        self.graph = graph
+        self.succ: Dict[int, Set[int]] = {n.idx: set() for n in graph.nodes}
+        self.pred: Dict[int, Set[int]] = {n.idx: set() for n in graph.nodes}
+        for e in graph.edges:
+            self.succ[e.src_idx].add(e.dst_idx)
+            self.pred[e.dst_idx].add(e.src_idx)
+
+    # ------------------------------------------------------------------
+    # Tarjan SCC
+    # ------------------------------------------------------------------
+    def _tarjan(self) -> List[Set[int]]:
+        index = 0
+        stack: List[int] = []
+        on_stack: Set[int] = set()
+        indices: Dict[int, int] = {}
+        lowlink: Dict[int, int] = {}
+        result: List[Set[int]] = []
+
+        def strongconnect(v: int) -> None:
+            nonlocal index
+            indices[v] = index
+            lowlink[v] = index
+            index += 1
+            stack.append(v)
+            on_stack.add(v)
+            for w in self.succ[v]:
+                if w not in indices:
+                    strongconnect(w)
+                    lowlink[v] = min(lowlink[v], lowlink[w])
+                elif w in on_stack:
+                    lowlink[v] = min(lowlink[v], indices[w])
+            # root of SCC
+            if lowlink[v] == indices[v]:
+                scc: Set[int] = set()
+                while True:
+                    w = stack.pop()
+                    on_stack.remove(w)
+                    scc.add(w)
+                    if w == v:
+                        break
+                result.append(scc)
+
+        for v in self.succ.keys():
+            if v not in indices:
+                strongconnect(v)
+        return result
+
+    # ------------------------------------------------------------------
+    # Dominators (simple iterative algorithm)
+    # ------------------------------------------------------------------
+    def _dominators(self, start: int = 0) -> Dict[int, Set[int]]:
+        nodes = list(self.succ.keys())
+        dom: Dict[int, Set[int]] = {n: set(nodes) for n in nodes}
+        dom[start] = {start}
+        changed = True
+        while changed:
+            changed = False
+            for n in nodes:
+                if n == start:
+                    continue
+                preds = self.pred[n]
+                if not preds:
+                    new_dom = {n}
+                else:
+                    it = iter(preds)
+                    new_dom = dom[next(it)].copy()
+                    for p in it:
+                        new_dom &= dom[p]
+                    new_dom.add(n)
+                if new_dom != dom[n]:
+                    dom[n] = new_dom
+                    changed = True
+        return dom
+
+    # ------------------------------------------------------------------
+    def find_loops(self) -> List[LoopInfo]:
+        loops: List[LoopInfo] = []
+        sccs = self._tarjan()
+        dom = self._dominators(0 if self.graph.nodes else 0)
+        for scc in sccs:
+            if len(scc) == 1:
+                n = next(iter(scc))
+                if n not in self.succ[n]:
+                    continue
+            # identify *all* back edges within the SCC
+            backedges: List[Tuple[int, int]] = []
+            for u in scc:
+                for v in self.succ[u]:
+                    if v in scc and v in dom[u]:
+                        backedges.append((u, v))
+            for latch, header in backedges:
+                preds = self.pred[header]
+                pre = next(iter(preds - scc)) if (preds - scc) else -1
+                loop_vars: List[Tuple[int, int, int]] = []
+                for e in self.graph.edges:
+                    if e.dst_idx == header and e.src_idx == latch:
+                        init_src = -1
+                        for e2 in self.graph.edges:
+                            if (
+                                e2.dst_idx == header
+                                and e2.arg_pos == e.arg_pos
+                                and e2.src_idx == pre
+                            ):
+                                init_src = e2.src_idx
+                                break
+                        loop_vars.append((e.arg_pos, init_src, e.src_idx))
+                loops.append(LoopInfo(header, scc, latch, pre, loop_vars))
+        return loops

--- a/ssa_builder.py
+++ b/ssa_builder.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from turing_provenance import ProvenanceGraph
+from loop_structure import LoopStructureAnalyzer, LoopInfo
+
+
+def insert_phi_nodes(pg: ProvenanceGraph, loops: List[LoopInfo]) -> Dict[int, List[Tuple[int, int, int]]]:
+    """Return mapping ``header -> [(arg_pos, init_src, back_src), ...]``."""
+    phi_map: Dict[int, List[Tuple[int, int, int]]] = {}
+    for info in loops:
+        if info.loop_vars:
+            phi_map[info.header] = list(info.loop_vars)
+    return phi_map
+
+
+def rename_to_ssa(pg: ProvenanceGraph, phi_map: Dict[int, List[Tuple[int, int, int]]]) -> Dict[int, str]:
+    """Assign human readable names to all node results and φ-nodes."""
+    names: Dict[int, str] = {n.idx: f"%n{n.idx}" for n in pg.nodes}
+    for header, vars in phi_map.items():
+        for arg_pos, _, _ in vars:
+            names[(header << 16) + arg_pos] = f"%n{header}.phi{arg_pos}"
+    return names
+
+
+def graph_to_ssa_with_loops(pg: ProvenanceGraph) -> str:
+    """Emit a tiny LLVM-like textual SSA for ``pg`` handling natural loops."""
+    analyzer = LoopStructureAnalyzer(pg)
+    loops = analyzer.find_loops()
+    phi_map = insert_phi_nodes(pg, loops)
+    names = rename_to_ssa(pg, phi_map)
+
+    # Precompute incoming edges per node
+    incoming: Dict[int, Dict[int, int]] = {n.idx: {} for n in pg.nodes}
+    for e in pg.edges:
+        incoming[e.dst_idx][e.arg_pos] = e.src_idx
+
+    lines: List[str] = []
+    for node in pg.nodes:
+        # emit φ-nodes if this is a loop header
+        if node.idx in phi_map:
+            for arg_pos, init_src, back_src in phi_map[node.idx]:
+                phi_name = names[(node.idx << 16) + arg_pos]
+                init_name = names.get(init_src, f"%n{init_src}" if init_src >= 0 else "undef")
+                back_name = names[back_src]
+                lines.append(
+                    f"{phi_name} = phi [{init_name}, %{init_src if init_src >= 0 else 'pre'}], [{back_name}, %{back_src}]"
+                )
+        # now emit the actual operation
+        args = []
+        for idx in range(len(node.args)):
+            src = incoming[node.idx].get(idx)
+            args.append(names.get(src, f"%n{src}" if src is not None else "undef"))
+        lines.append(f"{names[node.idx]} = {node.op} {', '.join(args)}")
+    return "\n".join(lines)

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -1,0 +1,63 @@
+from turing_provenance import ProvenanceGraph, ProvNode, ProvEdge
+from ssa_builder import graph_to_ssa_with_loops
+
+
+def _make_node(idx, op):
+    return ProvNode(idx, op, (), {}, idx)
+
+
+def test_simple_counter_phi():
+    pg = ProvenanceGraph()
+    pg._nodes = [
+        ProvNode(0, 'init', (), {}, 0),
+        ProvNode(1, 'cmp', (), {}, 1),
+        ProvNode(2, 'inc', (), {}, 2),
+    ]
+    pg._edges = [
+        ProvEdge(0,1,0),
+        ProvEdge(1,2,0),
+        ProvEdge(2,1,0),
+    ]
+    ssa = graph_to_ssa_with_loops(pg)
+    assert '%n1.phi0' in ssa
+    assert 'phi' in ssa
+
+
+def test_rotate_until_pattern_phi():
+    pg = ProvenanceGraph()
+    pg._nodes = [
+        ProvNode(0, 'start', (), {}, 0),
+        ProvNode(1, 'check', (), {}, 1),
+        ProvNode(2, 'rot', (), {}, 2),
+    ]
+    pg._edges = [
+        ProvEdge(0,1,0),
+        ProvEdge(1,2,0),
+        ProvEdge(2,1,0),
+    ]
+    ssa = graph_to_ssa_with_loops(pg)
+    assert '%n1.phi0' in ssa
+
+
+def test_two_loops_phis():
+    pg = ProvenanceGraph()
+    pg._nodes = [
+        ProvNode(0, 'i0', (), {}, 0),
+        ProvNode(1, 'outer_chk', (), {}, 1),
+        ProvNode(2, 'j0', (), {}, 2),
+        ProvNode(3, 'inner_chk', (), {}, 3),
+        ProvNode(4, 'inner_inc', (), {}, 4),
+        ProvNode(5, 'outer_inc', (), {}, 5),
+    ]
+    pg._edges = [
+        ProvEdge(0,1,0),
+        ProvEdge(1,5,0),
+        ProvEdge(5,1,0),
+        ProvEdge(1,3,0),
+        ProvEdge(2,3,0),
+        ProvEdge(3,4,0),
+        ProvEdge(4,3,0),
+    ]
+    ssa = graph_to_ssa_with_loops(pg)
+    assert '%n1.phi0' in ssa
+    assert '%n3.phi0' in ssa


### PR DESCRIPTION
## Summary
- implement `LoopStructureAnalyzer` to detect natural loops via SCCs and dominance
- add SSA builder that inserts φ-nodes and prints LLVM-like SSA
- provide tests for simple loops and multiple-loop scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fbd23ee60832a8bc72f62c47b063c