### PR TITLE
Add repository LOC counter script

### DIFF
--- a/count_loc.py
+++ b/count_loc.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+# directories to exclude from counting
+EXCLUDE_DIRS = {'.git', '__pycache__'}
+
+
+def iter_python_files(root: Path):
+    for path in root.rglob('*.py'):
+        if any(part in EXCLUDE_DIRS for part in path.parts):
+            continue
+        yield path
+
+
+def main():
+    root = Path(__file__).resolve().parent
+    total = 0
+    for path in iter_python_files(root):
+        with path.open('r', encoding='utf-8') as f:
+            total += sum(1 for _ in f)
+    print(total)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `count_loc.py` to print total Python lines of code in the repository

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'colorama', No module named 'src.transmogrifier.cells.simulator_methods.pressure_model', No module named 'transmogrifier.cells.cell_pressure_region_manager', No module named 'transmogrifier.cells.salinepressure')*


------
https://chatgpt.com/codex/tasks/task_e_689753a1988c832a852abdd3348070e0