### PR TITLE
Add roll operation and PIDBuffer domain tracking

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -236,13 +236,14 @@ _vis = None
 
 
 def visualise_step(sim, cells):
-    """Wrapper for ``Simulator.step`` that updates the pygame window."""
+    """Wrapper for ``Simulator.run_balanced_saline_sim`` that updates the pygame window."""
     global _vis
     if VISUALISE and _vis is None:
         _vis = _LCVisual(sim)
 
     
     sim.minimize(sim.cells)
+    sim.run_balanced_saline_sim()
 
     if VISUALISE:
         for ev in pygame.event.get():

--- a/tests/test_cell_pressure.py
+++ b/tests/test_cell_pressure.py
@@ -15,7 +15,7 @@ def test_simulation_stride_basic(stride):
                   right=i * WIDTH + WIDTH)
              for i in range(CELL_COUNT)]
     sim = Simulator(cells)
-    sp, _ = sim.step(cells)
+    sp, _ = sim.minimize(cells)
     assert isinstance(sp, (int, float))
     for c in cells:
         assert len(sim.get_cell_mask(c)) == c.right - c.left
@@ -43,7 +43,7 @@ def test_injection_mixed_prime7():
         )
         cells[0].injection_queue += 1
     for _ in range(10):
-        sp, _ = sim.step(cells)
+        sim.minimize(cells)
     sim.print_system()
     assert cells[0].injection_queue == 0
 
@@ -74,7 +74,7 @@ def test_sustained_random_injection():
                 sim.input_queues.get(target_cell.label, []) + [(payload, target_cell.stride)]
             )
             target_cell.injection_queue += 1
-        sim.step(cells)
+        sim.minimize(cells)
     total_remaining_items = 0
     for cell in cells:
         assert cell.injection_queue == 0


### PR DESCRIPTION
## Summary
- keep PIDBuffer domains in sync with linked cells without manual extent adjustments
- invoke balanced saline simulation via `minimize` and visualization wrapper
- allow memory graph setup to defer hydraulic balancing when regions overlap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899547e04a8832ab0f44a6d352a893e