### PR TITLE
Make PID/data crosschecks optional in visualization

### DIFF
--- a/src/transmogrifier/cells/simulator_methods/minimize.py
+++ b/src/transmogrifier/cells/simulator_methods/minimize.py
@@ -2,7 +2,7 @@ from itertools import zip_longest
 from ..bitstream_search import BitStreamSearch
 from .logutil import logger, analysis_logger
 
-def minimize(self, cells):
+def minimize(self, cells, verify=False):
     system_pressure = 0
     raws = {}
 
@@ -332,5 +332,6 @@ def minimize(self, cells):
 
     self.system_pressure = system_pressure
     logger.info(f"Mask state at the end of minimize: {self.bitbuffer.mask.hex()}")
-    self.crosscheck()
+    if verify:
+        self.crosscheck()
     return system_pressure, raws

--- a/src/transmogrifier/cells/simulator_methods/visualization.py
+++ b/src/transmogrifier/cells/simulator_methods/visualization.py
@@ -150,8 +150,9 @@ AUTO_INJECT_EVERY = 0.10          # seconds (set 0 to disable)
 class _LCVisual:
     """Simple pygame-based visualiser for the simulator's cells."""
 
-    def __init__(self, sim):
+    def __init__(self, sim, verify=False):
         self.sim = sim
+        self.verify = verify
         pygame.init()
         self.clock = pygame.time.Clock()
         self.font = pygame.font.Font(None, 18)
@@ -220,7 +221,8 @@ class _LCVisual:
                     mask_idx = (slot_left - anchor) // pb.domain_stride
                     pid_occupied = int(mask[mask_idx]) if 0 <= mask_idx < mask_slots else 0
                 bit_occupied = any(int(self.sim.bitbuffer[b]) for b in range(slot_left, min(slot_left + stride, self.sim.bitbuffer.mask_size)))
-                assert pid_occupied == bit_occupied, f"mask mismatch at {slot_left}"
+                if self.verify:
+                    assert pid_occupied == bit_occupied, f"mask mismatch at {slot_left}"
                 colour = COL_DATA if pid_occupied else COL_SOLVENT
                 # Active development: log grid/data placement and PID search
                 logger.debug(
@@ -261,13 +263,13 @@ class _LCVisual:
 _vis = None
 
 
-def visualise_step(sim, cells):
+def visualise_step(sim, cells, verify=False):
     """Run ``sim.minimize`` and update the pygame window."""
     global _vis
     if VISUALISE and _vis is None:
-        _vis = _LCVisual(sim)
+        _vis = _LCVisual(sim, verify=verify)
 
-    sim.minimize(sim.cells)
+    sim.minimize(sim.cells, verify=verify)
 
     if VISUALISE:
         for ev in pygame.event.get():


### PR DESCRIPTION
## Summary
- Add `verify` flag to simulator `minimize` to run PID/data crosschecks only when requested
- Allow pygame visualizer and `visualise_step` to toggle mask verification via the same flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b79221de0832aad0450da8beb2429