### PR TITLE
fix: preserve cell base pressure in saline API

### DIFF
--- a/src/transmogrifier/cells/cellsim/api/saline.py
+++ b/src/transmogrifier/cells/cellsim/api/saline.py
@@ -199,12 +199,17 @@ class SalinePressureAPI:
         cells = []
         for legacy in tqdm(sim.cells, desc="cells", leave=False):
             V = float(legacy.right - legacy.left)
-            cell = Cell(V=V,
-                        n={"Imp": float(getattr(legacy, "salinity", 0.0)),
-                           "Na": 0.0, "K": 0.0, "Cl": 0.0},
-                        base_pressure=float(getattr(legacy, "pressure", 0.0)),
-                        elastic_k=float(getattr(legacy, "elastic_k", 0.1)),
-                        visc_eta=float(getattr(legacy, "visc_eta", 0.0)))
+            cell = Cell(
+                V=V,
+                n={"Imp": float(getattr(legacy, "salinity", 0.0)),
+                   "Na": 0.0, "K": 0.0, "Cl": 0.0},
+                # Preserve the legacy cell's immutable baseline pressure
+                base_pressure=float(
+                    getattr(legacy, "base_pressure", getattr(legacy, "pressure", 0.0))
+                ),
+                elastic_k=float(getattr(legacy, "elastic_k", 0.1)),
+                visc_eta=float(getattr(legacy, "visc_eta", 0.0)),
+            )
             # organelles if present
             if hasattr(legacy, "organelles"):
                 for o in tqdm(legacy.organelles, desc="organelles", leave=False):

--- a/tests/transmogrifier/test_base_pressure_persistence.py
+++ b/tests/transmogrifier/test_base_pressure_persistence.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.transmogrifier.cells.cell_consts import Cell
+from src.transmogrifier.cells.simulator import Simulator
+from src.transmogrifier.cells.cellsim.api.saline import SalinePressureAPI
+
+
+def test_base_pressure_preserved_from_legacy():
+    cells = [Cell(stride=1, left=0, right=8, label='A')]
+    cells[0].base_pressure = 2.5
+    cells[0].pressure = 3.5
+    sim = Simulator(cells)
+
+    api = SalinePressureAPI.from_legacy(sim)
+
+    assert api.cells[0].base_pressure == pytest.approx(2.5)


### PR DESCRIPTION
## Summary
- keep legacy base pressure when building SalinePressureAPI cells
- add regression test for base pressure preservation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ba6b5cfc0832a82b4002b0a93b6cb