### PR TITLE
Refine simulator API and remove legacy aliases

### DIFF
--- a/src/transmogrifier/__init__.py
+++ b/src/transmogrifier/__init__.py
@@ -1,4 +1,11 @@
-from .cells.linear_cells import LinearCells
+from .cells import CellPressureRegionManager, Simulator
 from .graph.memory_graph import BitTensorMemoryGraph, NodeEntry, EdgeEntry, GraphSearch
 
-__all__ = ["LinearCells", "BitTensorMemoryGraph", "NodeEntry", "EdgeEntry", "GraphSearch"]
+__all__ = [
+    "CellPressureRegionManager",
+    "Simulator",
+    "BitTensorMemoryGraph",
+    "NodeEntry",
+    "EdgeEntry",
+    "GraphSearch",
+]

--- a/src/transmogrifier/cells/__init__.py
+++ b/src/transmogrifier/cells/__init__.py
@@ -1,5 +1,4 @@
-from .linear_cells import LinearCells
-from .cell_pressure import Simulator
 from .cell_pressure_region_manager import CellPressureRegionManager
+from .simulator import Simulator
 
-__all__ = ["LinearCells", "Simulator", "CellPressureRegionManager"]
+__all__ = ["CellPressureRegionManager", "Simulator"]

--- a/src/transmogrifier/graph/memory_graph.py
+++ b/src/transmogrifier/graph/memory_graph.py
@@ -9,7 +9,7 @@ import sys
 import threading
 from uuid import uuid4
 
-from ..cells.cell_pressure import Simulator
+from ..cells.simulator import Simulator
 from ..cells.cell_pressure_region_manager import CellPressureRegionManager
 from ..cells.cell_consts import Cell
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,16 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "operators" in item.keywords:
             item.add_marker(skip)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for cell pressure tests
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.fixture(params=[7, 11, 13, 17])
+def stride(request):
+    """Provide a selection of prime strides for pressure simulations."""
+    return request.param

--- a/tests/test_cell_pressure.py
+++ b/tests/test_cell_pressure.py
@@ -1,7 +1,7 @@
 import random
 import os
 import pytest
-from src.transmogrifier.cells.sim.simulator import Simulator
+from src.transmogrifier.cells.simulator import Simulator
 from src.transmogrifier.cells.cell_consts import Cell
 from src.transmogrifier.cells.bitbitbuffer import BitBitBuffer
 
@@ -41,7 +41,7 @@ def test_injection_mixed_prime7():
         sim.write_data(cells[0].label, p)
     for _ in range(10):
         sp, _ = sim.step(cells)
-    sim.print_system(cells)
+    sim.print_system()
     assert cells[0].injection_queue == 0
 
 def test_sustained_random_injection():

--- a/tests/transmogrifier/test_root_imports.py
+++ b/tests/transmogrifier/test_root_imports.py
@@ -5,5 +5,12 @@ import transmogrifier
 
 
 def test_root_exports():
-    expected = {"LinearCells", "BitTensorMemoryGraph", "NodeEntry", "EdgeEntry", "GraphSearch"}
+    expected = {
+        "CellPressureRegionManager",
+        "Simulator",
+        "BitTensorMemoryGraph",
+        "NodeEntry",
+        "EdgeEntry",
+        "GraphSearch",
+    }
     assert expected.issubset(set(transmogrifier.__all__))


### PR DESCRIPTION
## Summary
- expose `CellPressureRegionManager` and `Simulator` as the core cells exports
- clean up simulator initialisation and provide basic data-path helpers
- adjust tests to match the streamlined root API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892b49900c4832ab02fc921b12272e6