### PR TITLE
Vectorize hierarchy updates

### DIFF
--- a/src/transmogrifier/softbody/engine/hierarchy.py
+++ b/src/transmogrifier/softbody/engine/hierarchy.py
@@ -33,9 +33,12 @@ class Cell:
         return mesh_volume(self.X, self.faces)
 
     def surface_area(self) -> float:
-        tris = self.X[self.faces]
-        cross = np.cross(tris[:,1] - tris[:,0], tris[:,2] - tris[:,0])
-        return 0.5 * np.linalg.norm(cross, axis=1).sum()
+        idx = self.faces
+        a = self.X[idx[:, 0]]
+        b = self.X[idx[:, 1]]
+        c = self.X[idx[:, 2]]
+        cross = np.cross(b - a, c - a)
+        return float(0.5 * np.linalg.norm(cross, axis=1).sum())
 
     def contact_pressure_estimate(self) -> float:
         V = abs(self.enclosed_volume())
@@ -51,35 +54,122 @@ class Hierarchy:
     params: object
 
     def integrate(self, dt):
-        for c in self.cells:
-            self.solver.integrate(c.X, c.V, c.invm, dt)
+        if not self.cells:
+            return
+        X = np.vstack([c.X for c in self.cells])
+        V = np.vstack([c.V for c in self.cells])
+        invm = np.concatenate([c.invm for c in self.cells])
+        offsets = np.cumsum([0] + [len(c.X) for c in self.cells])
+        self.solver.integrate(X, V, invm, dt)
+        for c, start, end in zip(self.cells, offsets[:-1], offsets[1:]):
+            c.X[:] = X[start:end]
+            c.V[:] = V[start:end]
 
     def project_constraints(self, dt):
-        for c in self.cells:
-            self.solver.project(
-                c.constraints, c.X, c.invm, c.faces, mesh_volume, volume_gradients,
-                dt, self.params.iterations, self.box_min, self.box_max
-            )
+        if not self.cells:
+            return
+
+        sizes = [len(c.X) for c in self.cells]
+        offsets = np.cumsum([0] + sizes)
+        X = np.vstack([c.X for c in self.cells])
+        invm = np.concatenate([c.invm for c in self.cells])
+
+        # Aggregate stretch and bending constraints with index offsets
+        stretch_idx = []
+        stretch_rest = []
+        stretch_comp = []
+        stretch_lamb = []
+        bend_idx = []
+        bend_rest = []
+        bend_comp = []
+        bend_lamb = []
+        for off, c in zip(offsets[:-1], self.cells):
+            sc = c.constraints.get("stretch")
+            if sc is not None:
+                stretch_idx.append(sc["indices"] + off)
+                stretch_rest.append(sc["rest"])
+                stretch_comp.append(sc["compliance"])
+                stretch_lamb.append(sc["lamb"])
+            bc = c.constraints.get("bending")
+            if bc is not None:
+                bend_idx.append(bc["indices"] + off)
+                bend_rest.append(bc["rest"])
+                bend_comp.append(bc["compliance"])
+                bend_lamb.append(bc["lamb"])
+
+        cons = {}
+        if stretch_idx:
+            cons["stretch"] = {
+                "indices": np.vstack(stretch_idx),
+                "rest": np.concatenate(stretch_rest),
+                "compliance": np.concatenate(stretch_comp),
+                "lamb": np.concatenate(stretch_lamb),
+            }
+        if bend_idx:
+            cons["bending"] = {
+                "indices": np.vstack(bend_idx),
+                "rest": np.concatenate(bend_rest),
+                "compliance": np.concatenate(bend_comp),
+                "lamb": np.concatenate(bend_lamb),
+            }
+
+        faces_dummy = np.empty((0, 3), dtype=np.int32)
+        self.solver.project(
+            cons, X, invm, faces_dummy, mesh_volume, volume_gradients,
+            dt, self.params.iterations, self.box_min, self.box_max
+        )
+
+        # Volume constraints handled per cell on the aggregated arrays
+        for off, c in zip(offsets[:-1], self.cells):
+            vc = c.constraints.get("volume")
+            if vc is not None:
+                sl = slice(off, off + len(c.X))
+                vc.project(X[sl], invm[sl], c.faces, mesh_volume, volume_gradients, dt)
+
+        for c, start, end in zip(self.cells, offsets[:-1], offsets[1:]):
+            c.X[:] = X[start:end]
 
     def update_organelle_modes(self, dt):
-        for c in self.cells:
-            if not c.organelles:
+        counts = [len(c.organelles) for c in self.cells]
+        if sum(counts) == 0:
+            return
+
+        centroids = np.array([np.mean(c.X, axis=0) for c in self.cells])
+        v_adv = np.array([np.mean(c.V, axis=0) for c in self.cells])
+
+        pos_list = []
+        vel_list = []
+        alpha_list = []
+        cell_idx = []
+        for idx, c in enumerate(self.cells):
+            n = counts[idx]
+            if n == 0:
                 continue
+            pos_list.append(np.array([o.pos for o in c.organelles], dtype=np.float64))
+            vel_list.append(np.array([o.vel for o in c.organelles], dtype=np.float64))
+            alpha_list.append(np.clip([o.viscosity for o in c.organelles], 0.0, 1.0))
+            cell_idx.extend([idx] * n)
 
-            v_adv = np.mean(c.V, axis=0)
+        pos = np.vstack(pos_list)
+        vel = np.vstack(vel_list)
+        alpha = np.concatenate(alpha_list)[:, None]
+        v_adv_full = v_adv[cell_idx]
 
-            pos = np.array([o.pos for o in c.organelles], dtype=np.float64)
-            vel = np.array([o.vel for o in c.organelles], dtype=np.float64)
-            visc = np.array([o.viscosity for o in c.organelles], dtype=np.float64)[:, None]
-            alpha = np.clip(visc, 0.0, 1.0)
+        vel = (1.0 - alpha) * vel + alpha * v_adv_full
+        pos = pos + dt * vel
+        pos = np.clip(pos, self.box_min, self.box_max)
 
-            vel = (1.0 - alpha) * vel + alpha * v_adv
-            pos = pos + dt * vel
-            pos = np.clip(pos, self.box_min, self.box_max)
-
-            for i, o in enumerate(c.organelles):
-                o.vel = vel[i]
-                o.pos[:] = pos[i]
+        start = 0
+        for c in self.cells:
+            n = len(c.organelles)
+            if n == 0:
+                continue
+            v_slice = vel[start:start+n]
+            p_slice = pos[start:start+n]
+            for j, o in enumerate(c.organelles):
+                o.vel = v_slice[j]
+                o.pos[:] = p_slice[j]
+            start += n
 
 def build_cell(id_str, center, radius, params, subdiv=1, mass_per_vertex=1.0, target_volume=None):
     X, F = make_icosphere(subdiv=subdiv, radius=radius, center=center)


### PR DESCRIPTION
## Summary
- Vectorize `Cell.surface_area` using face-wide array operations
- Aggregate cell states so `XPBDSolver` integrates and projects constraints for all cells in a single call
- Broadcast organelle position and velocity updates across all cells

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c0df9ac44832a9f5db6570ebc6dfa