### PR TITLE
Add visualizer hook for cassette status and live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,15 @@ python -m src.reel_demo --mode reel      # Reel-to-reel layout
 ```
 
 Press <kbd>Space</kbd> to toggle play and <kbd>W</kbd> to toggle the red write indicator.
+
+## Live cassette demo
+
+To watch the full compile/write/run cycle with synchronized audio and reel
+animation, run:
+
+```bash
+python -m src.visualizations.live_cassette_demo
+```
+
+The window shows tape motion in real time as the simulator writes the program
+to a blank cassette and then executes it.

--- a/src/visualizations/live_cassette_demo.py
+++ b/src/visualizations/live_cassette_demo.py
@@ -1,0 +1,76 @@
+"""Run a full cassette demo with live audio and reel animation.
+
+This script compiles a simple program, writes it to a virtual cassette, and
+then executes it while displaying a real-time visualization of the tape.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+import pygame
+
+from ..compiler.bitops_translator import BitOpsTranslator
+from ..compiler.tape_compiler import TapeCompiler
+from ..hardware.cassette_tape import CassetteTapeBackend
+from ..turing_machine.survival_computer import prime_tape_with_program
+from ..turing_machine.tape_machine import TapeMachine
+
+from .reel_demo_shell import ReelDemoShell
+
+BACKGROUND = (30, 30, 30)
+
+
+def run_with_visual(func, shell: ReelDemoShell, screen, *args) -> bool:
+    """Run ``func`` in a thread while updating the reel visualization."""
+    thread = threading.Thread(target=func, args=args)
+    thread.start()
+    clock = pygame.time.Clock()
+    running = True
+    while running and thread.is_alive():
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+        dt = clock.tick(60) / 1000.0
+        shell.update(dt)
+        screen.fill(BACKGROUND)
+        shell.draw(screen)
+        pygame.display.flip()
+    thread.join()
+    return running
+
+
+def main() -> None:
+    BIT_WIDTH = 32
+    TAPE_LEN = 8192
+
+    translator = BitOpsTranslator(bit_width=BIT_WIDTH)
+    translator.bit_mul(5, 3)
+    compiler = TapeCompiler(translator.graph, BIT_WIDTH)
+    tape_map, instructions = compiler.compile()
+    frames = TapeCompiler.binarize_instructions(instructions)
+
+    pygame.init()
+    screen = pygame.display.set_mode((640, 480))
+    shell = ReelDemoShell(screen.get_rect())
+
+    cassette = CassetteTapeBackend(tape_length=TAPE_LEN, status_callback=shell.update_status)
+    shell.reel_graphics.total_tape = cassette.total_bits
+
+    if not run_with_visual(prime_tape_with_program, shell, screen, cassette, tape_map, frames):
+        pygame.quit()
+        return
+
+    machine = TapeMachine(cassette, BIT_WIDTH)
+    if not run_with_visual(machine.run, shell, screen, len(instructions)):
+        pygame.quit()
+        return
+
+    time.sleep(1.0)
+    cassette.close()
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_cassette_tape.py
+++ b/tests/test_cassette_tape.py
@@ -62,6 +62,22 @@ def test_write_adds_bias_tone():
     tape.close()
 
 
+def test_status_callback_receives_updates():
+    updates = []
+
+    def cb(tape_pos, motor_pos, reading, writing):
+        updates.append((tape_pos, reading, writing))
+
+    tape = CassetteTapeBackend(tape_length_inches=0.02, status_callback=cb)
+    frame = generate_bit_wave(1, 0)
+    tape.write_wave(0, 0, 0, frame)
+    assert updates, "callback was not invoked"
+    tape_pos, reading_flag, writing_flag = updates[-1]
+    assert writing_flag and not reading_flag
+    assert tape_pos[1] > 0
+    tape.close()
+
+
 def test_transport_pythonic_index_and_slice():
     tape = CassetteTapeBackend(tape_length_inches=0.02)
     transport = TapeTransport(tape, track=0, lane=0)


### PR DESCRIPTION
## Summary
- allow `CassetteTapeBackend` to report left/right tape usage and read/write activity via an optional callback
- add an automated test for the new status callback
- introduce `live_cassette_demo.py` which compiles a sample program, writes it to tape, and runs it with synchronized animation
- document the live demo in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68926fbe51d4832a909afc7124635b9d