### PR TITLE
Ensure salinity solver runs in cell visualiser

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -208,6 +208,7 @@ def visualise_step(sim, cells):
     if VISUALISE and _vis is None:
         _vis = _LCVisual(sim)
 
+    sim.run_saline_sim(cells)
     sp, mask = sim.step(cells)
 
     if VISUALISE:
@@ -225,8 +226,12 @@ def visualise_step(sim, cells):
 if __name__ == "__main__":
     import os
     import random
-    from ..cell_consts import Cell
-    from ..simulator import Simulator
+    try:
+        from ..helpers.cell_consts import Cell
+        from ..helpers.simulator import Simulator
+    except Exception:  # pragma: no cover - fallback for legacy layout
+        from ..cell_consts import Cell
+        from ..simulator import Simulator
 
     specs = [
         dict(left=0,   right=128,  label="0", len=128, stride=128),
@@ -237,6 +242,7 @@ if __name__ == "__main__":
 
     cells = [Cell(**s) for s in specs]
     sim = Simulator(cells)
+    sim.run_balanced_saline_sim(cells)
 
     vis = _LCVisual(sim)
 


### PR DESCRIPTION
## Summary
- Run the salinity/pressure solver before each simulation step in the visualiser
- Support new helper module imports for `Cell` and `Simulator`, falling back to legacy paths
- Initialise salinity balance before visualisation loop

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68966fae40ec832aadc0005fd5b9dd08