### PR TITLE
Add tape I/O opcodes and halting behaviour

### DIFF
--- a/src/hardware/analog_spec.py
+++ b/src/hardware/analog_spec.py
@@ -310,6 +310,32 @@ def zeros(n: int) -> List[np.ndarray]:
     """Return ``n`` silent frames."""
     return [np.zeros(FRAME_SAMPLES, dtype="f4") for _ in range(n)]
 
+
+# Placeholder implementations for I/O style opcodes
+# TODO: model full motor physics for seek/read/write behaviours
+DEFAULT_MOTOR_CALIB = MotorCalibration(1.0, 1.0, 0.0)
+
+
+def seek_op(_a: List[np.ndarray], _b: List[np.ndarray], distance: int) -> List[np.ndarray]:
+    """Return a trapezoidal motor envelope for a SEEK over ``distance`` frames."""
+    env = trapezoidal_motor_envelope(distance, DEFAULT_MOTOR_CALIB)
+    return [env]
+
+
+def read_op(x: List[np.ndarray], _b: List[np.ndarray], n: int) -> List[np.ndarray]:
+    """Copy ``n`` frames from ``x`` into a new list (placeholder for READ)."""
+    return [f.copy() for f in x[:n]]
+
+
+def write_op(_a: List[np.ndarray], y: List[np.ndarray], n: int) -> List[np.ndarray]:
+    """Copy ``n`` frames from ``y`` (placeholder for WRITE)."""
+    return [f.copy() for f in y[:n]]
+
+
+def halt_op(_a: List[np.ndarray], _b: List[np.ndarray], _p: int) -> List[np.ndarray]:
+    """HALT produces no frames but is included for dispatch completeness."""
+    return []
+
 # ---------------------------------------------------------------------------
 # 5. NAND Operator
 def nand_wave(
@@ -392,6 +418,9 @@ OperatorFn = Callable[[FrameList, FrameList, int], FrameList]
 
 
 PRIMITIVE_OPS: Dict[Opcode, OperatorFn] = {
+    Opcode.SEEK: lambda a, b, p: seek_op(a, b, p),
+    Opcode.READ: lambda a, b, p: read_op(a, b, p),
+    Opcode.WRITE: lambda a, b, p: write_op(a, b, p),
     Opcode.NAND: lambda a, b, p: nand_frames(a, b),
     Opcode.SIGL: lambda a, b, p: sigma_L(a, p),
     Opcode.SIGR: lambda a, b, p: sigma_R(a, p),
@@ -399,6 +428,7 @@ PRIMITIVE_OPS: Dict[Opcode, OperatorFn] = {
     Opcode.SLICE: lambda a, b, p: slice_frames(a, 0, p),
     Opcode.LENGTH: lambda a, b, p: length(a),
     Opcode.ZEROS: lambda a, b, p: zeros(p),
+    Opcode.HALT: lambda a, b, p: halt_op(a, b, p),
 }
 
 

--- a/tests/test_new_opcodes.py
+++ b/tests/test_new_opcodes.py
@@ -1,0 +1,81 @@
+import os, sys
+ROOT = os.path.dirname(os.path.dirname(__file__))
+sys.path.insert(0, ROOT)
+
+import numpy as np
+
+from src.hardware.analog_spec import (
+    BiosHeader,
+    Opcode,
+    generate_bit_wave,
+    header_frames,
+    dominant_tone,
+)
+from src.hardware.cassette_tape import CassetteTapeBackend
+from src.turing_machine.tape_machine import TapeMachine
+from src.turing_machine.tape_map import TapeMap
+
+
+def make_machine():
+    tape = CassetteTapeBackend(tape_length=128)
+    machine = TapeMachine(tape, bit_width=1)
+    machine.data_registers = {0: 0, 1: 10, 2: 20, 3: 30}
+    return machine, tape
+
+
+def test_seek_opcode_moves_head_and_register():
+    machine, tape = make_machine()
+    machine._execute(Opcode.SEEK, dest=0, reg_a=0, reg_b=0, param=5)
+    assert machine.data_registers[0] == 5
+    assert machine.transport._cursor == 5
+    tape.close()
+
+
+def test_read_opcode_copies_frames():
+    machine, tape = make_machine()
+    src = [generate_bit_wave(1, 0), generate_bit_wave(1, 1)]
+    machine.transport[:2] = src
+    machine._execute(Opcode.READ, dest=1, reg_a=0, reg_b=0, param=2)
+    out = machine.transport[10:12]
+    assert dominant_tone(out[0]).bin == dominant_tone(src[0]).bin
+    assert dominant_tone(out[1]).bin == dominant_tone(src[1]).bin
+    tape.close()
+
+
+def test_write_opcode_copies_from_reg_b():
+    machine, tape = make_machine()
+    src = [generate_bit_wave(1, 2), generate_bit_wave(1, 3)]
+    machine.transport[20:22] = src
+    machine._execute(Opcode.WRITE, dest=0, reg_a=0, reg_b=2, param=2)
+    out = machine.transport[0:2]
+    assert dominant_tone(out[0]).bin == dominant_tone(src[0]).bin
+    assert dominant_tone(out[1]).bin == dominant_tone(src[1]).bin
+    tape.close()
+
+
+def encode_instruction(word: int, frame_idx: int, tape: CassetteTapeBackend) -> None:
+    for lane in range(16):
+        bit = (word >> (15 - lane)) & 1
+        tape.write_bit(0, lane, frame_idx, bit)
+
+
+def test_run_halts_on_halt_opcode():
+    tape = CassetteTapeBackend(tape_length=256)
+    machine = TapeMachine(tape, bit_width=1)
+
+    bios = BiosHeader(1.0, 1.0, 0.0, [], [], 0)
+    frames = header_frames(bios)
+    for idx, frame in enumerate(frames):
+        for lane, bit in enumerate(frame):
+            tape.write_bit(0, lane, idx, bit)
+
+    tmap = TapeMap(bios, instruction_frames=2)
+    halt_word = Opcode.HALT.value << 12
+    nand_word = Opcode.NAND.value << 12
+    encode_instruction(halt_word, tmap.instr_start, tape)
+    encode_instruction(nand_word, tmap.instr_start + 1, tape)
+
+    machine.run(2)
+    assert machine.halted is True
+    assert machine.instruction_pointer == tmap.instr_start + 1
+    tape.close()


### PR DESCRIPTION
## Summary
- Implement SEEK, READ, WRITE and HALT placeholders in the analog spec with dispatch hooks
- Extend tape machine execution loop to handle the new opcodes and halt execution on HALT
- Add unit tests covering the new tape operations

## Testing
- `pytest tests/test_new_opcodes.py`

------
https://chatgpt.com/codex/tasks/task_e_68921ba4e6f0832a8908b1335b675d2e