### PR TITLE
Implement PCM operators and gated tape access

### DIFF
--- a/cassette_tape.py
+++ b/cassette_tape.py
@@ -22,6 +22,9 @@ import threading
 import queue
 import time
 
+from analog_spec import generate_bit_wave, FRAME_SAMPLES
+from tape_head import TapeHead
+
 try:
     import numpy as np
     _Vec = np.ndarray
@@ -59,7 +62,8 @@ class CassetteTapeBackend:
 
     # -------------------------- Runtime State ---------------------------------- #
     _head_pos_inches: float = 0.0
-    _tape_data: Dict[int, int] = field(default_factory=dict)
+    _tape_frames: Dict[int, _Vec] = field(default_factory=dict)
+    _gate: threading.Lock = field(default_factory=threading.Lock)
 
     _audio_cursor: int = 0
     _audio_buffer: _Vec | None = None
@@ -73,6 +77,7 @@ class CassetteTapeBackend:
         self._decay_s = self.decay_ms / 1000.0 * self.time_scale_factor
         self._release_s = self.release_ms / 1000.0 * self.time_scale_factor
         self._init_audio_system()
+        self._head = TapeHead(self)
 
     @property
     def total_bits(self) -> int:
@@ -102,19 +107,46 @@ class CassetteTapeBackend:
         self._simulate_movement(abs(distance_inches), self.seek_speed_ips, direction, 'seek')
         self._head_pos_inches = target_pos_inches
 
+    # ---------------------------- Bit / Frame Access --------------------------- #
+
+    def read_wave(self, bit_idx: int) -> _Vec:
+        """Return the PCM frame at ``bit_idx`` after physical seek and scan."""
+        with self._gate:
+            self.move_head_to_bit(bit_idx)
+            current_idx = int(round(self._head_pos_inches * self.bits_per_inch))
+            if current_idx != bit_idx:
+                raise RuntimeError("head misaligned for read")
+            bit_width_inches = 1.0 / self.bits_per_inch
+            self._head.enqueue_read(bit_idx)
+            self._simulate_movement(bit_width_inches, self.read_write_speed_ips, 1, 'read')
+            frame = self._head.activate('read', self.read_write_speed_ips)
+            self._head_pos_inches += bit_width_inches
+            if frame is None:
+                raise RuntimeError("read head not engaged at correct speed")
+            return frame
+
+    def write_wave(self, bit_idx: int, frame: _Vec):
+        """Write a PCM frame to ``bit_idx`` respecting head movement."""
+        with self._gate:
+            self.move_head_to_bit(bit_idx)
+            current_idx = int(round(self._head_pos_inches * self.bits_per_inch))
+            if current_idx != bit_idx:
+                raise RuntimeError("head misaligned for write")
+            bit_width_inches = 1.0 / self.bits_per_inch
+            self._head.enqueue_write(bit_idx, frame)
+            self._simulate_movement(bit_width_inches, self.read_write_speed_ips, 1, 'write')
+            self._head.activate('write', self.read_write_speed_ips)
+            self._head_pos_inches += bit_width_inches
+
+    # Digital convenience wrappers ------------------------------------------------ #
+
     def read_bit(self, bit_idx: int) -> int:
-        self.move_head_to_bit(bit_idx)
-        bit_width_inches = 1.0 / self.bits_per_inch
-        self._simulate_movement(bit_width_inches, self.read_write_speed_ips, 1, 'read')
-        self._head_pos_inches += bit_width_inches
-        return self._tape_data.get(bit_idx, 0)
+        wave = self.read_wave(bit_idx)
+        return 1 if float(np.max(np.abs(wave))) > 0.5 else 0
 
     def write_bit(self, bit_idx: int, value: int):
-        self.move_head_to_bit(bit_idx)
-        bit_width_inches = 1.0 / self.bits_per_inch
-        self._simulate_movement(bit_width_inches, self.read_write_speed_ips, 1, 'write')
-        self._head_pos_inches += bit_width_inches
-        self._tape_data[bit_idx] = 1 if value else 0
+        frame = generate_bit_wave(1 if value else 0, 0)
+        self.write_wave(bit_idx, frame)
         
     def _simulate_movement(self, distance_inches: float, target_speed_ips: float, direction: int, op_name: str):
         # --- 1. Calculate Time and Speed Profile ---
@@ -174,6 +206,7 @@ class CassetteTapeBackend:
 
         self._audio_buffer[self._audio_cursor : self._audio_cursor + num_samples] += final_mix
         self._audio_cursor += num_samples
+        time.sleep(scaled_time_sec)
 
     def _get_adsr_envelope(self, duration_s: float, n_samples: int) -> _Vec:
         env = np.zeros(n_samples, dtype="f4")

--- a/tape_head.py
+++ b/tape_head.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Physical tape head with speed-gated queues.
+
+The head mediates all data transfer to the backing store.  Reads and writes
+are enqueued and only executed when the motor reports that the tape is
+moving at the calibrated read/write speed **and** the head has been put into
+explicit read or write mode.  This models the requirement that no data moves
+without precise coordination of motor velocity and head activation.
+"""
+
+from dataclasses import dataclass, field
+import queue
+from typing import Optional
+
+from analog_spec import FRAME_SAMPLES
+
+try:  # pragma: no cover - numpy may be absent during import analysis
+    import numpy as np
+    _Vec = np.ndarray
+except ModuleNotFoundError:  # pragma: no cover
+    np = None
+    _Vec = list
+
+
+@dataclass
+class TapeHead:
+    tape: "CassetteTapeBackend"
+    speed_tolerance: float = 1e-3
+    _read_queue: "queue.Queue[int]" = field(default_factory=queue.Queue)
+    _write_queue: "queue.Queue[tuple[int, _Vec]]" = field(default_factory=queue.Queue)
+    mode: Optional[str] = None
+
+    def enqueue_read(self, bit_idx: int) -> None:
+        self._read_queue.put(bit_idx)
+
+    def enqueue_write(self, bit_idx: int, frame: _Vec) -> None:
+        self._write_queue.put((bit_idx, frame))
+
+    # ------------------------------------------------------------------
+    def activate(self, mode: str, speed: float) -> Optional[_Vec]:
+        """Execute queued transfers if ``speed`` matches read/write speed.
+
+        Returns the PCM frame for the processed read, or ``None`` otherwise.
+        """
+        self.mode = mode
+        if abs(speed - self.tape.read_write_speed_ips) > self.speed_tolerance:
+            return None
+
+        if mode == "read" and not self._read_queue.empty():
+            bit_idx = self._read_queue.get_nowait()
+            current_idx = int(round(self.tape._head_pos_inches * self.tape.bits_per_inch))
+            if current_idx != bit_idx:
+                raise RuntimeError("head misaligned during read activation")
+            return self.tape._tape_frames.get(
+                bit_idx, np.zeros(FRAME_SAMPLES, dtype="f4") if np is not None else [0.0] * FRAME_SAMPLES
+            )
+        if mode == "write" and not self._write_queue.empty():
+            bit_idx, frame = self._write_queue.get_nowait()
+            current_idx = int(round(self.tape._head_pos_inches * self.tape.bits_per_inch))
+            if current_idx != bit_idx:
+                raise RuntimeError("head misaligned during write activation")
+            self.tape._tape_frames[bit_idx] = frame.astype("f4") if np is not None else frame
+        return None

--- a/tests/test_analog_stub.py
+++ b/tests/test_analog_stub.py
@@ -1,6 +1,15 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 import numpy as np
 import pytest
-from analog_spec import FRAME_SAMPLES, generate_bit_wave, nand_wave
+from analog_spec import (
+    FRAME_SAMPLES,
+    generate_bit_wave,
+    nand_wave,
+    sigma_L,
+    sigma_R,
+)
 
 
 def test_generate_bit_wave_shapes():
@@ -12,8 +21,18 @@ def test_generate_bit_wave_shapes():
     assert np.max(np.abs(zero)) == 0.0
 
 
-def test_nand_wave_unimplemented():
-    x = generate_bit_wave(1, 0)
-    y = generate_bit_wave(1, 0)
-    with pytest.raises(NotImplementedError):
-        nand_wave(x, y)
+def test_nand_wave_behaviour():
+    x1 = generate_bit_wave(1, 0)
+    x0 = generate_bit_wave(0, 0)
+    assert np.max(np.abs(nand_wave(x1, x1))) == 0.0
+    assert np.max(np.abs(nand_wave(x1, x0))) > 0.0
+    assert np.max(np.abs(nand_wave(x0, x0))) > 0.0
+
+
+def test_sigma_ops():
+    frames = [generate_bit_wave(1, 0)] * 2
+    appended = sigma_L(frames, 1)
+    assert len(appended) == 3
+    assert np.max(np.abs(appended[-1])) == 0.0
+    trimmed = sigma_R(appended, 2)
+    assert len(trimmed) == 1

--- a/tests/test_cassette_tape.py
+++ b/tests/test_cassette_tape.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 from cassette_tape import CassetteTapeBackend
+from analog_spec import generate_bit_wave
 
 
 def test_read_write_emits_audio():
@@ -12,15 +13,32 @@ def test_read_write_emits_audio():
         tape_length_inches=0.02,
         op_sine_coeffs={"read": {440.0: 1.0}, "write": {880.0: 1.0}, "motor": {60.0: 0.5}},
     )
-    tape.write_bit(0, 1)
-    assert tape.read_bit(0) == 1
+    frame = generate_bit_wave(1, 0)
+    tape.write_wave(0, frame)
+    out = tape.read_wave(0)
+    assert np.max(np.abs(out)) > 0.0
     assert tape._audio_cursor > 0
     tape.close()
 
 
-def test_move_head_to_bit_and_write():
+def test_move_head_to_bit_and_write_wrapper():
     tape = CassetteTapeBackend(tape_length_inches=0.02)
     tape.move_head_to_bit(5)
     tape.write_bit(5, 1)
     assert tape.read_bit(5) == 1
+    tape.close()
+
+
+def test_head_gates_on_speed():
+    tape = CassetteTapeBackend(tape_length_inches=0.02)
+    # prepare data and head position
+    frame = generate_bit_wave(1, 0)
+    tape._tape_frames[0] = frame
+    tape.move_head_to_bit(0)
+    tape._head.enqueue_read(0)
+    # incorrect speed -> queue remains
+    assert tape._head.activate('read', 0.5) is None
+    # correct speed unlocks transfer
+    out = tape._head.activate('read', tape.read_write_speed_ips)
+    assert np.max(np.abs(out)) > 0
     tape.close()


### PR DESCRIPTION
## Summary
- Implement speed-gated `TapeHead` managing queued reads and writes
- Integrate head queues with cassette backend for motor-coordinated transfers
- Test that head queues only release data at calibrated read/write speed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689069a97e14832a99ba8569f46d809d