### PR TITLE
Reuse pygame font in visualizer

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -134,6 +134,7 @@ class _LCVisual:
         self.sim = sim
         pygame.init()
         self.clock = pygame.time.Clock()
+        self.font = pygame.font.Font(None, 18)
 
         # geometry is derived from the cell layout and may change as cells
         # expand/shrink; keep a cached copy and recalc when needed
@@ -217,9 +218,8 @@ class _LCVisual:
                     x += int(stride * SCALE_X)
 
             # label at left edge
-            font = pygame.font.Font(None, 18)
             self.screen.blit(
-                font.render(str(c.label), True, (255, 255, 255)),
+                self.font.render(str(c.label), True, (255, 255, 255)),
                 (xL + 4, y0 + 4),
             )
 


### PR DESCRIPTION
## Summary
- cache a single `pygame.font.Font` instance in `_LCVisual`
- reuse cached font when drawing cell labels

## Testing
- `pytest` *(fails: tests/test_cell_pressure.py::test_injection_mixed_prime7, tests/test_cell_pressure.py::test_sustained_random_injection, tests/transmogrifier/test_memory_graph_add_node.py::test_add_and_retrieve_node)*


------
https://chatgpt.com/codex/tasks/task_e_6897cefbf84c832ab90c6aada6049b5e