### PR TITLE
Add PID/bitmask crosschecks in simulator

### DIFF
--- a/src/transmogrifier/cells/simulator.py
+++ b/src/transmogrifier/cells/simulator.py
@@ -61,7 +61,7 @@ class Simulator:
         # Call ``run_saline_sim`` to enable the full saline pressure model.
 
 # Attach modularized methods from simulator_methods
-from .simulator_methods.visualization import print_system, bar
+from .simulator_methods.visualization import print_system, bar, crosscheck
 from .simulator_methods.cell_mask import get_cell_mask, set_cell_mask, pull_cell_mask, push_cell_mask
 from .simulator_methods.data_io import actual_data_hook
 
@@ -86,6 +86,7 @@ Simulator.quanta_map = quanta_map
 Simulator.dump_cells = dump_cells
 Simulator.lcm = lcm
 Simulator.minimize = minimize
+Simulator.crosscheck = crosscheck
 if _USE_CELLSIM:
     Simulator.run_saline_sim = cs_run_saline_sim
     Simulator.run_balanced_saline_sim = cs_run_balanced

--- a/src/transmogrifier/cells/simulator_methods/minimize.py
+++ b/src/transmogrifier/cells/simulator_methods/minimize.py
@@ -332,4 +332,5 @@ def minimize(self, cells):
 
     self.system_pressure = system_pressure
     logger.info(f"Mask state at the end of minimize: {self.bitbuffer.mask.hex()}")
+    self.crosscheck()
     return system_pressure, raws


### PR DESCRIPTION
## Summary
- add `crosscheck` utility to assert PID and bit masks stay in sync
- enforce per-slot PID/bitmask agreement in visualizer
- run `crosscheck` after each minimize cycle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4f84d350832aad2b5989d3b538ca