### PR TITLE
feat: apply envelopes to shift ops and add register-based NAND

### DIFF
--- a/nand_wave.py
+++ b/nand_wave.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+from analog_spec import FRAME_SAMPLES, nand_wave
+from analog_helpers import generate_bit_wave, extract_lane, replay_envelope
+
+
+__all__ = [
+    "FRAME_SAMPLES",
+    "generate_bit_wave",
+    "nand_wave",
+    "extract_lane",
+    "replay_envelope",
+]

--- a/tests/test_analog_stub.py
+++ b/tests/test_analog_stub.py
@@ -22,3 +22,13 @@ def test_sigma_ops():
     assert np.max(np.abs(appended[-1])) == 0.0
     trimmed = sigma_R(appended, 2)
     assert len(trimmed) == 1
+
+
+def test_sigma_envelope_edges():
+    frames = [np.ones(FRAME_SAMPLES, dtype="f4") for _ in range(2)]
+    left = sigma_L(frames, 0)
+    assert left[0][0] == pytest.approx(0.0, abs=1e-3)
+    assert left[-1][-1] == pytest.approx(0.0, abs=1e-3)
+    right = sigma_R(frames, 0)
+    assert right[0][0] == pytest.approx(0.0, abs=1e-3)
+    assert right[-1][-1] == pytest.approx(0.0, abs=1e-3)


### PR DESCRIPTION
## Summary
- apply attack/release envelopes when shifting frames and buffer data through registers
- drive NAND through register reads and allow direct lane passthrough for single-lane masks
- expose nand_wave helpers for tests and add coverage for envelope edges

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891df7b2558832ab0aeee8ca7a6d100