### PR TITLE
Ensure velocity advection uses original field

### DIFF
--- a/src/transmogrifier/cells/bath/voxel_fluid.py
+++ b/src/transmogrifier/cells/bath/voxel_fluid.py
@@ -370,6 +370,15 @@ class VoxelMACFluid:
         w = self._sample_face(self.w, Xw, axis=2)
         return np.stack([u, v, w], axis=-1)
 
+    def _sample_velocity_from(
+        self, u: np.ndarray, v: np.ndarray, w: np.ndarray, Xw: np.ndarray
+    ) -> np.ndarray:
+        """Sample the provided MAC velocity (u, v, w) at world points Xw (N,3)."""
+        us = self._sample_face(u, Xw, axis=0)
+        vs = self._sample_face(v, Xw, axis=1)
+        ws = self._sample_face(w, Xw, axis=2)
+        return np.stack([us, vs, ws], axis=-1)
+
     def _sample_scalar_cc(self, F: np.ndarray, Xw: np.ndarray) -> np.ndarray:
         """Trilinear interpolation of a cell-centered scalar field at world points."""
         dx = self.dx
@@ -455,10 +464,9 @@ class VoxelMACFluid:
             I, J, K = np.meshgrid(np.arange(nx), np.arange(ny), np.arange(nz), indexing='ij')
             X = np.stack([I+0.5, J+0.5, K], axis=-1).reshape(-1,3) * dx
 
-        V = self._sample_velocity(X)
+        V = self._sample_velocity_from(u0, v0, w0, X)
         Xb = X - dt * V
 
-        # sample the same component from Fcomp at Xb
         vals = self._sample_face(Fcomp, Xb, axis)
         return vals.reshape(Fcomp.shape)
 

--- a/tests/test_voxel_velocity_order.py
+++ b/tests/test_voxel_velocity_order.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import itertools
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def test_velocity_advection_order_invariance():
+    params = VoxelFluidParams(nx=2, ny=2, nz=2)
+    fluid = VoxelMACFluid(params)
+
+    rng = np.random.default_rng(0)
+    fluid.u = rng.random(fluid.u.shape)
+    fluid.v = rng.random(fluid.v.shape)
+    fluid.w = rng.random(fluid.w.shape)
+
+    u0 = fluid.u.copy()
+    v0 = fluid.v.copy()
+    w0 = fluid.w.copy()
+    dt = 0.1
+
+    def advect(order):
+        fluid.u[:] = u0
+        fluid.v[:] = v0
+        fluid.w[:] = w0
+        for comp in order:
+            if comp == 'u':
+                fluid.u = fluid._advect_component_face(u0, u0, v0, w0, dt, axis=0)
+            elif comp == 'v':
+                fluid.v = fluid._advect_component_face(v0, u0, v0, w0, dt, axis=1)
+            elif comp == 'w':
+                fluid.w = fluid._advect_component_face(w0, u0, v0, w0, dt, axis=2)
+        return fluid.u.copy(), fluid.v.copy(), fluid.w.copy()
+
+    orders = list(itertools.permutations(['u', 'v', 'w']))
+    results = [advect(order) for order in orders]
+
+    for r in results[1:]:
+        assert np.allclose(r[0], results[0][0])
+        assert np.allclose(r[1], results[0][1])
+        assert np.allclose(r[2], results[0][2])


### PR DESCRIPTION
## Summary
- add `_sample_velocity_from` to sample a velocity field from provided components
- use the original velocity triple for both backtracing and resampling during advection
- test that velocity advection is invariant to component update order

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dfbcb08f0832a97dafab5e9c7a9d1