### PR TITLE
feat: add spatial hash builder for self contacts

### DIFF
--- a/src/transmogrifier/softbody/engine/__init__.py
+++ b/src/transmogrifier/softbody/engine/__init__.py
@@ -9,7 +9,7 @@ from .constraints import (
     PlaneContact,
 )
 from .hierarchy import Cell, Organelle
-from .collisions import resolve_membrane_collisions
+from .collisions import resolve_membrane_collisions, build_self_contacts_spatial_hash
 
 __all__ = [
     "EngineParams",
@@ -21,4 +21,5 @@ __all__ = [
     "Cell",
     "Organelle",
     "resolve_membrane_collisions",
+    "build_self_contacts_spatial_hash",
 ]

--- a/tests/test_build_self_contacts_spatial_hash.py
+++ b/tests/test_build_self_contacts_spatial_hash.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from src.transmogrifier.softbody.engine import build_self_contacts_spatial_hash
+
+
+def test_build_self_contacts_spatial_hash_simple():
+    # Square made of two triangles in the XY plane
+    X = np.array([
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.5, 0.5, 0.1],  # vertex above centre
+    ])
+    faces = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    cell_ids = np.zeros(len(X), dtype=np.int32)
+
+    pairs = build_self_contacts_spatial_hash(X, faces, cell_ids, voxel_size=0.5)
+    pairs_set = {tuple(p) for p in pairs}
+
+    # Vertex 4 should be paired with both triangles, while vertices on the
+    # surface should not generate contacts due to adjacency filtering.
+    assert pairs_set == {(4, 0), (4, 1)}


### PR DESCRIPTION
## Summary
- implement `build_self_contacts_spatial_hash` using a voxel hash and adjacency filtering
- expose self contact builder through engine package
- test broad-phase self contact detection on a simple mesh

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cfdf56ffc832a99afa9e9ae9c8e81