### PR TITLE
add process graph linearizer for tape compiler

### DIFF
--- a/src/compiler/process_graph_helper.py
+++ b/src/compiler/process_graph_helper.py
@@ -1,0 +1,35 @@
+"""
+Helper utilities for working with ProcessGraph instances.
+
+This module provides a small adapter to translate the experimental
+ProcessGraph into a linear sequence of ProvNode objects.  TapeCompiler still
+expects a ProvenanceGraph-like interface and this helper bridges the gap.
+"""
+
+from __future__ import annotations
+
+from typing import List
+import networkx as nx
+
+from ..turing_machine.turing_provenance import ProvNode
+
+
+class ProcessGraphLinearizer:
+    """Linearise a ProcessGraph into a list of ProvNode records."""
+
+    def __init__(self, pg):
+        self.pg = pg
+
+    def linear_nodes(self) -> List[ProvNode]:
+        """Return nodes in topological order as ProvNode objects."""
+        order = list(nx.topological_sort(self.pg.G))
+        nodes: List[ProvNode] = []
+        for idx, nid in enumerate(order):
+            data = self.pg.G.nodes[nid]
+            label = data.get("label")
+            expr_obj = data.get("expr_obj")
+            if label is None and expr_obj is not None:
+                label = type(expr_obj).__name__
+            parents = [p for p, _ in data.get("parents", [])]
+            nodes.append(ProvNode(idx=idx, op=label, arg_ids=tuple(parents), kwargs={}, out_obj_id=nid))
+        return nodes

--- a/src/compiler/tape_compiler.py
+++ b/src/compiler/tape_compiler.py
@@ -65,13 +65,17 @@ class TapeCompiler:
         Compiles the graph into a tape map and a stream of instructions.
         """
         print("Compiler Step 1: Allocating registers for all graph objects...")
-        # First pass: Allocate a "register" for every output object in the graph
         from ..transmogrifier.graph.graph_express2 import ProcessGraph
-        self.graph = ProcessGraph(self.graph)
+        from .process_graph_helper import ProcessGraphLinearizer
+
+        if isinstance(self.graph, ProcessGraph):
+            linear_nodes = ProcessGraphLinearizer(self.graph).linear_nodes()
+        else:
+            linear_nodes = self.graph.nodes
 
         print("Compiler Step 2: Generating instruction stream from graph...")
         instructions: InstructionStream = []
-        for node in self.graph.nodes:
+        for node in linear_nodes:
             opcode = self._op_to_opcode(node.op)
             
             # Assign registers for inputs and outputs


### PR DESCRIPTION
## Summary
- introduce `ProcessGraphLinearizer` to convert `ProcessGraph` to a linear list of `ProvNode` records
- update `TapeCompiler` to use the new linearizer rather than assuming `nodes` exist

## Testing
- `pytest` *(fails: IndexError in `tests/test_cell_pressure.py` and related cases)*

------
https://chatgpt.com/codex/tasks/task_e_6893af1d8250832a8e43624a975cd417