### PR TITLE
Connect tape components through analog operators

### DIFF
--- a/tape_compiler.py
+++ b/tape_compiler.py
@@ -118,6 +118,7 @@ class TapeCompiler:
 
         # The TapeMap will calculate the final layout
         tape_map = TapeMap(bios, instruction_frames=len(instructions))
+        tape_map.bios.instr_start_addr = tape_map.instr_start
         
         print(f"Compilation successful. Generated {len(instructions)} instructions.")
         return tape_map, instructions

--- a/tape_machine.py
+++ b/tape_machine.py
@@ -9,10 +9,14 @@ computations.
 """
 from __future__ import annotations
 
-import time
 from typing import Dict, List
 
-from analog_spec import Opcode, nand_wave, sigma_L, sigma_R, concat, slice_frames, mu, length, zeros, generate_bit_wave
+from analog_spec import (
+    LANES,
+    Opcode,
+    apply_operator,
+    mu,
+)
 from cassette_tape import CassetteTapeBackend
 from tape_map import TapeMap
 from tape_transport import TapeTransport
@@ -28,83 +32,73 @@ class TapeMachine:
         self.transport = TapeTransport(cassette)
         self.tape_map: TapeMap | None = None
         self.instruction_pointer = 0
-        self.data_registers: Dict[int, int] = {} # Maps register index to tape address
+        self.data_registers: Dict[int, int] = {}
 
-    def _boot(self):
-        """Reads the BIOS from the tape to configure the machine."""
+    def _boot(self, instruction_count: int) -> None:
+        """Read BIOS and initialise register map."""
+
         print("TapeMachine: Booting...")
-        # Decode BIOS from the start of the tape
-        bios_frames = self.transport[0:TapeMap.get_bios_frame_count()]
-        self.tape_map = TapeMap.decode_bios(bios_frames)
-        
-        # Set the instruction pointer to the start of the code section
-        self.instruction_pointer = self.tape_map.instr_start
-        print(f"TapeMachine: Boot successful. Instruction pointer set to frame {self.instruction_pointer}.")
+        bios_frames: List[List[int]] = []
+        for i in range(TapeMap.get_bios_frame_count()):
+            frame = [self.cassette.read_bit(0, lane, i) for lane in range(LANES)]
+            bios_frames.append(frame)
+        bios = TapeMap.decode_bios(bios_frames)
+        self.tape_map = TapeMap(bios, instruction_frames=instruction_count)
 
-        # Map logical registers (0-15) to physical tape addresses in the data section
+        self.instruction_pointer = self.tape_map.instr_start
+        print(
+            f"TapeMachine: Boot successful. Instruction pointer set to frame {self.instruction_pointer}."
+        )
+
         for i in range(16):
             self.data_registers[i] = self.tape_map.data_start + (i * self.bit_width)
 
-    def _fetch_decode(self) -> tuple[Opcode, int, int, int]:
-        """Fetches and decodes one 16-bit instruction from the tape."""
-        instr_frame_bits = self.transport[self.instruction_pointer]
+    def _fetch_decode(self) -> tuple[Opcode, int, int, int, int]:
+        """Fetch and decode one 16‑bit instruction."""
+
+        bits = [self.cassette.read_bit(0, lane, self.instruction_pointer) for lane in range(16)]
         self.instruction_pointer += 1
-
-        # Convert bit list to integer
         word = 0
-        for bit in instr_frame_bits:
+        for bit in bits:
             word = (word << 1) | bit
-        
-        # Decode fields from the 16-bit word
-        opcode_val = (word >> 12) & 0xF
-        dest = (word >> 8) & 0xF
-        reg_a = (word >> 4) & 0xF
-        reg_b_or_param = word & 0xF
-        
-        return Opcode(opcode_val), dest, reg_a, reg_b_or_param
 
-    def _execute(self, opcode: Opcode, dest: int, reg_a: int, reg_b_or_param: int):
-        """Executes a single instruction using analog operators."""
-        # Get physical tape addresses for the logical registers
+        opcode_val = (word >> 12) & 0xF
+        reg_a = (word >> 10) & 0x3
+        reg_b = (word >> 8) & 0x3
+        dest = (word >> 6) & 0x3
+        param = word & 0x3F
+        return Opcode(opcode_val), dest, reg_a, reg_b, param
+
+    def _execute(
+        self, opcode: Opcode, dest: int, reg_a: int, reg_b: int, param: int
+    ) -> None:
+        """Execute a single instruction via ``analog_spec`` operators."""
+
         addr_dest = self.data_registers[dest]
         addr_a = self.data_registers[reg_a]
-        addr_b = self.data_registers[reg_b_or_param] # Assumes it's a register for now
+        addr_b = self.data_registers[reg_b]
 
-        # --- This is the new core logic, dispatching to analog_spec functions ---
-        
-        if opcode == Opcode.NAND:
-            # Read the full wave forms for the operands
-            wave_a = self.transport[addr_a : addr_a + self.bit_width]
-            wave_b = self.transport[addr_b : addr_b + self.bit_width]
-            
-            # Perform the NAND operation on each corresponding frame
-            result_waves = [nand_wave(wa, wb) for wa, wb in zip(wave_a, wave_b)]
+        wave_a = self.transport[addr_a : addr_a + self.bit_width]
+        wave_b = self.transport[addr_b : addr_b + self.bit_width]
 
-            # Write the resulting waveforms back to the destination
-            self.transport[addr_dest : addr_dest + self.bit_width] = result_waves
-
-        elif opcode == Opcode.ZEROS:
-            # Generate zero-energy frames
-            zero_waves = zeros(self.bit_width)
-            self.transport[addr_dest : addr_dest + self.bit_width] = zero_waves
-
-        # ... Other opcodes would be implemented here using the same pattern ...
-        # read waves -> call analog_spec function -> write result waves
-        
+        if opcode == Opcode.MU:
+            sel_idx = param & 0xF
+            sel_addr = self.data_registers.get(sel_idx, addr_b)
+            sel = self.transport[sel_addr : sel_addr + self.bit_width]
+            out = mu(wave_a, wave_b, sel)
         else:
-            # Placeholder for unimplemented opcodes
-            print(f"Warning: Opcode {opcode.name} not yet implemented in TapeMachine executor.")
-            time.sleep(0.01) # Simulate taking time
+            out = apply_operator(opcode, wave_a, wave_b, param)
 
-    def run(self, instruction_count: int):
-        """Runs the boot sequence and then the fetch-decode-execute cycle."""
-        self._boot()
-        
+        self.transport[addr_dest : addr_dest + len(out)] = out
+
+    def run(self, instruction_count: int) -> None:
+        """Boot the machine then execute ``instruction_count`` instructions."""
+
+        self._boot(instruction_count)
         print("TapeMachine: Starting execution loop...")
         for i in range(instruction_count):
-            print(f"  Executing instruction {i+1}/{instruction_count}", end='\r')
-            opcode, dest, reg_a, reg_b = self._fetch_decode()
-            self._execute(opcode, dest, reg_a, reg_b)
-        
+            print(f"  Executing instruction {i+1}/{instruction_count}", end="\r")
+            opcode, dest, reg_a, reg_b, param = self._fetch_decode()
+            self._execute(opcode, dest, reg_a, reg_b, param)
         print("\nExecution finished.")
 

--- a/tape_map.py
+++ b/tape_map.py
@@ -20,6 +20,7 @@ from analog_spec import (
     BiosHeader,
     BIOS_HEADER_STRUCT,
     REGISTERS,
+    LANES,
     header_frames,
     unpack_bios_header,
 )
@@ -72,6 +73,14 @@ class TapeMap:
             if len(byte_arr) >= BIOS_HEADER_STRUCT.size:
                 break
         return unpack_bios_header(bytes(byte_arr[: BIOS_HEADER_STRUCT.size]))
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def get_bios_frame_count() -> int:
+        """Return the number of frames occupied by a BIOS header."""
+
+        bits = BIOS_HEADER_STRUCT.size * 8
+        return (bits + LANES - 1) // LANES
 
 
 def create_register_tapes(bios: BiosHeader, n: int = REGISTERS) -> Dict[int, TapeMap]:


### PR DESCRIPTION
## Summary
- centralize primitive operator implementations in `analog_spec.apply_operator`
- fix instruction decoding and route `TapeMachine` opcodes through analog-spec dispatch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689207cf1820832aa2764bab40f70651