### PR TITLE
Finalize numeric boundary snapping by dropping wall sentinels

### DIFF
--- a/src/transmogrifier/cells/cell_consts.py
+++ b/src/transmogrifier/cells/cell_consts.py
@@ -108,16 +108,8 @@ DEFAULT_FLAG_PROFILES = {
     },
 }
 
-LEFT_WALL = Cell(
-    stride=1, left=0, right=0, len=0, profile='rigid_partition', rightmost=0, leftmost=0
-)
-RIGHT_WALL = Cell(
-    stride=1, left=0, right=0, len=0, profile='rigid_partition'
-)
-
 STRIDE = 12
 CELL_COUNT = 1
 MASK_BITS_TO_DATA_BITS = 16
-TEST_SIZE_STRIDE_TIMES_UNITS = (STRIDE ** 2 * 8 * STRIDE * CELL_COUNT) // ( 8 * STRIDE * CELL_COUNT)
+TEST_SIZE_STRIDE_TIMES_UNITS = (STRIDE ** 2 * 8 * STRIDE * CELL_COUNT) // (8 * STRIDE * CELL_COUNT)
 assert TEST_SIZE_STRIDE_TIMES_UNITS % STRIDE == 0
-# Simulator class to coordinate simulation steps

--- a/src/transmogrifier/cells/cell_walls.py
+++ b/src/transmogrifier/cells/cell_walls.py
@@ -1,207 +1,52 @@
-import math
-from .cell_consts import LEFT_WALL, RIGHT_WALL
-
-def snap_cell_walls(self, cells, proposals):
-
-    # ``expand`` is provided by :class:`Simulator`; no rebinding needed here.
-    #self.bar()
-    #print("Snapping cell walls...")
-        
-    # Initialize fixed extents if they don't exist
-    for cell in cells:
-        if not hasattr(cell, 'leftmost') or cell.leftmost is None:
-            #print(f"Line 648: Cell {cell.label} leftmost is None, setting to left {cell.left}")
-            cell.leftmost = cell.left
-        if not hasattr(cell, 'rightmost') or cell.rightmost is None:
-            #print(f"Line 651: Cell {cell.label} rightmost is None, setting to right - 1: {cell.right - 1}")
-            cell.rightmost = cell.right - 1  # rightmost is inclusive, so we subtract 1 to make it exclusive
-
-    # Initialize fixed extents if they don't exist
-    for proposal in proposals:
-        if not hasattr(proposal, 'leftmost') or proposal.leftmost is None:
-            #print(f"Line 657: Proposal {proposal.label} leftmost is None, setting to left {proposal.left}")
-            proposal.leftmost = proposal.left
-        if not hasattr(proposal, 'rightmost') or proposal.rightmost is None:
-                
-            # it's this one:
-            #print(f"Line 662: Proposal {proposal.label} rightmost is None, setting to right - 1: {proposal.right - 1}")
-            proposal.rightmost = proposal.right - 1
-
-    for c in [LEFT_WALL, RIGHT_WALL]:
-        if getattr(c, "leftmost", None) is None:
-            #print(f"Line 667: Wall {c.label} leftmost is None, setting to left {c.left}")
-            c.leftmost = c.left
-        if getattr(c, "rightmost", None) is None:
-            #print(f"Line 670: Wall {c.label} rightmost is None, setting to right - 1: {c.right - 1}")
-            c.rightmost = c.right - 1
-
-    # filter empty cells and proposals
-    # Note: rightmost is inclusive. A single-width cell has leftmost == rightmost and is valid.
-    empty_cells = [
-        c for c in cells
-        if ((c.leftmost > c.rightmost) or (c.left >= c.right)) and (c not in (LEFT_WALL, RIGHT_WALL))
-    ]
+from .cell_consts import Cell
 
 
-    print("Empty Cell Report:")
-    for c in empty_cells:
-        print(f" - Cell {c.label}: {c.leftmost} to {c.rightmost} data in {c.left} to {c.right} (stride {c.stride})")
-
-    cells = [
-        c for c in cells
-        if ((c.leftmost <= c.rightmost) and (c.left < c.right)) or (c in (LEFT_WALL, RIGHT_WALL))
-    ]
-    
-
-    
-    empty_proposals = [
-        p for p in proposals
-        if ((p.leftmost > p.rightmost) or (p.left >= p.right)) and (p not in (LEFT_WALL, RIGHT_WALL))
-    ]
-    
-    proposals = [
-        p for p in proposals
-        if ((p.leftmost <= p.rightmost) and (p.left < p.right)) or (p in (LEFT_WALL, RIGHT_WALL))
-    ]
-    sorted_cells = sorted(cells, key=lambda c: c.leftmost)
-    sorted_proposals = sorted(proposals, key=lambda p: p.leftmost)
-    cells = [LEFT_WALL] + sorted_cells + [RIGHT_WALL]
-    proposals = [LEFT_WALL] + sorted_proposals + [RIGHT_WALL]
-
-
-
-    # --- Pass 1: Calculate LCM-aligned boundaries ---
-    # Invariant: The beginning (left) of every cell MUST be aligned to the system LCM grid.
-    # The right of the previous cell is snapped to the same grid line.
-    boundary_updates = []
-    max_needed = self.bitbuffer.mask_size
-    print(f"strides are:")
-    for cell in sorted_cells + empty_cells:
-        print(f"Cell {cell.label} stride: {cell.stride}")
-    system_lcm = self.lcm(sorted_cells + empty_cells)
-    print(f"System LCM is: {system_lcm}")
+def snap_cell_walls(self, cells, proposals, left_boundary=0, right_boundary=None):
+    if right_boundary is None:
+        right_boundary = self.bitbuffer.mask_size
+    system_lcm = self.lcm(cells)
     assert system_lcm > 0, "System LCM must be greater than zero"
-    #this isn't always true assert system_lcm % 2 == 0, "System LCM must be even for proper alignment"
-    for cell in sorted_cells:
-        assert system_lcm % cell.stride == 0, f"Cell {cell.label} stride {cell.stride} must align with system LCM {system_lcm}"
-    self.system_lcm = system_lcm  # ensure metadata uses the same grid
+    self.system_lcm = system_lcm
 
-    # Keep RIGHT_WALL tracking the current mask extent to start, it may move right
-    RIGHT_WALL.leftmost = RIGHT_WALL.right = RIGHT_WALL.left = self.bitbuffer.mask_size
+    sorted_cells = sorted(cells, key=lambda c: c.left)
+    prev = left_boundary
+    for c in sorted_cells:
+        if c.left < prev:
+            raise AssertionError("LCM alignment requires non-overlapping cells")
+        prev = c.right
 
-    # Build LCM-aligned boundary for each adjacent pair (including LEFT_WALL->first and last->RIGHT_WALL)
-    for i in range(1, len(proposals)):
-        prev = proposals[i - 1]
-        curr = proposals[i]
+    for p in proposals:
+        if getattr(p, 'leftmost', None) is None:
+            p.leftmost = p.left
+        if getattr(p, 'rightmost', None) is None:
+            p.rightmost = p.right - 1
 
-        # base constraint: cannot violate fixed insides (prev.rightmost, curr.leftmost)
-        # and must not move boundary left of what already exists (prev.right)
-        base = max(
-            prev.right,
-            getattr(prev, 'rightmost', prev.right) + 1,
-            curr.leftmost,
-        )
-        b = ((base + system_lcm - 1) // system_lcm) * system_lcm
+    sorted_props = sorted(proposals, key=lambda p: p.left)
+    current = (left_boundary // system_lcm) * system_lcm
+    for p in sorted_props:
+        orig_left = p.left
+        data_width = p.rightmost - orig_left + 1
+        width = max(p.stride, p.right - orig_left, data_width)
+        p.left = current
+        p.right = ((p.left + width + system_lcm - 1) // system_lcm) * system_lcm
+        delta = p.left - orig_left
+        p.leftmost += delta
+        p.rightmost += delta
+        current = p.right
 
-        boundary_updates.append({'index': i, 'b': b})
-        max_needed = max(max_needed, b)
+    for cell, prop in zip(sorted(cells, key=lambda c: c.left), sorted_props):
+        cell.left, cell.right = prop.left, prop.right
 
+    final_extent = max(p.right for p in sorted_props) if sorted_props else right_boundary
+    if final_extent > self.bitbuffer.mask_size:
+        self.expand(self.bitbuffer.mask_size, final_extent - self.bitbuffer.mask_size, cells, sorted_props)
 
-
-    # --- Pass 2: Apply all calculated changes ---
-    for update in boundary_updates:
-        i = update['index']
-        prev = proposals[i - 1]
-        curr = proposals[i]
-
-        # preserve original lengths for pressure reweighting
-        orig_a_len = prev.right - prev.left
-        orig_b_len = curr.right - curr.left
-
-        b = update['b']
-
-        # Ensure non-negative widths while enforcing boundary on the LCM grid
-        if b > curr.right:
-            curr.right = (b + system_lcm - 1) // system_lcm * system_lcm
-        prev.right = b
-        curr.left = b
-
-        # Recompute proportional pressures based on new sub-lengths
-        new_a_len = prev.right - prev.left
-        new_b_len = curr.right - curr.left
-
-        new_p_a = (prev.pressure * new_a_len) // orig_a_len if orig_a_len > 0 else 0
-        new_p_b = (curr.pressure * new_b_len) // orig_b_len if orig_b_len > 0 else 0
-
-        self.system_pressure += (new_p_a + new_p_b) - (prev.pressure + curr.pressure)
-        prev.pressure = new_p_a
-        curr.pressure = new_p_b
-
-        # If the boundary is against RIGHT_WALL, keep it a zero-width wall at that grid line
-        if self.closed:
-            if curr is RIGHT_WALL:
-                curr.left = curr.leftmost = curr.right = b
-                curr.rightmost = b - 1
-
-
-    cells.pop()
-    cells.pop(0)  # Remove LEFT_WALL and RIGHT_WALL from the cells list
-    proposals.pop()
-    proposals.pop(0)  # Remove LEFT_WALL and RIGHT_WALL from the proposals
-
-
-
-    # destribute empty cells and proposals into empty space
-
-    #self.bar()
-    #print("Snapping empty cells and proposals to leftmost/rightmost boundaries...")
-
-
-    for empty_proposal in empty_proposals:
-        #print(f"Snapping empty proposal {empty_proposal.label} to left {max_needed} and right {max_needed + empty_proposal.stride}")
-        empty_proposal.left = max_needed
-        empty_proposal.right = max_needed + empty_proposal.stride
-        empty_proposal.leftmost = empty_proposal.left
-        #print(f"Line 773: Empty proposal {empty_proposal.label} leftmost set to {empty_proposal.leftmost}")
-        empty_proposal.rightmost = empty_proposal.right - 1
-        max_needed += empty_proposal.stride
-
-    #print("Done snapping empty cells and proposals.")
-    self.bar()
-    # Diagnostic print
-    print(f"Snapped cell walls: {[f'{cell.label}: {cell.left}-{cell.right} (stride {cell.stride})' for cell in proposals]}")
-
-
-    proposals = proposals# + empty_proposals
-    cells = cells# + empty_cells
-
-    # --- Intermission: Perform a single, system-wide expansion if needed ---
-    if max_needed > self.bitbuffer.mask_size:
-        print(f"Had to expand bitbuffer mask size from {self.bitbuffer.mask_size} to {max_needed} bits for snapping cell walls")
-        # This triggers the desired fallback logic in build_metadata to distribute the new space
-        self.expand(self.bitbuffer.mask_size, self.bitbuffer.intceil(max_needed - self.bitbuffer.mask_size, system_lcm), cells, proposals)
-
-
-    most_right = max(cell.right for cell in proposals)
-    if most_right + 1 > self.bitbuffer.mask_size:
-        #print(f"Expanding data buffer to accommodate last cell's right boundary: {cells[-1].right * MASK_BITS_TO_DATA_BITS} bits")
-        self.expand(self.bitbuffer.mask_size, self.bitbuffer.intceil(most_right - self.bitbuffer.mask_size, system_lcm), cells, proposals, warp=False)
-
-
-    if self.system_pressure > 0:
-            
-        #print(f"System pressure after snapping cell walls: {self.system_pressure}")
-        self.expand(self.bitbuffer.mask_size, self.bitbuffer.intceil(self.system_pressure, system_lcm), cells, proposals, warp=False)
-
-    #print("Done snapping cell walls.")
-    #self.bar()
 
 def build_metadata(self, offset_bits, size_bits, cells):
     assert len(cells) > 0, "No cells provided to build_metadata"
     events = []
-    # make sure these are lists
-    offs = offset_bits if isinstance(offset_bits, (list,tuple)) else [offset_bits]
-    szs  = size_bits   if isinstance(size_bits,   (list,tuple)) else [size_bits]
+    offs = offset_bits if isinstance(offset_bits, (list, tuple)) else [offset_bits]
+    szs = size_bits if isinstance(size_bits, (list, tuple)) else [size_bits]
 
     for offset in offs:
         assert isinstance(offset, int), f"Offset {offset} is not an integer"
@@ -209,41 +54,30 @@ def build_metadata(self, offset_bits, size_bits, cells):
         assert offset <= self.bitbuffer.mask_size, f"Offset {offset} exceeds mask size {self.bitbuffer.mask_size}"
 
     for off, sz in zip(offs, szs):
-        # 1) try to find a cell that contains `off`
         for cell in cells:
-            # Modification 4: auto-heal pathological “left > right”
             if cell.right < cell.left:
                 cell.right = cell.left
             if cell.left <= off < cell.right:
-                # Modification 1: robust centre selection (align to LCM within cell)
                 raw_mid = (cell.left + cell.right) // 2
                 aligned = raw_mid - (raw_mid % self.system_lcm)
-                center  = max(cell.left, min(aligned, cell.right - 1))
+                center = max(cell.left, min(aligned, cell.right - 1))
                 events.append((cell.label, center, sz))
                 break
         else:
-            # 2) fallback – split `sz` among cells
             n = len(cells)
             base = sz // n
-            rem  = sz % n
+            rem = sz % n
             for idx, cell in enumerate(cells):
-                share  = self.bitbuffer.intceil(base + (1 if idx < rem else 0), self.system_lcm)
+                share = self.bitbuffer.intceil(base + (1 if idx < rem else 0), self.system_lcm)
                 raw_mid = (cell.left + cell.right) // 2
-                center  = raw_mid - (raw_mid % self.system_lcm)
-                center  = max(cell.left, min(center, max(cell.right - self.system_lcm, cell.left)))
+                center = raw_mid - (raw_mid % self.system_lcm)
+                center = max(cell.left, min(center, max(cell.right - self.system_lcm, cell.left)))
                 events.append((cell.label, center, share))
 
-        
-    final = [(label, pos, share) for label, pos, share in events]
-    return sorted(final, key=lambda e: e[1])
-    
-    
+    return sorted(events, key=lambda e: e[1])
+
 
 def expand(self, offset_bits, size_bits, cells, proposals, warp=True):
-    """
-    Build the event list exactly as before, then hand it off to BitBitBuffer.
-    """
-    #print(f"Expanding bitbuffer mask size from {self.bitbuffer.mask_size} to accommodate {size_bits} bits at offsets {offset_bits}")
     if isinstance(offset_bits, int):
         offset_bits = [offset_bits]
     for offset in offset_bits:
@@ -251,12 +85,7 @@ def expand(self, offset_bits, size_bits, cells, proposals, warp=True):
         assert offset >= 0, f"Offset {offset} is negative, must be non-negative"
         assert offset <= self.bitbuffer.mask_size, f"Offset {offset} exceeds mask size {self.bitbuffer.mask_size}"
 
-    # Ensure metadata alignment grid is always current
-    #self.system_lcm = self.lcm(proposals)
-
     events = self.build_metadata(offset_bits, size_bits, cells)
-    #for label, pos, share in events:
-        #print(f"Expanding cell {label} at position {pos} with share {share} bits")
     proposals = self.bitbuffer.expand(events, cells, proposals)
 
     for new_cell in proposals:

--- a/src/transmogrifier/cells/simulator.py
+++ b/src/transmogrifier/cells/simulator.py
@@ -1,6 +1,6 @@
 from typing import Union
 from sympy import Integer
-from .cell_consts import Cell, MASK_BITS_TO_DATA_BITS, CELL_COUNT, RIGHT_WALL, LEFT_WALL
+from .cell_consts import Cell, MASK_BITS_TO_DATA_BITS, CELL_COUNT
 from .simulator_methods.salinepressure import SalineHydraulicSystem
 from ..bitbitbuffer import BitBitBuffer, CellProposal
 from .bitstream_search import BitStreamSearch

--- a/tests/transmogrifier/test_snap_cell_walls.py
+++ b/tests/transmogrifier/test_snap_cell_walls.py
@@ -1,7 +1,7 @@
 import pytest
 import random
 from src.transmogrifier.cells.simulator import Simulator  # Adjust this import to your project structure
-from src.transmogrifier.cells.cell_consts import Cell, LEFT_WALL, RIGHT_WALL
+from src.transmogrifier.cells.cell_consts import Cell
 from src.transmogrifier.bitbitbuffer import CellProposal
 
 def _build_cells(config: str, variant: str, seed: int | None = None):
@@ -273,15 +273,13 @@ def test_boundary_contiguity(sim_and_cells):
         assert isinstance(sim._fixture_error, exc_types)
         assert any(s.lower() in msg.lower() for s in substrs)
         return
-    if _maybe_expect_exception(sim, lambda: sim.snap_cell_walls(cells, proposals)):
+    if _maybe_expect_exception(sim, lambda: sim.snap_cell_walls(cells, proposals, left_boundary=0, right_boundary=sim.bitbuffer.mask_size)):
         return
 
     # --- Assertions ---
-    # Check contiguity from LEFT_WALL up to the last proposal
-    all_boundaries = [LEFT_WALL] + proposals
-    for i in range(len(all_boundaries) - 1):
-        prev_cell = all_boundaries[i]
-        curr_cell = all_boundaries[i+1]
+    for i in range(len(proposals) - 1):
+        prev_cell = proposals[i]
+        curr_cell = proposals[i + 1]
         assert prev_cell.right == curr_cell.left, \
             f"Gap or overlap found: Cell '{prev_cell.label}' ends at {prev_cell.right} but Cell '{curr_cell.label}' starts at {curr_cell.left}."
 

--- a/tests/transmogrifier/test_snap_cell_walls_matrix.py
+++ b/tests/transmogrifier/test_snap_cell_walls_matrix.py
@@ -2,7 +2,7 @@ import random
 import pytest
 
 from src.transmogrifier.cells.simulator import Simulator
-from src.transmogrifier.cells.cell_consts import Cell, LEFT_WALL, RIGHT_WALL
+from src.transmogrifier.cells.cell_consts import Cell
 from src.transmogrifier.bitbitbuffer import CellProposal
 
 
@@ -111,9 +111,9 @@ def test_snap_cell_walls_matrix(config, variant, seed):
     sprops = shrink_proposals(sim, cells)
     if exc_types:
         with pytest.raises(exc_types):
-            sim.snap_cell_walls(cells, sprops)
+            sim.snap_cell_walls(cells, sprops, left_boundary=0, right_boundary=sim.bitbuffer.mask_size)
     else:
-        sim.snap_cell_walls(cells, sprops)
+        sim.snap_cell_walls(cells, sprops, left_boundary=0, right_boundary=sim.bitbuffer.mask_size)
         for p in sprops:
             assert p.right - p.left >= p.stride > 0
 
@@ -121,18 +121,17 @@ def test_snap_cell_walls_matrix(config, variant, seed):
     props = widen_proposals(cells)
     if exc_types:
         with pytest.raises(exc_types):
-            sim.snap_cell_walls(cells, props)
+            sim.snap_cell_walls(cells, props, left_boundary=0, right_boundary=sim.bitbuffer.mask_size)
         return
 
-    sim.snap_cell_walls(cells, props)
+    sim.snap_cell_walls(cells, props, left_boundary=0, right_boundary=sim.bitbuffer.mask_size)
     lcm = sim.system_lcm
     for p in props:
         assert p.left % lcm == 0
         assert p.right % lcm == 0
 
-    chain = [LEFT_WALL] + props
-    for i in range(len(chain) - 1):
-        assert chain[i].right == chain[i+1].left
+    for i in range(len(props) - 1):
+        assert props[i].right == props[i+1].left
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- drop legacy LEFT_WALL/RIGHT_WALL sentinels in cell constants
- rewrite `snap_cell_walls` to align proposals purely by numeric boundaries and expand storage when needed

## Testing
- `pytest` *(fails: tests/test_cell_pressure.py::test_simulation_stride_basic[7], tests/test_cell_pressure.py::test_simulation_stride_basic[11], tests/test_cell_pressure.py::test_simulation_stride_basic[13], tests/test_cell_pressure.py::test_simulation_stride_basic[17], tests/test_cell_pressure.py::test_injection_mixed_prime7, tests/transmogrifier/test_memory_graph_dynamic_sync.py::test_dynamic_flag_syncs_with_memory)*

------
https://chatgpt.com/codex/tasks/task_e_6898b41ca7b8832a9f2160aa8220f016