### PR TITLE
Ensure SPH pressure force is repulsive

### DIFF
--- a/src/transmogrifier/cells/bath/discrete_fluid.py
+++ b/src/transmogrifier/cells/bath/discrete_fluid.py
@@ -333,6 +333,9 @@ class DiscreteFluid:
         """
         Symmetric pressure force:
         f_i += - m^2 (P_i/ρ_i^2 + P_j/ρ_j^2) ∇W_ij
+        ``gradW`` already returns the gradient with respect to particle ``i``
+        (pointing from particle ``j`` to ``i``), so the pair coefficient is
+        positive to yield a repulsive force.
         """
         f = np.zeros_like(self.p)
         for (i, j, rvec, r, W) in self._pairs_particles():
@@ -340,8 +343,8 @@ class DiscreteFluid:
             gW = self.kernel.gradW(rvec, r)
             Pi = self.P[i]; Pj = self.P[j]
             rhoi = self.rho[i]; rhoj = self.rho[j]
-            # pair coefficient
-            c = - self._m * self._m * (Pi / (rhoi * rhoi) + Pj / (rhoj * rhoj))
+            # pair coefficient (positive for repulsion)
+            c = self._m * self._m * (Pi / (rhoi * rhoi) + Pj / (rhoj * rhoj))
             fij = c[:, None] * gW
             # action-reaction (scatter-add)
             np.add.at(f, i,  fij)

--- a/tests/test_discrete_fluid_pressure_force.py
+++ b/tests/test_discrete_fluid_pressure_force.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+
+
+def test_two_particle_pressure_repulsive():
+    params = FluidParams()
+    positions = np.array([[0.0, 0.0, 0.0], [0.05, 0.0, 0.0]], dtype=np.float64)
+    fluid = DiscreteFluid(positions, velocities=None, temperature=None, salinity=None, params=params)
+    fluid._build_grid()
+
+    # Equal positive pressure for both particles
+    fluid.P[:] = 1.0e5
+
+    f = fluid._pressure_forces()
+
+    # Forces must be equal and opposite
+    assert np.allclose(f[0], -f[1])
+    # And they must be repulsive: particle 0 (left) feels force to the left
+    assert f[0][0] < 0


### PR DESCRIPTION
## Summary
- fix pressure force sign in `DiscreteFluid` so equal pressures repel and obey Newton's third law
- add unit test covering two-particle pressure repulsion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689deb5d0298832ab72606393f8155fa