### PR TITLE
Add track and lane support to cassette tape backend

### DIFF
--- a/survival_computer.py
+++ b/survival_computer.py
@@ -63,24 +63,24 @@ class GraphExecutor:
         # --- Translate each primitive into physical R/W/Move operations ---
         if op == "zeros":
             for i in range(self.bit_width):
-                self.cassette.write_bit(output_addr + i, 0)
+                self.cassette.write_bit(0, 0, output_addr + i, 0)
         
         elif op == "nand":
             addr_x, addr_y = input_addrs
             for i in range(self.bit_width):
-                bit_x = self.cassette.read_bit(addr_x + i)
-                bit_y = self.cassette.read_bit(addr_y + i)
+                bit_x = self.cassette.read_bit(0, 0, addr_x + i)
+                bit_y = self.cassette.read_bit(0, 0, addr_y + i)
                 result = 1 - (bit_x & bit_y)
-                self.cassette.write_bit(output_addr + i, result)
+                self.cassette.write_bit(0, 0, output_addr + i, result)
         
         elif op == "mu":
             addr_x, addr_y, addr_sel = input_addrs
             for i in range(self.bit_width):
-                bit_x = self.cassette.read_bit(addr_x + i)
-                bit_y = self.cassette.read_bit(addr_y + i)
-                sel = self.cassette.read_bit(addr_sel + i)
+                bit_x = self.cassette.read_bit(0, 0, addr_x + i)
+                bit_y = self.cassette.read_bit(0, 0, addr_y + i)
+                sel = self.cassette.read_bit(0, 0, addr_sel + i)
                 result = bit_y if sel else bit_x
-                self.cassette.write_bit(output_addr + i, result)
+                self.cassette.write_bit(0, 0, output_addr + i, result)
 
         elif op == "concat":
             # This is a simplified model: we assume concat inputs are smaller

--- a/tape_head.py
+++ b/tape_head.py
@@ -11,7 +11,7 @@ without precise coordination of motor velocity and head activation.
 
 from dataclasses import dataclass, field
 import queue
-from typing import Optional
+from typing import Optional, Tuple
 
 from analog_spec import FRAME_SAMPLES
 
@@ -27,15 +27,15 @@ except ModuleNotFoundError:  # pragma: no cover
 class TapeHead:
     tape: "CassetteTapeBackend"
     speed_tolerance: float = 1e-3
-    _read_queue: "queue.Queue[int]" = field(default_factory=queue.Queue)
-    _write_queue: "queue.Queue[tuple[int, _Vec]]" = field(default_factory=queue.Queue)
+    _read_queue: "queue.Queue[Tuple[int, int, int]]" = field(default_factory=queue.Queue)
+    _write_queue: "queue.Queue[Tuple[int, int, int, _Vec]]" = field(default_factory=queue.Queue)
     mode: Optional[str] = None
 
-    def enqueue_read(self, bit_idx: int) -> None:
-        self._read_queue.put(bit_idx)
+    def enqueue_read(self, track: int, lane: int, bit_idx: int) -> None:
+        self._read_queue.put((track, lane, bit_idx))
 
-    def enqueue_write(self, bit_idx: int, frame: _Vec) -> None:
-        self._write_queue.put((bit_idx, frame))
+    def enqueue_write(self, track: int, lane: int, bit_idx: int, frame: _Vec) -> None:
+        self._write_queue.put((track, lane, bit_idx, frame))
 
     # ------------------------------------------------------------------
     def activate(self, mode: str, speed: float) -> Optional[_Vec]:
@@ -48,17 +48,18 @@ class TapeHead:
             return None
 
         if mode == "read" and not self._read_queue.empty():
-            bit_idx = self._read_queue.get_nowait()
+            track, lane, bit_idx = self._read_queue.get_nowait()
             current_idx = int(round(self.tape._head_pos_inches * self.tape.bits_per_inch))
             if current_idx != bit_idx:
                 raise RuntimeError("head misaligned during read activation")
             return self.tape._tape_frames.get(
-                bit_idx, np.zeros(FRAME_SAMPLES, dtype="f4") if np is not None else [0.0] * FRAME_SAMPLES
+                (track, lane, bit_idx),
+                np.zeros(FRAME_SAMPLES, dtype="f4") if np is not None else [0.0] * FRAME_SAMPLES,
             )
         if mode == "write" and not self._write_queue.empty():
-            bit_idx, frame = self._write_queue.get_nowait()
+            track, lane, bit_idx, frame = self._write_queue.get_nowait()
             current_idx = int(round(self.tape._head_pos_inches * self.tape.bits_per_inch))
             if current_idx != bit_idx:
                 raise RuntimeError("head misaligned during write activation")
-            self.tape._tape_frames[bit_idx] = frame.astype("f4") if np is not None else frame
+            self.tape._tape_frames[(track, lane, bit_idx)] = frame.astype("f4") if np is not None else frame
         return None


### PR DESCRIPTION
## Summary
- Refactor cassette backend to address frames by `(track, lane, bit_idx)`
- Extend tape head and survival computer to use track/lane-aware reads and writes
- Test multi-lane read/write operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689116e6d80c832a89e219b88575a367