### PR TITLE
Fix BitBitSlice sub-slice offset handling

### DIFF
--- a/src/transmogrifier/bitbitbuffer/helpers/bitbitindexer.py
+++ b/src/transmogrifier/bitbitbuffer/helpers/bitbitindexer.py
@@ -107,9 +107,10 @@ class BitBitIndexer:
             idxs = spec.indices()
             # single‑bit view  → BitBitItem
             if isinstance(spec.index, int):
+                mask_index = spec.base_offset + idxs[0]
                 return BitBitItem(
                     buffer = buf,
-                    mask_index = idxs[0],
+                    mask_index = mask_index,
                     length = 1,
                     cast = spec.caster,
                     plane = spec.plane
@@ -117,7 +118,8 @@ class BitBitIndexer:
             # slice view → BitBitSlice (handle reverse step)
             step      = spec.index.step or 1
             reversed_ = step < 0
-            start_bit = idxs[0] if step > 0 else idxs[-1]
+            start_idx = idxs[0] if step > 0 else idxs[-1]
+            start_bit = spec.base_offset + start_idx
             return BitBitSlice(
                 buffer   = buf,
                 start_bit= start_bit,

--- a/tests/bitbitbuffer/test_slice_offsets.py
+++ b/tests/bitbitbuffer/test_slice_offsets.py
@@ -1,0 +1,24 @@
+from src.transmogrifier.bitbitbuffer.bitbitbuffer import BitBitBuffer
+
+
+def test_nested_slice_offsets():
+    buf = BitBitBuffer(mask_size=256)
+    buf.mask[:] = bytes(range(32))  # 0x00..0x1f
+
+    outer = buf[8:40]
+    assert outer.hex() == bytes(range(1, 5)).hex()
+
+    inner = outer[8:24]
+    assert inner.hex() == bytes(range(2, 4)).hex()
+
+    for i in [0, 6, 15]:
+        assert inner[i] == int(buf[16 + i])
+
+
+def test_cell_slice_does_not_overlap():
+    buf = BitBitBuffer(mask_size=256)
+    buf[0:128] = [1] * 128
+
+    cell1 = buf[128:256]
+    assert cell1.hex() == '00' * 16
+    assert cell1[0:128].hex() == '00' * 16


### PR DESCRIPTION
## Summary
- preserve base offset when slicing BitBitBuffer views so nested slices and single-bit views address correct global bits
- add regression tests for nested BitBitBuffer slices and mask stamping overlap

## Testing
- `pytest -k test_slice_offsets`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b587714a4832aa47622470c24a5a8