### PR TITLE
Handle pressure nullspace in voxel fluid solver

### DIFF
--- a/tests/test_voxel_pressure_nullspace.py
+++ b/tests/test_voxel_pressure_nullspace.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def test_pressure_projection_uniform_divergence_nullspace():
+    params = VoxelFluidParams(nx=2, ny=2, nz=2)
+    fluid = VoxelMACFluid(params)
+
+    # Create a velocity field with uniform divergence
+    ramp = np.tile(np.arange(params.nx + 1, dtype=float)[:, None, None], (1, params.ny, params.nz))
+    fluid.u = ramp
+    fluid.v.fill(0.0)
+    fluid.w.fill(0.0)
+
+    fluid._project(dt=0.1)
+
+    fluid_cells = ~fluid.solid
+    mean_pressure = float(fluid.pr[fluid_cells].mean())
+
+    assert np.all(np.isfinite(fluid.pr))
+    assert abs(mean_pressure) < 1e-6


### PR DESCRIPTION
## Summary
- Ensure pressure projection removes nullspace by subtracting RHS mean before solving
- Allow Poisson CG solver to zero RHS mean or fix a reference cell
- Add regression test for uniform divergence yielding near-zero mean pressure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dfe3cbf48832ab223f298df07a2f3