### PR TITLE
Use tqdm nesting for cellsim progress bars

### DIFF
--- a/src/transmogrifier/cells/cellsim/chemistry/crn.py
+++ b/src/transmogrifier/cells/cellsim/chemistry/crn.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, List
+from tqdm.auto import tqdm  # type: ignore
 
 @dataclass
 class Reaction:
@@ -10,7 +11,7 @@ class Reaction:
 
     def rate(self, conc: Dict[str, float]) -> float:
         v = self.k
-        for sp, sto in self.nu_react.items():
+        for sp, sto in tqdm(self.nu_react.items(), desc="reactants", leave=False):
             v *= conc.get(sp, 0.0) ** sto
         return v
 
@@ -21,9 +22,9 @@ class CRN:
 
     def v(self, conc: Dict[str,float]) -> Dict[str,float]:
         prod = {sp: 0.0 for sp in self.species}
-        for rxn in self.reactions:
+        for rxn in tqdm(self.reactions, desc="reactions", leave=False):
             r = rxn.rate(conc)
-            for sp in self.species:
+            for sp in tqdm(self.species, desc="species", leave=False):
                 nu = rxn.nu_prod.get(sp,0) - rxn.nu_react.get(sp,0)
                 if nu != 0:
                     prod[sp] += nu * r

--- a/src/transmogrifier/cells/cellsim/core/checks.py
+++ b/src/transmogrifier/cells/cellsim/core/checks.py
@@ -2,32 +2,33 @@ from __future__ import annotations
 from typing import Iterable
 import math
 from .units import R as RGAS, EPS
+from tqdm.auto import tqdm  # type: ignore
 
 
 def assert_nonneg(cells, bath, species: Iterable[str]):
-    for c in cells:
+    for c in tqdm(cells, desc="cells", leave=False):
         assert c.V >= 0.0, "negative volume"
-        for sp in species:
+        for sp in tqdm(species, desc="species", leave=False):
             assert c.n.get(sp, 0.0) >= -EPS, f"negative amount in cell {sp}"
-            for o in getattr(c, "organelles", []):
+            for o in tqdm(getattr(c, "organelles", []), desc="organelles", leave=False):
                 assert o.n.get(sp, 0.0) >= -EPS, f"negative amount in organelle {sp}"
     assert bath.V >= 0.0, "negative bath volume"
-    for sp in species:
+    for sp in tqdm(species, desc="bath species", leave=False):
         assert bath.n.get(sp, 0.0) >= -EPS, f"negative amount in bath {sp}"
 
 
 def assert_mass_conserved(cells, bath, species: Iterable[str], totals: dict[str, float], tol: float = 1e-6):
-    for sp in species:
+    for sp in tqdm(species, desc="species", leave=False):
         total = bath.n.get(sp, 0.0)
-        for c in cells:
+        for c in tqdm(cells, desc="cells", leave=False):
             total += c.n.get(sp, 0.0)
-            for o in getattr(c, "organelles", []):
+            for o in tqdm(getattr(c, "organelles", []), desc="organelles", leave=False):
                 total += o.n.get(sp, 0.0)
         assert abs(total - totals.get(sp, total)) < tol, f"mass not conserved for {sp}"
 
 
 def assert_passive_no_energy(cell, bath, dS_cell: dict, Cint: dict, Cext: dict, species: Iterable[str], T: float, Rgas: float = RGAS):
-    for sp in species:
+    for sp in tqdm(species, desc="species", leave=False):
         flux = dS_cell.get(sp, 0.0)
         if flux == 0.0:
             continue

--- a/src/transmogrifier/cells/cellsim/core/numerics.py
+++ b/src/transmogrifier/cells/cellsim/core/numerics.py
@@ -1,3 +1,5 @@
+from tqdm.auto import tqdm  # type: ignore
+
 def clamp_nonneg(x: float, eps: float=1e-18) -> float:
     return x if x > eps else eps
 
@@ -18,7 +20,7 @@ def imex_euler(y, f_explicit, f_implicit, dt, max_iter=8, tol=1e-8):
     y_new = y + dt * f_explicit(y)
     if f_implicit is None:
         return y_new
-    for _ in range(max_iter):
+    for _ in tqdm(range(max_iter), desc="imex", leave=False):
         y_prev = y_new
         y_new = y + dt * (f_explicit(y) + f_implicit(y_new))
         if abs(y_new - y_prev) < tol:

--- a/src/transmogrifier/cells/cellsim/placement/bitbuffer.py
+++ b/src/transmogrifier/cells/cellsim/placement/bitbuffer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from math import gcd
 from typing import Sequence, Iterable
+from tqdm.auto import tqdm  # type: ignore
 
 class BitBufferAdapter:
     """Lightweight bridge to BitBitBuffer.expand.
@@ -20,7 +21,7 @@ class BitBufferAdapter:
 
     def _lcm(self, cells: Sequence) -> int:
         L = 1
-        for c in cells:
+        for c in tqdm(cells, desc="cells", leave=False):
             s = max(1, getattr(c, "stride", 1))
             L = L * s // gcd(L, s)
         return L
@@ -36,7 +37,7 @@ class BitBufferAdapter:
             return proposals
         lcm = self._lcm(cells)
         events = []
-        for cell, dV in zip(cells, dV_total):
+        for cell, dV in tqdm(zip(cells, dV_total), desc="expand", total=len(cells), leave=False):
             if dV <= 0:
                 continue
             size = self.intceil(dV, lcm)


### PR DESCRIPTION
## Summary
- convert cellsim loops to native tqdm progress bars, removing custom progress code
- propagate nested tqdm bars through engine, API helpers, checks, numerics, chemistry and placement utilities

## Testing
- `pytest` *(fails: KeyboardInterrupt after 12 tests due to progress-bar interaction)*

------
https://chatgpt.com/codex/tasks/task_e_689b86fa6a88832aa29b919c8b515453