### PR TITLE
feat: add saturating Na-K pump

### DIFF
--- a/src/transmogrifier/cells/cellsim/data/state.py
+++ b/src/transmogrifier/cells/cellsim/data/state.py
@@ -50,6 +50,13 @@ class Cell(Compartment):
     organelles: List[Organelle] = field(default_factory=list)
     base_pressure: float = 1e4
     _prev_eps: float = 0.0  # runtime
+    # Na/K pump controls
+    pump_enabled: bool = False
+    pump_Jmax: float = 0.0
+    pump_Km_Nai: float = 10.0
+    pump_Km_Ko: float = 1.5
+    pump_alpha_tension: float = 0.0
+    J_pump: float = 0.0
 
     def set_initial_A0_if_missing(self):
         if self.A0 <= 0.0:

--- a/src/transmogrifier/cells/cellsim/transport/pumps.py
+++ b/src/transmogrifier/cells/cellsim/transport/pumps.py
@@ -1,13 +1,56 @@
+from __future__ import annotations
 from typing import Dict
 
-def na_k_pump_flux(comp_left, comp_right, *, A: float, rate: float, dt: float) -> Dict[str,float]:
-    """Return dS_left for a Na/K-ATPase pumping 3 Na out, 2 K in.
 
-    rate: mol/(m^2*s) maximum turnover. Positive rate ejects Na from left (cell).
-    A: membrane area in m^2.
-    dt: timestep in s.
+def na_k_atpase_constant(J_pump_cell: float) -> float:
+    """Return pump mol/s (cell-wide). Positive means: 3 Na out, 2 K in."""
+    return max(J_pump_cell, 0.0)
+
+
+def na_k_atpase_saturating(
+    C_Nai: float,
+    C_Ko: float,
+    A: float,
+    *,
+    Jmax: float = 0.0,
+    Km_Nai: float = 10.0,
+    Km_Ko: float = 1.5,
+    eps: float = 0.0,
+    alpha_tension: float = 0.0,
+) -> float:
+    """Saturating surrogate of Na/K ATPase.
+
+    J = Jmax * (Nai/(Km_Nai+Nai))^3 * (Ko/(Km_Ko+Ko))^2
+        * (1 + alpha_tension*max(eps,0)) * A
+
+    Returns mol/s across the membrane (cell-wide).
+    """
+    if Jmax <= 0.0 or A <= 0.0:
+        return 0.0
+    f_Nai = (C_Nai / (Km_Nai + C_Nai)) if C_Nai > 0 else 0.0
+    f_Ko = (C_Ko / (Km_Ko + C_Ko)) if C_Ko > 0 else 0.0
+    boost = 1.0 + alpha_tension * max(eps, 0.0)
+    return Jmax * (f_Nai ** 3) * (f_Ko ** 2) * boost * A
+
+
+def apply_na_k_pump_to_left_changes(dS_left: Dict[str, float], J_pump: float, dt: float) -> None:
+    """Apply pump flux to left-compartment species changes (mol)."""
+    if J_pump <= 0.0 or dt <= 0.0:
+        return
+    dS_left["Na"] = dS_left.get("Na", 0.0) - 3.0 * J_pump * dt
+    dS_left["K"] = dS_left.get("K", 0.0) + 2.0 * J_pump * dt
+
+
+def na_k_pump_flux(comp_left, comp_right, *, A: float, rate: float, dt: float) -> Dict[str, float]:
+    """Backward-compatible constant-rate pump helper.
+
+    Computes cell-wide pump flux from a surface rate (mol/(m^2*s)).
+    Returns species changes for the left compartment (cell).
     """
     if rate <= 0.0 or dt <= 0.0 or A <= 0.0:
         return {}
-    J = rate * A * dt
-    return {"Na": -3.0 * J, "K": 2.0 * J}
+    dS: Dict[str, float] = {}
+    J = na_k_atpase_constant(rate * A)
+    apply_na_k_pump_to_left_changes(dS, J, dt)
+    return dS
+

--- a/tests/test_mass_charge.py
+++ b/tests/test_mass_charge.py
@@ -7,7 +7,7 @@ from src.transmogrifier.cells.cellsim.core.geometry import sphere_area_from_volu
 def test_mass_conserved_without_pump():
     cell = Cell(V=10.0, n={"Na":10.0, "K":5.0})
     bath = Bath(V=100.0, n={"Na":100.0, "K":50.0})
-    eng = SalineEngine([cell], bath, species=("Na","K"), pump_rate=0.0)
+    eng = SalineEngine([cell], bath, species=("Na","K"))
     before = {sp: cell.n[sp] + bath.n[sp] for sp in ("Na","K")}
     eng.step(1.0)
     after = {sp: cell.n[sp] + bath.n[sp] for sp in ("Na","K")}
@@ -19,10 +19,11 @@ def test_pump_stoichiometry():
     cell = Cell(V=10.0, n={"Na":10.0, "K":5.0})
     bath = Bath(V=100.0, n={"Na":100.0, "K":50.0})
     rate = 1e-3
-    eng = SalineEngine([cell], bath, species=("Na","K"), pump_rate=rate)
+    eng = SalineEngine([cell], bath, species=("Na","K"))
     area, _ = sphere_area_from_volume(cell.V)
+    cell.J_pump = rate * area
     eng.step(1.0)
-    expected = rate * area * 1.0
+    expected = cell.J_pump * 1.0
     assert math.isclose(cell.n["Na"], 10.0 - 3*expected, rel_tol=1e-6)
     assert math.isclose(bath.n["Na"], 100.0 + 3*expected, rel_tol=1e-6)
     assert math.isclose(cell.n["K"], 5.0 + 2*expected, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- add Na/K ATPase helpers for constant and saturating kinetics
- integrate pump into SalineEngine and expose per-cell concentrations
- add pump configuration fields to Cell and update tests

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b54a8d48c832aa39ca1e7302c453a