### PR TITLE
feat: make operator tests optional

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+import pytest
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -6,7 +8,26 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable TapeVisualizer output during tests",
     )
+    parser.addoption(
+        "--run-operators",
+        action="store_true",
+        help="Run tests that execute the operator simulation",
+    )
+
 
 def pytest_configure(config):
     if config.getoption("--tape-viz"):
         os.environ["TAPE_VIZ"] = "1"
+    config.addinivalue_line(
+        "markers",
+        "operators: tests that run the operator simulation",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-operators"):
+        return
+    skip = pytest.mark.skip(reason="need --run-operators option to run")
+    for item in items:
+        if "operators" in item.keywords:
+            item.add_marker(skip)

--- a/tests/test_new_opcodes.py
+++ b/tests/test_new_opcodes.py
@@ -3,6 +3,9 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, ROOT)
 
 import numpy as np
+import pytest
+
+pytestmark = pytest.mark.operators
 
 from src.hardware.analog_spec import (
     BiosHeader,


### PR DESCRIPTION
## Summary
- add --run-operators pytest flag to gate slow operator simulation tests
- mark opcode execution tests so they only run when --run-operators is provided

## Testing
- `pytest -q`
- `pytest tests/test_new_opcodes.py -q`
- `pytest tests/test_new_opcodes.py --run-operators -q`

------
https://chatgpt.com/codex/tasks/task_e_689253957c2c832aa42236ad5275ac93