### PR TITLE
fix: convert region specs to bits

### DIFF
--- a/src/transmogrifier/graph/memory_graph.py
+++ b/src/transmogrifier/graph/memory_graph.py
@@ -327,6 +327,17 @@ class BitTensorMemory: #sizes in bytes
             raise ValueError("Expanded regions exceed memory size")
 
         specs = [s for s in specs if s["right"] > s["left"]]
+
+        # Convert byte-based positions and strides to bit offsets for the simulator
+        for s in specs:
+            s["left"] *= 8
+            s["right"] *= 8
+            s["len"] *= 8
+            s["stride"] *= 8
+            if s["min"] is not None:
+                s["min"] *= 8
+            if s["max"] is not None:
+                s["max"] *= 8
         return specs
     def mark_free(self, offset, size):
         # mark free bits and reset delta


### PR DESCRIPTION
## Summary
- convert byte-based region specs to bit offsets before creating simulator cells

## Testing
- `python -m src.transmogrifier.graph.memory_graph` *(fails: Unable to allocate 512 bytes for label 'node')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68965388de60832aa10da1ed279e056e