### PR TITLE
Guard visualization input keys when pygame missing

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -122,8 +122,19 @@ FPS         = 60
 # ────────────────────────────────────────────────────────────────
 # Live injection driver (manual keys 0-7 or auto every N seconds)
 # ----------------------------------------------------------------
-INJECT_KEYS = {pygame.K_0: 0, pygame.K_1: 1, pygame.K_2: 2, pygame.K_3: 3,
-               pygame.K_4: 4, pygame.K_5: 5, pygame.K_6: 6, pygame.K_7: 7}
+if VISUALISE:  # pragma: no branch - trivial runtime guard
+    INJECT_KEYS = {
+        pygame.K_0: 0,
+        pygame.K_1: 1,
+        pygame.K_2: 2,
+        pygame.K_3: 3,
+        pygame.K_4: 4,
+        pygame.K_5: 5,
+        pygame.K_6: 6,
+        pygame.K_7: 7,
+    }
+else:
+    INJECT_KEYS = {}
 AUTO_INJECT_EVERY = 0.10          # seconds (set 0 to disable)
 
 
@@ -279,7 +290,7 @@ if __name__ == "__main__":
             if ev.type == pygame.QUIT:
                 pygame.quit()
                 sys.exit()
-            if ev.type == pygame.KEYDOWN and ev.key in INJECT_KEYS:
+            if INJECT_KEYS and ev.type == pygame.KEYDOWN and ev.key in INJECT_KEYS:
                 idx = INJECT_KEYS[ev.key]
                 target = cells[idx]
                 data_len = (target.stride * sim.bitbuffer.bitsforbits + 7) // 8


### PR DESCRIPTION
## Summary
- Avoid pygame key lookups when visualization disabled
- Skip manual injection when no key mapping is available

## Testing
- `pytest` *(fails: too many values to unpack; location out of domain bounds; Unable to allocate 512 ...)*

------
https://chatgpt.com/codex/tasks/task_e_6897ce91a618832aae98ad4c6d1e48ed