### PR TITLE
Ensure salinity solver runs in cell visualiser

### DIFF
--- a/src/transmogrifier/cells/simulator.py
+++ b/src/transmogrifier/cells/simulator.py
@@ -69,7 +69,12 @@ Simulator.minimize = minimize
 Simulator.run_saline_sim = SalineHydraulicSystem.run_saline_sim
 Simulator.run_balanced_saline_sim = SalineHydraulicSystem.run_balanced_saline_sim
 Simulator.update_s_p_expressions = SalineHydraulicSystem.update_s_p_expressions
-Simulator.equilibrium_fracs = SalineHydraulicSystem.equilibrium_fracs
+# Delegate equilibrium fraction queries to the active hydraulic engine.
+def _equilibrium_fracs(self, t):
+    if self.engine is None:
+        raise AttributeError("Saline engine not initialized; call run_saline_sim first")
+    return self.engine.equilibrium_fracs(t)
+Simulator.equilibrium_fracs = _equilibrium_fracs
 Simulator.balance_system = SalineHydraulicSystem.balance_system
 
 

--- a/src/transmogrifier/cells/simulator_methods/evolution.py
+++ b/src/transmogrifier/cells/simulator_methods/evolution.py
@@ -7,7 +7,9 @@ def evolution_tick(self, cells, max_iters: int = 10, *, flush: bool = True):
     prev_widths = [c.right - c.left for c in cells]
     for _ in range(max_iters):
         self.update_s_p_expressions(cells)
-        fractions = self.equilibrium_fracs(0.0)
+        if self.engine is None:
+            raise AttributeError("Saline engine not initialized; call run_saline_sim first")
+        fractions = self.engine.equilibrium_fracs(0.0)
         total_space = self.bitbuffer.mask_size
         proposals = []
         new_widths = []

--- a/src/transmogrifier/cells/simulator_methods/salinepressure.py
+++ b/src/transmogrifier/cells/simulator_methods/salinepressure.py
@@ -87,10 +87,11 @@ class SalineHydraulicSystem:
         sim.snap_cell_walls(sim.cells, sim.cells)
 
 
-    def run_balanced_saline_sim(self, sim, mode='open'):
+    @staticmethod
+    def run_balanced_saline_sim(sim, mode='open'):
         """Balance the system then run the standard saline simulation."""
-        self.balance_system(sim.cells, mode)
-        self.run_saline_sim(sim, as_float=True)
+        sim.balance_system(sim.cells, sim.bitbuffer, mode=mode)
+        SalineHydraulicSystem.run_saline_sim(sim, as_float=True)
     def reset_state(self):
         """Start at t=0 with equal volumes."""
         self.current_t = 0.0

--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -208,6 +208,7 @@ def visualise_step(sim, cells):
     if VISUALISE and _vis is None:
         _vis = _LCVisual(sim)
 
+    sim.run_saline_sim()
     sp, mask = sim.step(cells)
 
     if VISUALISE:
@@ -225,8 +226,12 @@ def visualise_step(sim, cells):
 if __name__ == "__main__":
     import os
     import random
-    from ..cell_consts import Cell
-    from ..simulator import Simulator
+    try:
+        from ..helpers.cell_consts import Cell
+        from ..helpers.simulator import Simulator
+    except Exception:  # pragma: no cover - fallback for legacy layout
+        from ..cell_consts import Cell
+        from ..simulator import Simulator
 
     specs = [
         dict(left=0,   right=128,  label="0", len=128, stride=128),
@@ -237,6 +242,7 @@ if __name__ == "__main__":
 
     cells = [Cell(**s) for s in specs]
     sim = Simulator(cells)
+    sim.run_balanced_saline_sim()
 
     vis = _LCVisual(sim)
 


### PR DESCRIPTION
## Summary
- Run the salinity/pressure solver before each simulation step in the visualiser
- Support new helper module imports for `Cell` and `Simulator`, falling back to legacy paths
- Initialise salinity balance before visualisation loop
- Delegate equilibrium fraction calculations through the hydraulic engine and expose a balanced solver entry point

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager')*

------
https://chatgpt.com/codex/tasks/task_e_68966fae40ec832aadc0005fd5b9dd08