### PR TITLE
Fix circular import in memory graph helpers

### DIFF
--- a/src/transmogrifier/graph/memory_graph/__init__.py
+++ b/src/transmogrifier/graph/memory_graph/__init__.py
@@ -1,1 +1,24 @@
-from .memory_graph import BitTensorMemoryGraph
+"""Convenience imports for the memory-graph helper package.
+
+This package wraps :mod:`memory_graph.memory_graph` and re-exports the core
+types so that ``import src.transmogrifier.graph.memory_graph`` provides access
+to the graph implementation as well as its data structures.  This mirrors the
+expectations in :mod:`src.transmogrifier.graph` which imports several of these
+symbols directly from the package.
+"""
+
+from .memory_graph import (
+    BitTensorMemoryGraph,
+    BitTensorMemory,
+    NodeEntry,
+    EdgeEntry,
+    GraphSearch,
+)
+
+__all__ = [
+    "BitTensorMemoryGraph",
+    "BitTensorMemory",
+    "NodeEntry",
+    "EdgeEntry",
+    "GraphSearch",
+]

--- a/src/transmogrifier/graph/memory_graph/helpers/bit_tensor_memory_dag_helper.py
+++ b/src/transmogrifier/graph/memory_graph/helpers/bit_tensor_memory_dag_helper.py
@@ -12,7 +12,11 @@ from uuid import uuid4
 from ....cells.simulator import Simulator
 from ....cells.simulator_methods.salinepressure import SalineHydraulicSystem
 from ....cells.cell_consts import Cell
-from ...memory_graph import BitTensorMemory
+# Avoid importing via the parent ``memory_graph`` package to prevent
+# circular initialisation when ``memory_graph`` itself imports helpers.
+# ``BitTensorMemory`` lives alongside this module, so we can import it
+# directly from the local helper package.
+from .bit_tensor_memory import BitTensorMemory
 
 import json
 


### PR DESCRIPTION
## Summary
- prevent circular import by importing `BitTensorMemory` locally within DAG helper
- expose core memory graph types from package `memory_graph`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.transmogrifier.cells.simulator_methods.pressure_model', ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager', ModuleNotFoundError: No module named 'transmogrifier.cells.salinepressure', ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6896669d7f10832a95715c33d0bb98c4