### PR TITLE
defer cell sync until after expansion

### DIFF
--- a/src/transmogrifier/cells/cell_walls.py
+++ b/src/transmogrifier/cells/cell_walls.py
@@ -35,12 +35,17 @@ def snap_cell_walls(self, cells, proposals, left_boundary=0, right_boundary=None
         p.rightmost += delta
         current = p.right
 
-    for cell, prop in zip(sorted(cells, key=lambda c: c.left), sorted_props):
-        cell.left, cell.right = prop.left, prop.right
-
     final_extent = max(p.right for p in sorted_props) if sorted_props else right_boundary
     if final_extent > self.bitbuffer.mask_size:
         self.expand(self.bitbuffer.mask_size, final_extent - self.bitbuffer.mask_size, cells, sorted_props)
+
+    for cell, prop in zip(sorted(cells, key=lambda c: c.left), sorted_props):
+        cell.left = prop.left
+        cell.right = prop.right
+        cell.leftmost = prop.leftmost
+        cell.rightmost = prop.rightmost
+
+    return sorted_props
 
     
 def build_metadata(self, offset_bits, size_bits, cells):

--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -236,14 +236,12 @@ _vis = None
 
 
 def visualise_step(sim, cells):
-    """Wrapper for ``Simulator.run_balanced_saline_sim`` that updates the pygame window."""
+    """Run ``sim.minimize`` and update the pygame window."""
     global _vis
     if VISUALISE and _vis is None:
         _vis = _LCVisual(sim)
 
-    
     sim.minimize(sim.cells)
-    sim.run_balanced_saline_sim()
 
     if VISUALISE:
         for ev in pygame.event.get():

--- a/tests/transmogrifier/test_snap_cell_walls_deferred_sync.py
+++ b/tests/transmogrifier/test_snap_cell_walls_deferred_sync.py
@@ -1,0 +1,20 @@
+from src.transmogrifier.cells.cell_consts import Cell
+from src.transmogrifier.cells.simulator import Simulator
+from src.transmogrifier.bitbitbuffer import CellProposal
+
+
+def test_snap_cell_walls_defers_cell_sync_until_after_expand():
+    """Expanding past the mask should not raise and cells update afterward."""
+    cells = [
+        Cell(label="A", left=0, right=8, stride=8, leftmost=0, rightmost=7),
+        Cell(label="B", left=8, right=16, stride=8, leftmost=8, rightmost=15),
+    ]
+    sim = Simulator(cells)
+
+    proposals = [CellProposal(c) for c in cells]
+    proposals[1].right = 40  # push beyond current mask
+
+    sim.snap_cell_walls(cells, proposals)
+
+    assert cells[1].right >= 40
+    assert sim.bitbuffer.mask_size > 16

--- a/tests/transmogrifier/test_visualization_no_pygame.py
+++ b/tests/transmogrifier/test_visualization_no_pygame.py
@@ -1,0 +1,26 @@
+import pytest
+
+from src.transmogrifier.cells.cell_consts import Cell
+from src.transmogrifier.cells.simulator import Simulator
+from src.transmogrifier.cells.simulator_methods import visualization as viz
+
+
+def test_visualization_runs_without_pygame(monkeypatch):
+    """visualise_step should execute even when pygame is unavailable."""
+    # Simulate pygame being unavailable
+    monkeypatch.setattr(viz, "pygame", None)
+    monkeypatch.setattr(viz, "VISUALISE", False)
+    viz._vis = None
+
+    cells = [
+        Cell(left=0, right=128, label="0", len=128, stride=128),
+        Cell(left=128, right=256, label="1", len=128, stride=64),
+        Cell(left=256, right=512, label="2", len=256, stride=32),
+        Cell(left=512, right=768, label="3", len=256, stride=16),
+    ]
+    sim = Simulator(cells)
+
+    viz.visualise_step(sim, cells)
+
+    # nothing should have created a visualiser instance
+    assert viz._vis is None


### PR DESCRIPTION
## Summary
- delay syncing snapped cell bounds to cells until after any required bitbuffer expansion
- drop redundant `run_balanced_saline_sim` call from visualiser step
- add regression test covering expansion beyond the mask

## Testing
- `pytest tests/transmogrifier/test_snap_cell_walls_deferred_sync.py::test_snap_cell_walls_defers_cell_sync_until_after_expand -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689963e79b88832a994928fb16cb763d