### PR TITLE
feat: add tunable cell biophysics presets

### DIFF
--- a/src/transmogrifier/cells/cell_consts.py
+++ b/src/transmogrifier/cells/cell_consts.py
@@ -1,5 +1,10 @@
 
 from enum import IntFlag, auto
+from .cellsim.constants import (
+    DEFAULT_ELASTIC_K,
+    DEFAULT_LP0,
+    SALINITY_PER_DATA_UNIT,
+)
 
 
 
@@ -52,8 +57,8 @@ class Cell:
         self.r_wall_flags = flags['right_wall']
         self.c_flags      = flags['cell']
         self.system_flags = flags['system']
-        self.l_solvent_permiability = 1
-        self.r_solvent_permiability = 1
+        self.l_solvent_permiability = DEFAULT_LP0
+        self.r_solvent_permiability = DEFAULT_LP0
         self.injection_queue = 0
         self.resize_queue = 0
         self.stride = stride
@@ -67,7 +72,8 @@ class Cell:
         # any baseline hydrostatic pressure in the system.
         self.volume = float(self.len)
         self.reference_volume = float(self.len)
-        self.elastic_coeff = 0.1
+        self.elastic_coeff = DEFAULT_ELASTIC_K
+        self.salinity_per_data_unit = SALINITY_PER_DATA_UNIT
         self.base_pressure = 0.0
         self.pressure = 0.0
         self.concentration = 0.0

--- a/src/transmogrifier/cells/cellsim/constants.py
+++ b/src/transmogrifier/cells/cellsim/constants.py
@@ -1,0 +1,41 @@
+"""Default biophysical constants for cellsim.
+
+These values target typical eukaryotic cells but can be overridden
+through presets for other cell types.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+# Amount of impermeant solute (moles) per unit of abstract data.
+# This provides a stable osmotic load for each data-carrying organelle.
+SALINITY_PER_DATA_UNIT: float = 1e-3
+
+# Baseline hydraulic permeability of the plasma membrane (m/Pa/s).
+DEFAULT_LP0: float = 1e-12
+
+# Effective surface elastic modulus of the membrane (Pa).
+DEFAULT_ELASTIC_K: float = 1e5
+
+
+@dataclass(frozen=True)
+class Preset:
+    """Biophysical parameter bundle for a cell type."""
+    salinity_per_data_unit: float = SALINITY_PER_DATA_UNIT
+    elastic_k: float = DEFAULT_ELASTIC_K
+    Lp0: float = DEFAULT_LP0
+
+
+# Predefined parameter sets keyed by shorthand names.  Additional
+# presets may be added by callers.
+PRESETS: dict[str, Preset] = {
+    "eukaryote": Preset(),
+}
+
+
+def apply_preset(cell, preset: str = "eukaryote") -> None:
+    """Apply the named preset parameters to ``cell`` in-place."""
+    cfg = PRESETS.get(preset)
+    if cfg is None:
+        raise KeyError(f"Unknown preset '{preset}'")
+    cell.elastic_k = cfg.elastic_k
+    cell.Lp0 = cfg.Lp0

--- a/src/transmogrifier/cells/cellsim/data/state.py
+++ b/src/transmogrifier/cells/cellsim/data/state.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass, field
 from typing import Dict, List
 from ..core.geometry import sphere_area_from_volume
+from ..constants import (
+    DEFAULT_ELASTIC_K,
+    DEFAULT_LP0,
+    SALINITY_PER_DATA_UNIT,
+)
 
 @dataclass
 class Compartment:
@@ -17,7 +22,7 @@ class Organelle:
     volume_total: float
     lumen_fraction: float = 0.7
     n: Dict[str, float] = field(default_factory=dict)
-    Lp0: float = 0.01
+    Lp0: float = DEFAULT_LP0
     Ps0: Dict[str, float] = field(default_factory=lambda: {"Na":0.01,"K":0.01,"Cl":0.01,"Imp":0.0})
     sigma: Dict[str, float] = field(default_factory=lambda: {"Na":0.9,"K":0.9,"Cl":0.9,"Imp":1.0})
     Ea_Lp: float | None = None
@@ -34,6 +39,9 @@ class Organelle:
         if self.V_solid <= 0.0:
             self.V_solid = self.volume_total - self._V_lumen
         self.volume_total = self.V_solid + self._V_lumen
+        # Seed a standard impermeant solute load if missing.
+        if "Imp" not in self.n:
+            self.n["Imp"] = self.V_lumen() * SALINITY_PER_DATA_UNIT
 
     def V_lumen(self) -> float:
         return max(self._V_lumen, 0.0)
@@ -54,9 +62,9 @@ class Organelle:
 @dataclass
 class Cell(Compartment):
     A0: float = 0.0
-    elastic_k: float = 0.1
+    elastic_k: float = DEFAULT_ELASTIC_K
     visc_eta: float = 0.0
-    Lp0: float = 1.0
+    Lp0: float = DEFAULT_LP0
     Ps0: Dict[str, float] = field(default_factory=lambda: {"Na":0.01,"K":0.01,"Cl":0.01,"Imp":0.0})
     sigma: Dict[str, float] = field(default_factory=lambda: {"Na":0.9,"K":0.9,"Cl":0.9,"Imp":1.0})
     Ea_Lp: float | None = None

--- a/tests/transmogrifier/test_cell_consts.py
+++ b/tests/transmogrifier/test_cell_consts.py
@@ -1,4 +1,10 @@
 from transmogrifier.cells.cell_consts import Cell, DEFAULT_FLAG_PROFILES
+from transmogrifier.cells.cellsim.constants import (
+    DEFAULT_ELASTIC_K,
+    DEFAULT_LP0,
+    SALINITY_PER_DATA_UNIT,
+)
+from transmogrifier.cells.cellsim.data.state import Organelle
 
 
 def test_cell_flag_profiles():
@@ -8,3 +14,15 @@ def test_cell_flag_profiles():
     assert cell.r_wall_flags == flags["right_wall"]
     assert cell.c_flags == flags["cell"]
     assert cell.system_flags == flags["system"]
+
+
+def test_cell_biophysical_defaults():
+    c = Cell(stride=1, left=0, right=4, len=4)
+    assert c.elastic_coeff == DEFAULT_ELASTIC_K
+    assert c.l_solvent_permiability == DEFAULT_LP0
+    assert c.salinity_per_data_unit == SALINITY_PER_DATA_UNIT
+
+
+def test_organelle_salinity_seed():
+    o = Organelle(volume_total=1.0)
+    assert o.n["Imp"] == o.V_lumen() * SALINITY_PER_DATA_UNIT


### PR DESCRIPTION
## Summary
- provide shared constants for salinity, elasticity and permeability with a eukaryotic preset
- seed organelles with a standard impermeant solute load
- default cell objects to realistic membrane elasticity and hydraulic permeability
- test the new defaults

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb0df1f28832a8230c99a9bcb9fd4