### PR TITLE
Ensure auto-generated node IDs

### DIFF
--- a/src/transmogrifier/graph/memory_graph.py
+++ b/src/transmogrifier/graph/memory_graph.py
@@ -2349,13 +2349,17 @@ class BitTensorMemoryGraph:
             return str(obj).encode("utf-8")
 
         if isinstance(node_entry, NodeEntry):
-            # Ensure the provided node has the desired ID
-            if node_id is not None:
-                node_entry.node_id = node_id
-            node_id = node_entry.node_id
+            # ``node_entry`` may already carry an ID, but treat ``0`` as
+            # "unset" so we always emit a usable identifier.  Callers can
+            # still override via the explicit ``node_id`` parameter.
+            if node_id in (None, 0):
+                node_id = node_entry.node_id
+            if node_id in (None, 0):
+                node_id = uuid4().int % 2**32
+            node_entry.node_id = node_id
             node_bytes = ctypes.string_at(ctypes.addressof(node_entry), ctypes.sizeof(NodeEntry))
         else:
-            if node_id is None:
+            if node_id in (None, 0):
                 node_id = uuid4().int % 2**32
             node_data = _to_bytes(node_entry)
             new_node_entry = NodeEntry(node_id=node_id, node_data=node_data)


### PR DESCRIPTION
## Summary
- guarantee non-zero IDs when adding NodeEntry objects without identifiers
- treat zero as an unset ID and generate new values automatically

## Testing
- `pytest` *(fails: IndexError in tests/test_cell_pressure.py::test_simulation_stride_basic[7])*

------
https://chatgpt.com/codex/tasks/task_e_68949f87486c832a8ed3402f2b7408d6