### PR TITLE
Add bath fluid adapter interface

### DIFF
--- a/src/transmogrifier/cells/bath/__init__.py
+++ b/src/transmogrifier/cells/bath/__init__.py
@@ -6,5 +6,6 @@ convenience.
 """
 
 from .fluid import Bath
+from .adapter import BathAdapter, SPHAdapter, MACAdapter
 
-__all__ = ["Bath"]
+__all__ = ["Bath", "BathAdapter", "SPHAdapter", "MACAdapter"]

--- a/src/transmogrifier/cells/bath/adapter.py
+++ b/src/transmogrifier/cells/bath/adapter.py
@@ -1,0 +1,100 @@
+"""Adapters bridging Bath to specific fluid backends.
+
+These thin wrappers provide a common interface for sampling fields,
+depositing sources, and advancing the simulation regardless of the
+underlying fluid representation. They are intentionally lightweight so
+that higher level orchestration code can stream patch batches without
+branching on the backend type.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+
+from .discrete_fluid import DiscreteFluid
+from .voxel_fluid import VoxelMACFluid
+
+
+class BathAdapter:
+    """Abstract interface over a fluid simulator used by :class:`Bath`."""
+
+    def sample(self, points: np.ndarray) -> Dict[str, np.ndarray]:
+        """Sample fluid fields at ``points`` (shape: ``(N,3)``)."""
+        raise NotImplementedError
+
+    def deposit(
+        self,
+        centers: np.ndarray,
+        dV: np.ndarray,
+        dS: np.ndarray,
+        radius: float,
+    ) -> Dict[str, np.ndarray]:
+        """Deposit volume/solute sources around ``centers``.
+
+        Returns a dictionary describing realized amounts. Implementations
+        may ignore certain fields if unsupported by the backend.
+        """
+        raise NotImplementedError
+
+    def step(self, dt: float) -> None:
+        """Advance the underlying simulator by ``dt`` seconds."""
+        raise NotImplementedError
+
+
+@dataclass
+class SPHAdapter(BathAdapter):
+    """Adapter for :class:`DiscreteFluid` (weakly-compressible SPH)."""
+
+    sim: DiscreteFluid
+
+    def __post_init__(self) -> None:
+        # rest_density is used to convert volume sources to mass sources
+        self._rho0 = self.sim.params.rest_density
+
+    def sample(self, points: np.ndarray) -> Dict[str, np.ndarray]:
+        return self.sim.sample_at(points)
+
+    def deposit(
+        self,
+        centers: np.ndarray,
+        dV: np.ndarray,
+        dS: np.ndarray,
+        radius: float,
+    ) -> Dict[str, np.ndarray]:
+        dV = np.asarray(dV, dtype=float)
+        dS = np.asarray(dS, dtype=float)
+        # Convert volume change to mass using rest density
+        dM = self._rho0 * dV
+        dS_mass = self._rho0 * dS
+        return self.sim.apply_sources(centers, dM=dM, dS_mass=dS_mass, radius=radius)
+
+    def step(self, dt: float) -> None:
+        self.sim.step(dt)
+
+
+@dataclass
+class MACAdapter(BathAdapter):
+    """Adapter for :class:`VoxelMACFluid` (incompressible grid solver)."""
+
+    sim: VoxelMACFluid
+
+    def sample(self, points: np.ndarray) -> Dict[str, np.ndarray]:
+        return self.sim.sample_at(points)
+
+    def deposit(
+        self,
+        centers: np.ndarray,
+        dV: np.ndarray,
+        dS: np.ndarray,
+        radius: float,
+    ) -> Dict[str, np.ndarray]:
+        # Incompressible grid: only scalar sources are supported here.
+        dS = np.asarray(dS, dtype=float)
+        self.sim.add_scalar_sources(centers, dT=np.zeros_like(dS), dS=dS, radius=radius)
+        return {"dV": np.zeros_like(dV), "dS": dS}
+
+    def step(self, dt: float) -> None:
+        self.sim.step(dt)

--- a/tests/test_bath_adapter.py
+++ b/tests/test_bath_adapter.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "src")))
+
+from src.transmogrifier.cells.bath import SPHAdapter, MACAdapter
+from src.transmogrifier.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+from src.transmogrifier.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def test_sph_adapter_deposit_and_sample():
+    params = FluidParams()
+    sim = DiscreteFluid(
+        positions=np.zeros((1, 3)),
+        velocities=None,
+        temperature=None,
+        salinity=None,
+        params=params,
+    )
+    adapter = SPHAdapter(sim)
+
+    centers = np.zeros((1, 3))
+    res = adapter.deposit(centers, dV=np.array([1e-6]), dS=np.array([0.0]), radius=params.smoothing_length)
+    assert "dM" in res and res["dM"].shape == (1,)
+
+    adapter.step(1e-4)
+    sample = adapter.sample(centers)
+    assert "rho" in sample and sample["rho"].shape == (1,)
+
+
+def test_mac_adapter_deposit_salinity():
+    params = VoxelFluidParams(nx=2, ny=2, nz=2)
+    sim = VoxelMACFluid(params)
+    adapter = MACAdapter(sim)
+
+    centers = np.array([[params.dx * 0.5, params.dx * 0.5, params.dx * 0.5]])
+    adapter.deposit(centers, dV=np.array([0.0]), dS=np.array([0.5]), radius=params.dx)
+    assert np.any(sim.S > 0.0)
+
+    adapter.step(1e-4)
+    sample = adapter.sample(centers)
+    assert "S" in sample and sample["S"].shape == (1,)


### PR DESCRIPTION
## Summary
- introduce `BathAdapter` with SPH and MAC implementations to unify sampling, depositing, and stepping across fluid backends
- export adapters from `transmogrifier.cells.bath` namespace
- add tests exercising basic deposit and sampling through both adapters

## Testing
- `pytest tests/test_bath_adapter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689df2d1e698832a869002f7434f32d2