### PR TITLE
Refactor register tapes to omit BIOS

### DIFF
--- a/src/turing_machine/tape_machine.py
+++ b/src/turing_machine/tape_machine.py
@@ -9,7 +9,7 @@ computations.
 """
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, Sequence
 
 from ..hardware.analog_spec import (
     LANES,
@@ -26,14 +26,15 @@ class TapeMachine:
     A simulated machine that reads instructions from a tape and executes them
     using analog wave-based operations.
     """
-    def __init__(self, cassette: CassetteTapeBackend, bit_width: int):
+    def __init__(self, cassette: CassetteTapeBackend, bit_width: int, register_mode: bool = False):
         self.cassette = cassette
         self.bit_width = bit_width
-        self.transport = TapeTransport(cassette)
+        self.transport = TapeTransport(cassette, register_mode=register_mode)
         self.tape_map: TapeMap | None = None
         self.instruction_pointer = 0
         self.data_registers: Dict[int, int] = {}
         self.halted = False
+        self.register_mode = register_mode
 
     def _boot(self, instruction_count: int) -> None:
         """Read BIOS and initialise register map."""
@@ -132,4 +133,12 @@ class TapeMachine:
             print("\nExecution halted.")
         else:
             print("\nExecution finished.")
+
+    # ------------------------------------------------------------------
+    def queue_register_ops(self, ops: Sequence[int]) -> None:
+        """Forward operator codes to the underlying transport when in register mode."""
+
+        if not self.register_mode:
+            raise RuntimeError("machine not initialised for register mode")
+        self.transport.queue_operators(ops)
 

--- a/tests/manual_test_runner.py
+++ b/tests/manual_test_runner.py
@@ -195,12 +195,13 @@ def test_header_layout():
     print(f"decoded instr_start_addr {decoded.instr_start_addr}")
     assert decoded.instr_start_addr == h.instr_start_addr
 
-    regs = create_register_tapes(h)
+    regs = create_register_tapes()
     print(f"register keys {regs.keys()}")
     assert set(regs.keys()) == {0,1,2}
     for r in regs.values():
-        assert r.instr_start == len(header_frames(h))
-        assert r.data_start == r.instr_start
+        assert r.instr_start == 0
+        assert r.data_start == 0
+        assert r.is_register
 
 
 def test_loops():

--- a/tests/test_header_layout.py
+++ b/tests/test_header_layout.py
@@ -72,10 +72,11 @@ def test_tape_map_bios_roundtrip():
 
 
 def test_register_tapes_independent():
-    h = make_header()
-    regs = create_register_tapes(h)
+    """Registers are pure data tapes with no BIOS or instruction table."""
+    regs = create_register_tapes()
     assert set(regs.keys()) == {0, 1, 2}
     for r in regs.values():
-        assert r.instr_start == len(header_frames(h))
-        assert r.data_start == r.instr_start
+        assert r.instr_start == 0
+        assert r.data_start == 0
+        assert r.is_register
 

--- a/tests/test_register_mode.py
+++ b/tests/test_register_mode.py
@@ -1,0 +1,18 @@
+import pytest
+
+from src.hardware.cassette_tape import CassetteTapeBackend
+from src.turing_machine.tape_transport import TapeTransport
+
+
+def test_register_transport_requires_operator_sequence():
+    tape = CassetteTapeBackend(tape_length_inches=0.02, time_scale_factor=0.0)
+    transport = TapeTransport(tape, register_mode=True)
+    try:
+        with pytest.raises(PermissionError):
+            _ = transport[0]
+        transport.queue_operators([0x1])
+        _ = transport[0]
+        with pytest.raises(PermissionError):
+            _ = transport[1]
+    finally:
+        tape.close()


### PR DESCRIPTION
## Summary
- Allow `TapeMap` to flag tapes operating in register mode and mark factory-created registers accordingly
- Introduce lockable `TapeTransport` that consumes queued operator codes before permitting register I/O
- Permit `TapeMachine` to run in register mode and forward operator sequences, with tests for register locking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924426fd2c832ab8f2047b1381a3ef