### PR TITLE
Refine analog tape timings and dynamic thresholds

### DIFF
--- a/tests/manual_test_runner.py
+++ b/tests/manual_test_runner.py
@@ -249,9 +249,9 @@ def test_motor_profile():
     print("Testing simulate movement writes audio.")
     tape = CassetteTapeBackend(time_scale_factor=0.0)
     tape._simulate_movement(1.0, tape.seek_speed_ips, 1, 'seek')
-    print(f"audio cursor {tape._audio_cursor}, any audio {np.any(tape._audio_buffer[:tape._audio_cursor])}")
+    print(f"audio cursor {tape._audio_cursor}, any audio {np.any(tape._audio_buffer[:tape._buffer_cursor])}")
     assert tape._audio_cursor > 0
-    assert np.any(tape._audio_buffer[:tape._audio_cursor])
+    assert np.any(tape._audio_buffer[:tape._buffer_cursor])
     tape.close()
 
 

--- a/tests/test_motor_profile.py
+++ b/tests/test_motor_profile.py
@@ -23,6 +23,6 @@ def test_simulate_movement_writes_audio():
     tape = CassetteTapeBackend(time_scale_factor=0.0)
     tape._simulate_movement(1.0, tape.seek_speed_ips, 1, "seek")
     assert tape._audio_cursor > 0
-    assert np.any(tape._audio_buffer[:tape._audio_cursor])
+    assert np.any(tape._audio_buffer[:tape._buffer_cursor])
     tape.close()
 

--- a/tests/test_nand_wave.py
+++ b/tests/test_nand_wave.py
@@ -1,13 +1,17 @@
-import os, sys
+import os
+import sys
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import numpy as np
 import pytest
 
 import src.hardware.nand_wave as nw
+from src.hardware.analog_spec import BIT_FRAME_MS, REFERENCE_BIT_FRAME_MS
 
 
-ENERGY_THRESH = 0.01
+BASE_ENERGY_THRESH = 0.01
+ENERGY_THRESH = max(BASE_ENERGY_THRESH * (BIT_FRAME_MS / REFERENCE_BIT_FRAME_MS), 1e-5)
 
 
 def test_parallel_xor_copy():


### PR DESCRIPTION
## Summary
- scale ADSR segments as ratios of the bit frame and normalize each lane's amplitude
- introduce dynamic energy thresholds and dominant-tone detection for NAND logic
- track total audio output separately and apply master volume to playback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68923b255ef4832aae7248f82bc502dc