### PR TITLE
Refine broad-phase contact hashing and pump updates

### DIFF
--- a/src/transmogrifier/cells/cellsim/transport/pumps.py
+++ b/src/transmogrifier/cells/cellsim/transport/pumps.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 from typing import Dict
 
+import numpy as np
 
-def na_k_atpase_constant(J_pump_cell: float) -> float:
+
+def na_k_atpase_constant(J_pump_cell: float | np.ndarray) -> float | np.ndarray:
     """Return pump mol/s (cell-wide). Positive means: 3 Na out, 2 K in."""
-    return max(J_pump_cell, 0.0)
+    return np.maximum(J_pump_cell, 0.0)
 
 
 def na_k_atpase_saturating(

--- a/src/transmogrifier/softbody/engine/params.py
+++ b/src/transmogrifier/softbody/engine/params.py
@@ -20,6 +20,12 @@ class EngineParams:
     # reduce memory churn.
     enable_self_contacts: bool = True
     contact_voxel_size: float = 0.05
+    # Chunking knobs for ``build_self_contacts_spatial_hash``.  ``max_vox_entries``
+    # and ``vbatch`` are shrunk automatically when the estimated temporary array
+    # footprint exceeds ``contact_ram_limit``.
+    contact_max_vox_entries: int = 8_000_000
+    contact_vbatch: int = 250_000
+    contact_ram_limit: int | None = None  # bytes; ``None`` = no cap
 
     # Thin bath (Z is 1 voxel thick in the demo)
     bath_min = (0.0, 0.0, 0.0)


### PR DESCRIPTION
## Summary
- guard self-contact hashing with a RAM budget and running set dedupe
- expose chunking/memory knobs in EngineParams
- handle Na/K pump arrays and refresh pump rates each step
- sync SalineEngine array state back to cell/bath objects
- vectorize collision hashing to avoid Python sets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d45653008832a9180417c2aeb0bd1