### PR TITLE
Fix saline transport physics

### DIFF
--- a/src/transmogrifier/cells/cellsim/bath/reservoir.py
+++ b/src/transmogrifier/cells/cellsim/bath/reservoir.py
@@ -2,4 +2,5 @@ from ..data.state import Bath
 
 def update_pressure(bath: Bath, sum_dV: float):
     if bath.compressibility and bath.compressibility > 0.0:
-        bath.pressure += -bath.compressibility * (sum_dV / max(bath.V, 1e-18))
+        # compressibility κ: ΔV = κ·V·ΔP  ⇒  ΔP = ΔV / (κ·V)
+        bath.pressure += -(sum_dV / (bath.compressibility * max(bath.V, 1e-18)))

--- a/src/transmogrifier/cells/cellsim/core/numerics.py
+++ b/src/transmogrifier/cells/cellsim/core/numerics.py
@@ -1,7 +1,16 @@
 from tqdm.auto import tqdm  # type: ignore
 
-def clamp_nonneg(x: float, eps: float=1e-18) -> float:
-    return x if x > eps else eps
+
+def clamp_nonneg(x: float, eps: float = 1e-18) -> float:
+    """Clamp negative values to zero without inserting a floor concentration.
+
+    Previously this helper returned ``eps`` for non-positive inputs which meant
+    that a compartment with ``n=0`` moles and ``V=0`` volume would report a
+    concentration of 1 mol/m³.  That artificial osmotic term could flip the sign
+    of fluxes in edge cases.  Returning ``0.0`` keeps quantities non-negative
+    without sneaking in extra solute.
+    """
+    return x if x > 0.0 else 0.0
 
 def adapt_dt(dt: float, rel: float) -> float:
     if rel > 1e-3:   # too big: halve

--- a/src/transmogrifier/cells/cellsim/engine/saline.py
+++ b/src/transmogrifier/cells/cellsim/engine/saline.py
@@ -112,7 +112,7 @@ class SalineEngine:
                 Rgas=RGAS,
                 C_left_override=Cint,
                 C_right_override=Cext,
-                Jv_pressure_term=(self.bath.pressure - P_i),
+                Jv_pressure_term=(P_i - self.bath.pressure),
             )
 
             if J_pump > 0.0:
@@ -149,7 +149,8 @@ class SalineEngine:
 
         # optional bath pressure update via compressibility
         if getattr(self.bath, "compressibility", 0.0) > 0.0:
-            self.bath.pressure += -self.bath.compressibility * (sum_dV / max(self.bath.V, 1e-18))
+            # compressibility κ: ΔV = κ·V·ΔP  ⇒  ΔP = ΔV / (κ·V)
+            self.bath.pressure += -(sum_dV / (self.bath.compressibility * max(self.bath.V, 1e-18)))
 
         # invariant checks
         if self.enable_checks:

--- a/src/transmogrifier/cells/cellsim/transport/kedem_katchalsky.py
+++ b/src/transmogrifier/cells/cellsim/transport/kedem_katchalsky.py
@@ -58,12 +58,13 @@ def fluxes(
     sigma_arr = _arr_from(sigma, species, default=1.0)
     P_arr = _arr_from(Ps, species)
 
-    # Osmotic term Σ σ_i R T (C_R - C_L)
-    osm = np.sum(sigma_arr * Rgas * T * (C_R_arr - C_L_arr))
+    # Osmotic term Σ σ_i R T (C_L - C_R)
+    osm = np.sum(sigma_arr * Rgas * T * (C_L_arr - C_R_arr))
 
-    Jv = Lp * A * (Jv_pressure_term - osm)  # left->right positive
+    # Jv is positive for flow from left→right
+    Jv = Lp * A * (Jv_pressure_term - osm)
     dV_L = -Jv
 
-    Js = P_arr * A * (C_R_arr - C_L_arr) + (1.0 - sigma_arr) * C_L_arr * Jv
+    Js = P_arr * A * (C_L_arr - C_R_arr) + (1.0 - sigma_arr) * C_L_arr * Jv
     dS_L = {sp: -Js[i] for i, sp in enumerate(species)}
     return dV_L, dS_L


### PR DESCRIPTION
## Summary
- Correct osmotic and pressure sign conventions in Kedem–Katchalsky fluxes
- Clamp negative volumes and solute amounts to zero instead of a tiny floor to avoid spurious osmotic terms
- Use true compressibility relation for bath pressure updates

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.transmogrifier.cells.bitbitbuffer')*

------
https://chatgpt.com/codex/tasks/task_e_689b9742ada0832aa08909f0aa95e829