### PR TITLE
Add softbody init modules and run numpy demo

### DIFF
--- a/src/transmogrifier/softbody/__init__.py
+++ b/src/transmogrifier/softbody/__init__.py
@@ -1,0 +1,3 @@
+"""Softbody simulation components (XPBD-based)."""
+
+__all__ = ["bridge", "demo", "engine"]

--- a/src/transmogrifier/softbody/bridge/__init__.py
+++ b/src/transmogrifier/softbody/bridge/__init__.py
@@ -1,0 +1,5 @@
+"""Data structures for interfacing softbody mechanics with other systems."""
+
+from .state_io import ZeroDCell, ZeroDState, ZeroDDelta
+
+__all__ = ["ZeroDCell", "ZeroDState", "ZeroDDelta"]

--- a/src/transmogrifier/softbody/demo/__init__.py
+++ b/src/transmogrifier/softbody/demo/__init__.py
@@ -1,0 +1,7 @@
+"""Demonstration scripts showcasing the softbody engine."""
+
+__all__ = [
+    "run_ascii_demo",
+    "run_numpy_demo",
+    "run_opengl_demo",
+]

--- a/src/transmogrifier/softbody/engine/__init__.py
+++ b/src/transmogrifier/softbody/engine/__init__.py
@@ -1,0 +1,22 @@
+"""XPBD engine and geometry utilities for softbody simulations."""
+
+from .params import EngineParams
+from .xpbd_core import XPBDSolver
+from .constraints import (
+    StretchConstraint,
+    VolumeConstraint,
+    DihedralBendingConstraint,
+    PlaneContact,
+)
+from .hierarchy import Cell, Organelle
+
+__all__ = [
+    "EngineParams",
+    "XPBDSolver",
+    "StretchConstraint",
+    "VolumeConstraint",
+    "DihedralBendingConstraint",
+    "PlaneContact",
+    "Cell",
+    "Organelle",
+]


### PR DESCRIPTION
## Summary
- integrate softbody package with explicit `__init__` modules
- expose XPBD engine classes and demo scripts

## Testing
- `python -m src.transmogrifier.softbody.demo.run_numpy_demo --frames 10`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c054cc43c832a98fb72308041a5a9