### PR TITLE
Introduce mass-based source tracking

### DIFF
--- a/tests/test_discrete_source_conservation.py
+++ b/tests/test_discrete_source_conservation.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+
+
+def test_discrete_source_conservation():
+    params = FluidParams(source_relaxation=1.0)
+    positions = np.array([
+        [0.0, 0.0, 0.0],
+        [0.05, 0.0, 0.0],
+        [0.0, 0.05, 0.0],
+        [0.0, 0.0, 0.05],
+    ], dtype=np.float64)
+    fluid = DiscreteFluid(positions, velocities=None, temperature=None, salinity=None, params=params)
+
+    initial_mass = fluid.m.sum()
+    initial_solute = fluid.solute_mass.sum()
+
+    centers = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=np.float64)
+    dM = np.array([0.05, -0.02])
+    dS = np.array([0.01, -0.004])
+
+    realized = fluid.apply_sources(centers, dM, dS, radius=0.1)
+    fluid.step(1e-3)
+
+    final_mass = fluid.m.sum()
+    final_solute = fluid.solute_mass.sum()
+
+    assert np.isclose(final_mass, initial_mass + realized["dM"].sum())
+    assert np.isclose(final_solute, initial_solute + realized["dS_mass"].sum())

--- a/tests/test_surface_tension_sign.py
+++ b/tests/test_surface_tension_sign.py
@@ -19,8 +19,8 @@ def test_surface_tension_normals_and_restoring_force():
     # Compute normals explicitly to check orientation
     n_vec = np.zeros_like(positions)
     for (i, j, rvec, r, W) in fluid._pairs_particles():
-        m_over_rho_j = fluid._m / np.maximum(fluid.rho[j], 1e-12)
-        m_over_rho_i = fluid._m / np.maximum(fluid.rho[i], 1e-12)
+        m_over_rho_j = fluid.m[j] / np.maximum(fluid.rho[j], 1e-12)
+        m_over_rho_i = fluid.m[i] / np.maximum(fluid.rho[i], 1e-12)
         gW = fluid.kernel.gradW(rvec, r)
         n_vec[i] += m_over_rho_j[:, None] * gW
         n_vec[j] -= m_over_rho_i[:, None] * gW


### PR DESCRIPTION
## Summary
- track per-particle mass and solute with relaxing targets
- distribute source terms conservatively without direct density edits
- add regression test ensuring mass/solute sources conserve totals

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e175a40cc832a9db4042baaf2f0ff