### PR TITLE
Cache pygame font in visualizer

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -137,6 +137,7 @@ class _LCVisual:
         self.sim = sim
         pygame.init()
         self.clock = pygame.time.Clock()
+        self.font = pygame.font.Font(None, 18)
 
         # geometry is derived from the cell layout and may change as cells
         # expand/shrink; keep a cached copy and recalc when needed
@@ -222,9 +223,8 @@ class _LCVisual:
                     x += int(stride * self.scale_x)
 
             # label at left edge
-            font = pygame.font.Font(None, 18)
             self.screen.blit(
-                font.render(str(c.label), True, (255, 255, 255)),
+                self.font.render(str(c.label), True, (255, 255, 255)),
                 (xL + 4, y0 + 4),
             )
 


### PR DESCRIPTION
## Summary
- Instantiate a single `pygame.font.Font` in `_LCVisual` and reuse it during draws

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897ead57fc8832a9a7279da41c68d09