### PR TITLE
Clarify register tape design and refine analog NAND

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,10 @@ bits  5- 0 : PARAM  (length, shift-k, etc.)
 
 ## 4  Register Behaviour
 
-* Each register occupies two fixed tracks of main tape.
+* Each register is an independent two-track tape unit, not a fixed pair on the main tape.
 * **Track-0:** data/instruction carriers.
 * **Track-1:** write-bias tone when writing; data otherwise.
+* Registers contain no further registers, avoiding recursive hierarchies.
 * Operations sequence (always):
   1  Motor **SEEK** envelope to target address.
   2  Continuous **read** or **write** sweep over *n* bit-frames (no stop-start per bit).

--- a/tape_map.py
+++ b/tape_map.py
@@ -6,7 +6,7 @@ This module defines helpers that derive the fixed BIOS, instruction table
 and data zone layout of virtual tapes.  Registers are modelled as **fully
 independent tape systems** rather than as mere track pairs on the main tape,
 reflecting the design where the CPU can drive multiple devices in
-simultaneity.
+simultaneity.  Each register stands alone and contains no nested registers.
 
 Only the structural addressing rules are modelled here; no analogue physics
 is emulated.  The intention is to provide deterministic digital maps that
@@ -78,8 +78,9 @@ def create_register_tapes(bios: BiosHeader, n: int = REGISTERS) -> Dict[int, Tap
     """Return independent ``TapeMap`` objects for ``n`` registers.
 
     Each register is modelled as its own two-track tape with a BIOS header and
-    data region but no instruction table.  This mirrors the original hardware
-    concept where the CPU can play directly into multiple devices at once.
+    data region but no instruction table.  Register tapes contain no
+    subordinate registers, mirroring the original hardware concept where the
+    CPU can play directly into multiple devices at once.
     """
 
     return {i: TapeMap(bios, instruction_frames=0) for i in range(n)}


### PR DESCRIPTION
## Summary
- Document registers as independent two-track tapes with no nested registers
- Clarify `TapeMap` helpers for standalone register tapes
- Improve `nand_wave` and bit generation with phase support to satisfy analog stub tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689124e36268832aaeb957d8385cb456