### PR TITLE
Add FieldStack support to softbody hierarchy

### DIFF
--- a/src/transmogrifier/cells/cellsim/mechanics/softbody0d.py
+++ b/src/transmogrifier/cells/cellsim/mechanics/softbody0d.py
@@ -17,6 +17,7 @@ from src.transmogrifier.softbody.engine.coupling import (
     laplace_from_Ka,
     cell_area,
 )
+from src.transmogrifier.softbody.engine.fields import FieldStack
 
 
 @dataclass
@@ -197,8 +198,15 @@ class Softbody0DProvider(MechanicsProvider):
             solver=solver,
             params=self._params,
         )
-        # after self._h = Hierarchy(...)
-        from src.transmogrifier.softbody.resources.field_library import uniform_flow, shear_flow, fluid_noise, gravity
+        # Attach a field stack for optional environmental forces/noise
+        self._h.fields = FieldStack()
+
+        from src.transmogrifier.softbody.resources.field_library import (
+            uniform_flow,
+            shear_flow,
+            fluid_noise,
+            gravity,
+        )
 
         # whole-system drift to +X
         self._h.fields.add(uniform_flow(u=(0.03, 0.0, 0.0), dim=3))
@@ -207,7 +215,9 @@ class Softbody0DProvider(MechanicsProvider):
         # self._h.fields.add(shear_flow(rate=0.5, axis_xy=(0,1), dim=3))
 
         # gentle Brownian jiggle (no COM drift)
-        #self._h.fields.add(fluid_noise(sigma=5e-4, com_neutral=True, dim=3))
+        # self._h.fields.add(fluid_noise(sigma=5e-4, com_neutral=True, dim=3))
 
         # gravity on a subset (example: only cell0 & cell2)
-        # self._h.fields.add(gravity(g=(0,-0.4,0), selector=lambda c: c.id in {"cell0","cell2"}, dim=3))
+        # self._h.fields.add(
+        #     gravity(g=(0, -0.4, 0), selector=lambda c: c.id in {"cell0", "cell2"}, dim=3)
+        # )

--- a/src/transmogrifier/softbody/engine/hierarchy.py
+++ b/src/transmogrifier/softbody/engine/hierarchy.py
@@ -6,6 +6,7 @@ from typing import List
 from .mesh import make_icosphere, mesh_volume, volume_gradients, build_adjacency
 from .constraints import VolumeConstraint
 from .xpbd_core import XPBDSolver
+from .fields import FieldStack
 
 @dataclass
 class Organelle:
@@ -52,6 +53,7 @@ class Hierarchy:
     cells: List[Cell]
     solver: XPBDSolver
     params: object
+    fields: FieldStack = field(default_factory=FieldStack)
 
     def integrate(self, dt):
         if not self.cells:

--- a/src/transmogrifier/softbody/resources/field_library.py
+++ b/src/transmogrifier/softbody/resources/field_library.py
@@ -1,6 +1,6 @@
 # field_library.py
 import numpy as np
-from .fields import VectorField
+from src.transmogrifier.softbody.engine.fields import VectorField
 
 def gravity(g=(0.0, -9.81, 0.0), selector=None, dim=3):
     g = np.asarray(g, dtype=float)


### PR DESCRIPTION
## Summary
- provide a FieldStack for each softbody hierarchy and populate it in the 0D provider
- fix resource field library to import VectorField from engine module

## Testing
- `python - <<'PY'
from src.transmogrifier.softbody.demo.run_numpy_demo import make_cellsim_backend, step_cellsim
import numpy as np
api, provider = make_cellsim_backend(cell_vols=[1.0], cell_imps=[100], cell_elastic_k=[0.5], bath_na=1000, bath_cl=1000, bath_pressure=1e4, bath_volume_factor=5.0, substeps=2, dt_provider=0.01)
provider.sync(api.cells, api.bath)
print('built world, field stack', provider._h.fields)
def centroid():
    return float(np.mean(provider._h.cells[0].X[:,0]))
print('initial centroid x', centroid())
for step in range(3):
    step_cellsim(api, 0.01)
    print('step', step, 'centroid x', centroid())
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9b6e7dfc832a8e98f2de0440dcf3