### PR TITLE
Refine pygame import handling

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -105,12 +105,14 @@ def bar(sim, number=2, width=80):
 # ────────────────────────────────────────────────────────────────
 # Live Pygame Visualiser driven by the Simulator
 # ----------------------------------------------------------------
+import sys
+import time
+
 try:  # pragma: no cover - optional dependency
-    import pygame, sys, time
+    import pygame
     VISUALISE = True
-except Exception:  # pragma: no cover - pygame not available
+except ImportError:  # pragma: no cover - pygame not available
     pygame = None  # type: ignore
-    sys = time = None  # type: ignore
     VISUALISE = False
 SCALE_X     = 1.0           # pixels per byte  (auto-scaled below)
 ROW_H       = 28            # pixels per cell row


### PR DESCRIPTION
## Summary
- Import `sys` and `time` outside the pygame try/except
- Catch `ImportError` when pygame is missing and disable visualization

## Testing
- `pytest` *(fails: test_injection_mixed_prime7, test_sustained_random_injection, test_add_and_retrieve_node)*

------
https://chatgpt.com/codex/tasks/task_e_6897cea6e8b8832ab40ae0029b1a8f50