### PR TITLE
Add per-module agent guidance docs

### DIFF
--- a/ANALOG_SPEC.md
+++ b/ANALOG_SPEC.md
@@ -1,0 +1,17 @@
+# ANALOG_SPEC
+
+Notes for `analog_spec.py`: placeholder maths must be replaced with physically credible PCM processing.
+
+## Implement real analog operators
+- Substitute list operations for `sigma_L`, `sigma_R`, `concat`, `slice`, `mu`, `length`, and `zeros` with lane-aware PCM transforms.
+- Respect global constants (LANES, BIT_FRAME_MS, DATA_ADSR, etc.) when generating or timing frames.
+- `mu` must perform VCA-style gating between X and Y lanes, driven by the selector's amplitude.
+- `length` should run a simulated motor sweep to an end-stop marker and encode the elapsed frame count as binary PCM frames.
+
+## Documentation & approximations
+- Document any remaining simplifications (e.g., linear envelopes, integer quantisation) and reference the relevant AGENTS.md sections.
+- Provide helper utilities for silence generation, frame concatenation, and FFT analysis that all honour `FRAME_SAMPLES`.
+- Add unit tests verifying each primitive's round-trip: PCM → FFT → bits.
+
+---
+No silent stubs or pure digital math. Every operator must emit audio evidence of its effect per AGENTS.md §6.

--- a/CASSETTE_ADAPTER.md
+++ b/CASSETTE_ADAPTER.md
@@ -1,0 +1,14 @@
+# CASSETTE_ADAPTER
+
+Compatibility façade for the v2 tape backend.
+
+## Purpose
+- Exposes legacy methods (`move_head`, `execute_instruction`, `tape_length`) so older demos continue to run.
+
+## Required actions
+- Document a migration path: either port these shims into `cassette_tape.py` or update callers to use the core API directly.
+- Ensure `execute_instruction` produces a faint but audible pulse rather than silence, satisfying AGENTS.md §6.
+- Validate parameters for `move_head` and raise errors on out-of-range seeks.
+
+## Clean-up markers
+- Once no callers rely on this adapter, delete the file and update imports.

--- a/CASSETTE_TAPE.md
+++ b/CASSETTE_TAPE.md
@@ -1,0 +1,20 @@
+# CASSETTE_TAPE
+
+Guidance for `cassette_tape.py` backend to maintain analog fidelity.
+
+## Bit I/O through analog pipeline
+- Replace `read_bit`/`write_bit` wrappers with versions that perform FFT-based lane analysis and render PCM frames with bias and motor carriers engaged.
+- Reading must seek, scan, and decode via `dominant_tone`; writing must call `generate_bit_wave` and log every motor/head movement.
+
+## Instruction execution hook
+- Provide an `execute_instruction` method that emits a short instruction-track pulse so higher layers need not import the adapter.
+
+## Motor and head modelling
+- Validate head alignment after every seek/read/write; raise informative errors when misaligned.
+- Use trapezoidal envelopes from `analog_spec.trapezoidal_motor_envelope` for all movement profiles.
+
+## Testing
+- Add tests verifying analog read/write round-trips for single bits and multi-lane frames, ensuring PCM→FFT→bit correctness.
+
+---
+Absence of audible frames or reliance on digital shortcuts violates AGENTS.md §11.

--- a/SURVIVAL_COMPUTER.md
+++ b/SURVIVAL_COMPUTER.md
@@ -1,0 +1,25 @@
+# SURVIVAL_COMPUTER
+
+Guidance for `survival_computer.py`: bridge the gap between high-level bit ops and the analog tape simulator.
+
+## Outstanding gaps
+- Inputs never allocated; initial operands resolve to `None` and reads crash.
+- `_execute_node` only handles `zeros`, `nand`, and `mu`; all others emit a placeholder instruction sound.
+
+## Required work
+1. **Graph preprocessing**
+   - During compilation, allocate tape addresses for every node argument and write constant bit patterns before execution begins.
+   - Guard against missing addresses; raise clear errors when operands are absent.
+2. **Primitive translation**
+   - Implement analog sequences for `sigma_L`, `sigma_R`, `slice`, `length`, and a real `concat` using cassette read/write operations.
+   - Each primitive must call `cassette.read_wave`/`write_wave`; digital shortcuts are forbidden by AGENTS.md §6.
+   - `length` should mechanically time a motor run to an end-marker and encode the frame count into PCM.
+3. **Backend API alignment**
+   - Import `CassetteTapeBackend` from `cassette_adapter` *or* add `execute_instruction` to the core backend.
+   - Remove unsupported constructor args (`analogue_mode`, `frame_ms`) or map them to existing fields such as `time_scale_factor`.
+4. **Error signaling & docs**
+   - Replace silent fallbacks with explicit `NotImplementedError` or log warnings when primitives lack full analog support.
+   - Expand module docstring to cite AGENTS.md §§6–7 so future edits honour lane, motor, and ADSR rules.
+
+---
+Every operation must leave an audible trace; digital shortcuts or silent stubs are considered failure under AGENTS.md §11.


### PR DESCRIPTION
## Summary
- Add SURVIVAL_COMPUTER.md outlining memory allocation, primitive translation, and backend alignment tasks
- Add ANALOG_SPEC.md detailing analog operator implementations and documentation requirements
- Add CASSETTE_TAPE.md with instructions on analog bit I/O, instruction pulses, and motor modelling
- Add CASSETTE_ADAPTER.md describing compatibility facade duties and deprecation plan

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68914c88521c832a821fd201ed59e6a5