### PR TITLE
Handle zero-length BitBitBuffer slices

### DIFF
--- a/src/transmogrifier/bitbitbuffer/helpers/bitbitindexer.py
+++ b/src/transmogrifier/bitbitbuffer/helpers/bitbitindexer.py
@@ -63,6 +63,15 @@ class BitBitIndexer:
     def access(spec: BitBitIndex) -> Any:
         #print(f"accessed {spec.index} with spec: {spec}")
         if spec.empty:
+            buf = spec.caller.buffer if hasattr(spec.caller, 'buffer') else spec.caller
+            if isinstance(spec.index, slice) and spec.mode == 'view':
+                start, stop, step = spec.normalize()
+                reversed_ = step < 0
+                return BitBitSlice(buf, start, 0, reversed=reversed_, plane=spec.plane)
+            if spec.mode in ('hex', 'data_hex'):
+                return ''
+            if spec.mode == 'get':
+                return b''
             return None
         if spec.index_hook is not None:
             translated_index = spec.index_hook(spec.index)


### PR DESCRIPTION
## Summary
- ensure BitBitIndexer returns an empty BitBitSlice for zero-length ranges
- avoid None results by returning empty strings/bytes for hex and get modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897e6e5de34832aa2392794966a2ded