### PR TITLE
Fix reverse slice detection in bit indexer

### DIFF
--- a/src/transmogrifier/bitbitbuffer/helpers/bitbitindex.py
+++ b/src/transmogrifier/bitbitbuffer/helpers/bitbitindex.py
@@ -18,9 +18,9 @@ class BitBitIndex:
         self.index_hook = index_hook
         self.empty = False
         if isinstance(index, slice):
-            if index.start is None and index.stop is None:
+            if index.start is None and index.stop is None and (index.step is None or index.step == 1):
                 self.empty = True
-            elif index.start == index.stop:
+            elif index.start is not None and index.stop is not None and index.start == index.stop:
                 self.empty = True
 
     def __repr__(self):

--- a/tests/transmogrifier/test_tuplepattern_reverse_slice.py
+++ b/tests/transmogrifier/test_tuplepattern_reverse_slice.py
@@ -1,0 +1,9 @@
+from transmogrifier.bitbitbuffer.bitbitbuffer import BitBitBuffer
+
+
+def test_tuplepattern_handles_full_reverse_slice():
+    buf = BitBitBuffer(mask_size=32, bitsforbits=16)
+    buf[0:10] = [1,0,1,1,0,0,1,0,1,0]
+    left, right = buf.tuplepattern(0, 10, 5, "bi")
+    assert left == [[1, 1], [0, 1], [1, 2], [0, 1]]
+    assert isinstance(right, list) and right


### PR DESCRIPTION
## Summary
- avoid marking full reverse slices as empty in `BitBitIndex`
- add regression test for `tuplepattern` handling of reverse slices

## Testing
- `pytest tests/transmogrifier/test_tuplepattern_reverse_slice.py -q`
- `pytest` *(fails: ModuleNotFoundError: No module named 'transmogrifier.cells.cell_pressure_region_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6897bdc86130832a8f59607899d642d9