### PR TITLE
Mark PID slots as occupied when generating IDs

### DIFF
--- a/src/transmogrifier/bitbitbuffer/helpers/pidbuffer.py
+++ b/src/transmogrifier/bitbitbuffer/helpers/pidbuffer.py
@@ -92,6 +92,9 @@ class PIDBuffer:
         value = uuid_id.int.to_bytes(self.pids.bitsforbits // 8, byteorder='big')
         logging.debug(f"[PIDBuffer.create_id] writing uuid={uuid_id} at data_index={data_index}, bytes={value.hex()}")
         self.pids._data_access[data_index : data_index + 1] = value
+        # mark this stride slot as occupied in the PID mask so that
+        # visualisers and subsequent lookups see the entry immediately
+        self.pids[data_index] = 1
         return uuid_id
 
     def __getitem__(self, key):


### PR DESCRIPTION
## Summary
- Ensure PIDBuffer sets its mask bit when creating PID entries so visualisation and lookups see injected data

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'transmogrifier.cells.salinepressure')*

------
https://chatgpt.com/codex/tasks/task_e_68976091a220832abc674533c5dcc087