### PR TITLE
Fix organelle volume bookkeeping and rigid bath handling

### DIFF
--- a/src/transmogrifier/cells/cellsim/api/saline.py
+++ b/src/transmogrifier/cells/cellsim/api/saline.py
@@ -116,6 +116,8 @@ class SalinePressureAPI:
                     "volume_total": float(getattr(o, "volume_total", 0.0)),
                     "lumen_fraction": float(getattr(o, "lumen_fraction", 0.0)),
                     "V_lumen": float(o.V if hasattr(o, "V") else 0.0),
+                    "V_solid": float(getattr(o, "V_solid", 0.0)),
+                    "incompressible": bool(getattr(o, "incompressible", False)),
                     "n": {sp: float(o.n.get(sp, 0.0)) for sp in species},
                     "conc": {sp: float((o.n.get(sp, 0.0) / max(o.V, 1e-18))) for sp in species},
                 }
@@ -442,7 +444,7 @@ def build_dynamic_pid_relocation(sim, api: SalinePressureAPI):
             # approximate: one organelle spanning occupied count
             occ_slots = len(set_abs_indices)
             vol = float(occ_slots * stride)
-            cs_cell.organelles.append(Organelle(volume_total=vol, lumen_fraction=0.0, n={"Imp": 0.0}))
+            cs_cell.organelles.append(Organelle(volume_total=vol, lumen_fraction=0.0, n={"Imp": 0.0}, V_solid=vol, incompressible=True))
 
         # Build a simple left-pack relocation: move occupied slots to the left edge
         dst_indices: list[int] = []

--- a/src/transmogrifier/cells/cellsim/data/state.py
+++ b/src/transmogrifier/cells/cellsim/data/state.py
@@ -24,9 +24,23 @@ class Organelle:
     Ea_Ps: Dict[str, float] = field(default_factory=lambda: {"Na":None,"K":None,"Cl":None,"Imp":None})
     anchor_stiffness: float = float("inf")
     eps_ref: float = 0.0
+    V_solid: float = 0.0
+    incompressible: bool = False
+    _V_lumen: float | None = None
+
+    def __post_init__(self):
+        if self._V_lumen is None:
+            self._V_lumen = self.volume_total * self.lumen_fraction
+        if self.V_solid <= 0.0:
+            self.V_solid = self.volume_total - self._V_lumen
+        self.volume_total = self.V_solid + self._V_lumen
 
     def V_lumen(self) -> float:
-        return max(self.volume_total * self.lumen_fraction, 1e-18)
+        return max(self._V_lumen, 0.0)
+
+    def set_V_lumen(self, v: float):
+        self._V_lumen = v
+        self.volume_total = max(self.V_solid + self.V_lumen(), 0.0)
 
     # Provide a Compartment-like interface for transport code
     @property


### PR DESCRIPTION
## Summary
- Track organelle solid and lumen volumes separately and skip flux for incompressible organelles
- Clamp cell volume to organelle occupancy and avoid updating bath volume for incompressible baths
- Include organelle solid volume and incompressible flag in snapshots and stride-backed creation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.transmogrifier.cells.bitbitbuffer')*
- `pytest tests/test_organelle_exclusion.py tests/test_mass_charge.py tests/test_cellsim_engine.py tests/test_pressure_model.py`

------
https://chatgpt.com/codex/tasks/task_e_689b9c449860832ab0ee6f36aaa386f7