### PR TITLE
Add naive membrane collision resolution

### DIFF
--- a/src/transmogrifier/softbody/engine/__init__.py
+++ b/src/transmogrifier/softbody/engine/__init__.py
@@ -9,6 +9,7 @@ from .constraints import (
     PlaneContact,
 )
 from .hierarchy import Cell, Organelle
+from .collisions import resolve_membrane_collisions
 
 __all__ = [
     "EngineParams",
@@ -19,4 +20,5 @@ __all__ = [
     "PlaneContact",
     "Cell",
     "Organelle",
+    "resolve_membrane_collisions",
 ]

--- a/src/transmogrifier/softbody/engine/collisions.py
+++ b/src/transmogrifier/softbody/engine/collisions.py
@@ -1,0 +1,88 @@
+import numpy as np
+from typing import List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .hierarchy import Cell
+
+
+def _inside_triangle(p: np.ndarray, a: np.ndarray, b: np.ndarray, c: np.ndarray) -> bool:
+    v0 = c - a
+    v1 = b - a
+    v2 = p - a
+    d00 = np.dot(v0, v0)
+    d01 = np.dot(v0, v1)
+    d11 = np.dot(v1, v1)
+    d20 = np.dot(v2, v0)
+    d21 = np.dot(v2, v1)
+    denom = d00 * d11 - d01 * d01
+    if denom == 0.0:
+        return False
+    v = (d11 * d20 - d01 * d21) / denom
+    w = (d00 * d21 - d01 * d20) / denom
+    u = 1.0 - v - w
+    return (u >= 0.0) and (v >= 0.0) and (w >= 0.0)
+
+
+def _vertex_triangle_penetration(v: np.ndarray, a: np.ndarray, b: np.ndarray, c: np.ndarray):
+    n = np.cross(b - a, c - a)
+    norm = np.linalg.norm(n)
+    if norm < 1e-12:
+        return 0.0, None
+    n = n / norm
+    dist = np.dot(v - a, n)
+    if dist >= 0.0:
+        return dist, None
+    proj = v - dist * n
+    if _inside_triangle(proj, a, b, c):
+        return dist, n
+    return dist, None
+
+
+def _resolve_pair(v: np.ndarray, tri_verts: List[np.ndarray], normal: np.ndarray, depth: float):
+    v += -depth * normal
+
+
+def resolve_membrane_collisions(
+    cells: List["Cell"], min_separation: float = 0.0, iters: int = 10
+):
+    """Naively separate vertex-triangle penetrations within/between cells.
+
+    Runs a handful of relaxation iterations; each pass scatters small
+    corrections to penetrating vertex/triangle pairs.  This is an
+    intentionally simple placeholder for a future broad-phase + XPBD contact
+    solver but already prevents visible interpenetration in small meshes.
+    """
+    for _ in range(iters):
+        changed = False
+        for idx, cell in enumerate(cells):
+            V = cell.X
+            F = cell.faces
+            for vi, v in enumerate(V):
+                for f in F:
+                    if vi in f:
+                        continue
+                    a, b, c = V[f[0]], V[f[1]], V[f[2]]
+                    dist, n = _vertex_triangle_penetration(v, a, b, c)
+                    if n is not None and dist < min_separation:
+                        _resolve_pair(v, [a, b, c], n, dist - min_separation)
+                        changed = True
+
+            for other in cells[idx + 1 :]:
+                Vo = other.X
+                Fo = other.faces
+                for v in V:
+                    for f in Fo:
+                        a, b, c = Vo[f[0]], Vo[f[1]], Vo[f[2]]
+                        dist, n = _vertex_triangle_penetration(v, a, b, c)
+                        if n is not None and dist < min_separation:
+                            _resolve_pair(v, [a, b, c], n, dist - min_separation)
+                            changed = True
+                for v in Vo:
+                    for f in F:
+                        a, b, c = V[f[0]], V[f[1]], V[f[2]]
+                        dist, n = _vertex_triangle_penetration(v, a, b, c)
+                        if n is not None and dist < min_separation:
+                            _resolve_pair(v, [a, b, c], n, dist - min_separation)
+                            changed = True
+        if not changed:
+            break

--- a/src/transmogrifier/softbody/engine/hierarchy.py
+++ b/src/transmogrifier/softbody/engine/hierarchy.py
@@ -7,6 +7,7 @@ from .mesh import make_icosphere, mesh_volume, volume_gradients, build_adjacency
 from .constraints import VolumeConstraint
 from .xpbd_core import XPBDSolver
 from .fields import FieldStack
+from .collisions import resolve_membrane_collisions
 from src.transmogrifier.cells.cellsim.membranes.membrane import (
     Membrane, MembraneConfig, MembraneHooks,
 )
@@ -183,6 +184,8 @@ class Hierarchy:
             if vc is not None:
                 vc.project(c.X, c.invm, c.faces, mesh_volume, volume_gradients, dt)
 
+        # Ensure membranes do not intersect themselves or other membranes
+        resolve_membrane_collisions(self.cells)
 
     def update_organelle_modes(self, dt):
         counts = [len(c.organelles) for c in self.cells]

--- a/tests/test_membrane_collisions.py
+++ b/tests/test_membrane_collisions.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from src.transmogrifier.softbody.engine.mesh import make_icosphere, build_adjacency
+from src.transmogrifier.softbody.engine.hierarchy import Cell
+from src.transmogrifier.softbody.engine.collisions import resolve_membrane_collisions
+
+
+def _build_cell(offset=(0.0, 0.0, 0.0)):
+    v, f = make_icosphere(subdiv=0, radius=0.1, center=offset)
+    edges, bends = build_adjacency(f)
+    invm = np.ones(len(v), dtype=np.float64)
+    cons = {}
+    return Cell(
+        id="c",
+        X=v.copy(),
+        V=np.zeros_like(v),
+        invm=invm,
+        faces=f,
+        edges=np.array(edges),
+        bends=np.array(bends),
+        constraints=cons,
+        organelles=[],
+    )
+
+
+def _inside_triangle(p, a, b, c):
+    v0 = c - a
+    v1 = b - a
+    v2 = p - a
+    d00 = np.dot(v0, v0)
+    d01 = np.dot(v0, v1)
+    d11 = np.dot(v1, v1)
+    d20 = np.dot(v2, v0)
+    d21 = np.dot(v2, v1)
+    denom = d00 * d11 - d01 * d01
+    if denom == 0.0:
+        return False
+    v = (d11 * d20 - d01 * d21) / denom
+    w = (d00 * d21 - d01 * d20) / denom
+    u = 1.0 - v - w
+    return (u >= 0.0) and (v >= 0.0) and (w >= 0.0)
+
+
+def _min_vertex_triangle_dist(V, F, W):
+    m = np.inf
+    for v in V:
+        for tri in F:
+            a, b, c = W[tri]
+            n = np.cross(b - a, c - a)
+            norm = np.linalg.norm(n)
+            if norm < 1e-12:
+                continue
+            n = n / norm
+            dist = np.dot(v - a, n)
+            proj = v - dist * n
+            if _inside_triangle(proj, a, b, c):
+                m = min(m, dist)
+    return m
+
+
+def test_resolve_membrane_collisions_between_cells():
+    c1 = _build_cell((0.0, 0.0, 0.0))
+    c2 = _build_cell((0.05, 0.0, 0.0))  # overlapping spheres
+    resolve_membrane_collisions([c1, c2])
+    d12 = _min_vertex_triangle_dist(c1.X, c2.faces, c2.X)
+    d21 = _min_vertex_triangle_dist(c2.X, c1.faces, c1.X)
+    tol = -5e-4
+    assert d12 >= tol
+    assert d21 >= tol


### PR DESCRIPTION
## Summary
- add naive vertex-triangle based membrane collision resolver
- call resolver after constraint projection to prevent self and inter-cell overlaps
- expose resolver from softbody engine and test overlapping spheres

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf2d6e720832a9980ba48680baf40