### PR TITLE
Synchronize dynamic flag and add pressure balancing support

### DIFF
--- a/src/transmogrifier/cells/pressure_model.py
+++ b/src/transmogrifier/cells/pressure_model.py
@@ -1,17 +1,38 @@
-from sympy import Integer
+from sympy import Integer, Float
 from .cell_consts import CELL_COUNT
 from .salinepressure import SalineHydraulicSystem
 
-def update_s_p_expressions(sim, cells):
-    sim.s_exprs = [Integer(cell.salinity) for cell in cells]
-    sim.p_exprs = [Integer(cell.pressure) for cell in cells]
+def balance_system(cells, mode='open'):
+    """Balance salinity and pressure across the whole system."""
+    if not cells or mode not in ('open', 'closed'):
+        return
+    if mode == 'open':
+        total_s = sum(c.salinity for c in cells) or 1
+        total_p = sum(c.pressure for c in cells) or 1
+        for c in cells:
+            c.salinity = c.salinity / total_s
+            c.pressure = c.pressure / total_p
+    else:  # closed system – zero-sum
+        avg_s = sum(c.salinity for c in cells) / len(cells)
+        avg_p = sum(c.pressure for c in cells) / len(cells)
+        for c in cells:
+            c.salinity -= avg_s
+            c.pressure -= avg_p
+
+def update_s_p_expressions(sim, cells, *, as_float=False):
+    if as_float:
+        sim.s_exprs = [Float(cell.salinity) for cell in cells]
+        sim.p_exprs = [Float(cell.pressure) for cell in cells]
+    else:
+        sim.s_exprs = [Integer(cell.salinity) for cell in cells]
+        sim.p_exprs = [Integer(cell.pressure) for cell in cells]
 def equilibrium_fracs(sim, t):
     if not hasattr(sim, 'engine') or sim.engine is None:
         run_saline_sim(sim)
     return sim.engine.equilibrium_fracs(t)
-def run_saline_sim(sim):
+def run_saline_sim(sim, *, as_float=False):
     # 1) Instantiate engine with your per‐cell salinity & pressure expressions (or plain numbers)
-    update_s_p_expressions(sim, sim.cells)
+    update_s_p_expressions(sim, sim.cells, as_float=as_float)
     sim.engine = SalineHydraulicSystem(
         sim.s_exprs,           # e.g. [Integer(s0), Integer(s1), …]
         sim.p_exprs,           # e.g. [Integer(p0), Integer(p1), …]
@@ -45,3 +66,9 @@ def run_saline_sim(sim):
             sim.expand([offset], sim.bitbuffer.intceil(size, sim.lcm(sim.cells)), sim.cells, sim.cells)
 
     sim.snap_cell_walls(sim.cells, sim.cells)
+
+
+def run_balanced_saline_sim(sim, mode='open'):
+    """Balance the system then run the standard saline simulation."""
+    balance_system(sim.cells, mode)
+    run_saline_sim(sim, as_float=True)

--- a/tests/transmogrifier/test_memory_graph_dynamic_sync.py
+++ b/tests/transmogrifier/test_memory_graph_dynamic_sync.py
@@ -1,0 +1,10 @@
+from transmogrifier.graph.memory_graph import BitTensorMemoryGraph
+
+
+def test_dynamic_flag_syncs_with_memory():
+    g = BitTensorMemoryGraph(1024, dynamic=False)
+    assert g.dynamic is False
+    assert g.hard_memory.dynamic is False
+    g.dynamic = True
+    assert g.dynamic is True
+    assert g.hard_memory.dynamic is True


### PR DESCRIPTION
## Summary
- keep BitTensorMemoryGraph's dynamic flag in sync with backing memory
- add hydraulic system balancing utilities for open and closed conditions
- add regression test for dynamic flag synchronisation

## Testing
- `pytest` *(fails: test_cell_pressure suite reports bytearray index errors)*

------
https://chatgpt.com/codex/tasks/task_e_6894af7900ec832aaea8c4efb71a4ebe