### PR TITLE
feat: add 2D and 1D modes to softbody demos

### DIFF
--- a/src/transmogrifier/softbody/demo/run_numpy_demo.py
+++ b/src/transmogrifier/softbody/demo/run_numpy_demo.py
@@ -63,6 +63,7 @@ def make_cellsim_backend(*,
     bath_volume_factor: float,
     substeps: int,
     dt_provider: float,
+    dim: int = 3,
 ):
     """Build a cellsim system attached to the softbody 0D provider.
 
@@ -89,7 +90,7 @@ def make_cellsim_backend(*,
 
     api = SalinePressureAPI(cells, bath)
     provider = api.attach_softbody_mechanics(
-        SoftbodyProviderCfg(substeps=substeps, dt_provider=dt_provider)
+        SoftbodyProviderCfg(substeps=substeps, dt_provider=dt_provider, dim=dim)
     )
     return api, provider
 
@@ -171,6 +172,8 @@ def build_numpy_parser(add_help: bool = True) -> argparse.ArgumentParser:
     parser.add_argument("--gl-viewport-h", type=int, default=800, help="OpenGL stream: viewport height")
     parser.add_argument("--verbose", action="store_true", help="Log per-cell parameters each frame")
     parser.add_argument("--debug", action="store_true", help="Log full per-vertex and per-face data")
+    parser.add_argument("--sim-dim", type=int, choices=[1, 2, 3], default=3,
+                        help="Softbody simulation dimension")
     return parser
 
 

--- a/src/transmogrifier/softbody/engine/params.py
+++ b/src/transmogrifier/softbody/engine/params.py
@@ -7,6 +7,7 @@ class EngineParams:
     substeps: int = 6
     iterations: int = 10
     damping: float = 0.696
+    dimension: int = 3
 
     # XPBD compliances (1/k)
     stretch_compliance: float = 1e-6


### PR DESCRIPTION
## Summary
- allow EngineParams to specify simulation dimension
- add 2D area and 1D length measures for volume constraints
- update hierarchy, provider and demos to run 2D/1D softbody sims

## Testing
- `python -m py_compile src/transmogrifier/softbody/engine/params.py src/transmogrifier/softbody/engine/mesh.py src/transmogrifier/softbody/engine/hierarchy.py src/transmogrifier/softbody/engine/coupling.py src/transmogrifier/cells/cellsim/mechanics/softbody0d.py src/transmogrifier/softbody/demo/run_numpy_demo.py src/transmogrifier/softbody/demo/run_ascii_demo.py src/transmogrifier/softbody/demo/run_opengl_demo.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d6c3b164c832aa982c7bbddcdf3b7