### PR TITLE
Fix PIDBuffer gap retrieval and add lookup test

### DIFF
--- a/tests/test_pidbuffer.py
+++ b/tests/test_pidbuffer.py
@@ -1,0 +1,12 @@
+from src.transmogrifier.bitbitbuffer.bitbitbuffer import BitBitBuffer
+
+
+def test_get_by_pid_returns_absolute_gap():
+    buffer = BitBitBuffer(mask_size=64)
+    # Register PIDBuffer domain from 16 to 32 with stride 4
+    buffer.register_pid_buffer(left=16, right=32, stride=4, label="A")
+    pb = buffer.pid_buffers["A"]
+    # Request a PID for absolute gap 20
+    pid = pb.get_pids([20])[0]
+    # Lookup should return the absolute gap 20
+    assert buffer.get_by_pid("A", pid) == 20


### PR DESCRIPTION
## Summary
- correct PIDBuffer cached PID lookups by converting stride index to absolute gap and storing stride index in cache
- add regression test verifying `get_by_pid` returns absolute gap

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897ffea49b0832a9f414308b18cb405