### PR TITLE
Normalize discrete fluid interpolation with Shepard weights

### DIFF
--- a/src/transmogrifier/cells/bath/discrete_fluid.py
+++ b/src/transmogrifier/cells/bath/discrete_fluid.py
@@ -201,22 +201,24 @@ class DiscreteFluid:
 
         rho = np.zeros(points.shape[0]); P = np.zeros_like(rho)
         v = np.zeros_like(points); T = np.zeros(points.shape[0]); S = np.zeros_like(T)
+        denom = np.zeros(points.shape[0])
 
         for (pi, pj, rvec, r, W) in pairs_iter:
             # accumulate SPH sums at points pi from neighbor particles pj
             m_over_rho = (self._m / self.rho[pj])
             w = W * m_over_rho
 
-            rho[pi] += self._m * W
-            P[pi]   += self.P[pj] * w
-            T[pi]   += self.T[pj] * w
-            S[pi]   += self.S[pj] * w
-            v[pi]   += self.v[pj] * w[:, None]
+            rho[pi]  += self._m * W
+            denom[pi] += w
+            P[pi]    += self.P[pj] * w
+            T[pi]    += self.T[pj] * w
+            S[pi]    += self.S[pj] * w
+            v[pi]    += self.v[pj] * w[:, None]
 
         # Normalize interpolated fields where needed (pressure, T, S, v)
         # For rho we used standard SPH density estimate; leave as-is.
         eps = 1e-12
-        denom = np.maximum(rho / self._m, eps)
+        denom = np.maximum(denom, eps)
         P /= denom; T /= denom; S /= denom; v /= denom[:, None]
         return {"rho": rho, "P": P, "v": v, "T": T, "S": S}
 

--- a/tests/test_discrete_interpolation.py
+++ b/tests/test_discrete_interpolation.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+
+
+def test_uniform_scalar_interpolation_with_density_variation():
+    rng = np.random.default_rng(0)
+    n_particles = 20
+    positions = rng.uniform(-0.5, 0.5, size=(n_particles, 3))
+    params = FluidParams(particle_mass=1.0, smoothing_length=1.0)
+    fluid = DiscreteFluid(positions, velocities=None, temperature=None, salinity=None, params=params)
+
+    # Assign non-uniform densities
+    fluid.rho = rng.uniform(0.5, 2.0, size=n_particles) * params.rest_density
+
+    # Particles carry uniform scalar fields
+    fluid.P[:] = 1.0
+    fluid.T[:] = 1.0
+    fluid.S[:] = 1.0
+    fluid.v[:] = 1.0
+
+    # Sample at random points in the domain
+    sample_points = rng.uniform(-0.5, 0.5, size=(5, 3))
+    out = fluid.sample_at(sample_points)
+
+    assert np.allclose(out['P'], 1.0, atol=1e-6)
+    assert np.allclose(out['T'], 1.0, atol=1e-6)
+    assert np.allclose(out['S'], 1.0, atol=1e-6)
+    assert np.allclose(out['v'], np.ones_like(out['v']), atol=1e-6)


### PR DESCRIPTION
## Summary
- accumulate Shepard denominator `Σ m/ρ_j W` in `sample_at` and use it to normalize interpolated pressure, temperature, salinity, and velocity
- add regression test for interpolating uniform scalar fields with non-uniform particle densities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfbd24820832a8a158adac5b37a4a