### PR TITLE
Refactor saline sim API

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/salinepressure.py
+++ b/src/transmogrifier/cells/simulator_methods/salinepressure.py
@@ -87,10 +87,10 @@ class SalineHydraulicSystem:
         sim.snap_cell_walls(sim.cells, sim.cells)
 
 
-    def run_balanced_saline_sim(self, sim, mode='open'):
+    def run_balanced_saline_sim(self, mode="open"):
         """Balance the system then run the standard saline simulation."""
-        self.balance_system(sim.cells, mode)
-        self.run_saline_sim(sim, as_float=True)
+        self.balance_system(self.cells, self.bitbuffer, mode)
+        self.run_saline_sim(self, as_float=True)
     def reset_state(self):
         """Start at t=0 with equal volumes."""
         self.current_t = 0.0

--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -242,7 +242,7 @@ if __name__ == "__main__":
 
     cells = [Cell(**s) for s in specs]
     sim = Simulator(cells)
-    sim.run_balanced_saline_sim(cells)
+    sim.run_balanced_saline_sim()
 
     vis = _LCVisual(sim)
 


### PR DESCRIPTION
## Summary
- Simplify `run_balanced_saline_sim` by using simulator state internally
- Update visualization harness to call the refactored method

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'matplotlib'; ModuleNotFoundError: No module named 'src.transmogrifier.cells.simulator_methods.pressure_model'; ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager'; ModuleNotFoundError: No module named 'transmogrifier.cells.salinepressure')*
- `python - <<'PY'
import src.transmogrifier.cells.simulator_methods.visualization as vis
print('VISUALISE =', getattr(vis, 'VISUALISE', None))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68967f28e31c832a86acae4418c7cc6a