### PR TITLE
Replace cell BitBitBuffer shim imports with canonical package

### DIFF
--- a/tests/test_cell_pressure.py
+++ b/tests/test_cell_pressure.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from src.transmogrifier.cells.simulator import Simulator
 from src.transmogrifier.cells.cell_consts import Cell
-from src.transmogrifier.cells.bitbitbuffer import BitBitBuffer
+from src.transmogrifier.bitbitbuffer import BitBitBuffer
 
 def test_simulation_stride_basic(stride):
     random.seed(0)

--- a/tests/transmogrifier/test_bitstream_search.py
+++ b/tests/transmogrifier/test_bitstream_search.py
@@ -1,4 +1,4 @@
-from transmogrifier.cells.bitstream_search import BitStreamSearch
+from src.transmogrifier.bitbitbuffer.helpers.bitstream_search import BitStreamSearch
 
 
 class DummyBitslice:

--- a/tests/transmogrifier/test_salinepressure.py
+++ b/tests/transmogrifier/test_salinepressure.py
@@ -1,12 +1,14 @@
-from sympy import Integer
 import pytest
 from src.transmogrifier.cells.cellsim.api.saline import SalinePressureAPI as SalineHydraulicSystem
 from src.transmogrifier.cells.simulator import Simulator
 from src.transmogrifier.cells.cell_consts import Cell
+from src.transmogrifier.cells.cellsim.data.state import Cell as SimCell, Bath
 
 
 def test_equilibrium_fracs_sum_to_one():
-    system = SalineHydraulicSystem([Integer(1), Integer(1)], [Integer(1), Integer(1)], width=10)
+    cells = [SimCell(V=1.0, n={"Imp": 1.0}), SimCell(V=1.0, n={"Imp": 1.0})]
+    bath = Bath(V=1.0, n={"Imp": 1.0})
+    system = SalineHydraulicSystem(cells, bath, width=10)
     fracs = system.equilibrium_fracs(0.0)
     assert abs(sum(fracs) - 1.0) < 1e-6
 


### PR DESCRIPTION
## Summary
- Use `src.transmogrifier.bitbitbuffer` in cell-pressure test
- Import `BitStreamSearch` from bitbitbuffer helpers
- Initialize proper SimCell/Bath objects in saline pressure test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9e537b68832a83b107c67e426131