### PR TITLE
Differentiate level-one glyph

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -49,12 +49,12 @@ def print_system(sim, width=80):
     labels     = string.ascii_lowercase
     alpha_len  = len(labels)
     glyph_bases = [
-            ord('a'),    # level 1
-            ord('A'),    # level 2
-            0x03B1,      # level 3 α
-            0x0391,      # level 4 Α
-            0x0430,      # level 5 а
-            0x0410,      # level 6 А
+            ord('A'),    # level 1
+            0x03B1,      # level 2 α
+            0x0391,      # level 3 Α
+            0x0430,      # level 4 а
+            0x0410,      # level 5 А
+            0x24B6,      # level 6 Ⓐ
     ]
     max_level = len(glyph_bases)
 


### PR DESCRIPTION
## Summary
- Ensure cnt==1 uses uppercase letters when visualizing cell data
- Shift ramp mapping and add circled capital symbols to keep six ramp levels

## Testing
- `pytest` *(fails: ValueError in tests/test_cell_pressure.py::test_injection_mixed_prime7; AssertionError in tests/test_cell_pressure.py::test_sustained_random_injection; RuntimeError in tests/transmogrifier/test_memory_graph_add_node.py::test_add_and_retrieve_node)*

------
https://chatgpt.com/codex/tasks/task_e_6897d33f9f08832abcdc1df40542c752