### PR TITLE
Handle missing pygame in visualization demo

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -118,8 +118,16 @@ FPS         = 60
 # ────────────────────────────────────────────────────────────────
 # Live injection driver (manual keys 0-7 or auto every N seconds)
 # ----------------------------------------------------------------
-INJECT_KEYS = {pygame.K_0: 0, pygame.K_1: 1, pygame.K_2: 2, pygame.K_3: 3,
-               pygame.K_4: 4, pygame.K_5: 5, pygame.K_6: 6, pygame.K_7: 7}
+INJECT_KEYS = ({
+    pygame.K_0: 0,
+    pygame.K_1: 1,
+    pygame.K_2: 2,
+    pygame.K_3: 3,
+    pygame.K_4: 4,
+    pygame.K_5: 5,
+    pygame.K_6: 6,
+    pygame.K_7: 7,
+} if pygame else {})
 AUTO_INJECT_EVERY = 0.10          # seconds (set 0 to disable)
 
 
@@ -250,7 +258,11 @@ def visualise_step(sim, cells):
 if __name__ == "__main__":
     import os
     import random
-    
+    import time
+
+    if not VISUALISE:
+        raise SystemExit("pygame required for demo")
+
     from ..cell_consts import Cell
     from ..simulator import Simulator
 


### PR DESCRIPTION
## Summary
- import `time` in the visualization demo's main block
- exit early with a helpful message when pygame isn't available
- guard key mapping so module imports cleanly without pygame

## Testing
- `python -m src.transmogrifier.cells.simulator_methods.visualization` (no pygame)
- `SDL_VIDEODRIVER=dummy PYGAME_HIDE_SUPPORT_PROMPT=1 python -m src.transmogrifier.cells.simulator_methods.visualization` (with pygame, fails with existing assertion)
- `pytest` *(fails: tests/test_cell_pressure.py::test_injection_mixed_prime7, tests/test_cell_pressure.py::test_sustained_random_injection, tests/transmogrifier/test_memory_graph_add_node.py::test_add_and_retrieve_node)*

------
https://chatgpt.com/codex/tasks/task_e_6897d310d0b8832aaa5ff3e97bb564c3