### PR TITLE
Clamp voxel salinity after advection and diffusion

### DIFF
--- a/src/transmogrifier/cells/bath/voxel_fluid.py
+++ b/src/transmogrifier/cells/bath/voxel_fluid.py
@@ -204,7 +204,9 @@ class VoxelMACFluid:
         T0 = self.T.copy(); S0 = self.S.copy()
         self.T = self._advect_scalar_cc(T0, dt)
         self.S = self._advect_scalar_cc(S0, dt)
+        self.S = np.clip(self.S, 0.0, 1.0)
         self._diffuse_scalars(dt)
+        self.S = np.clip(self.S, 0.0, 1.0)
 
     # ---------------------------------------------------------------------
     # Forces

--- a/tests/test_voxel_salinity_clamp.py
+++ b/tests/test_voxel_salinity_clamp.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def test_salinity_clamp():
+    params = VoxelFluidParams(nx=3, ny=3, nz=3, solute_diffusivity=1.0e-9)
+    fluid = VoxelMACFluid(params)
+    fluid.S = np.linspace(-0.1, 1.1, fluid.S.size).reshape(fluid.S.shape)
+    fluid.step(1e-3)
+    assert fluid.S.min() >= 0.0
+    assert fluid.S.max() <= 1.0
+


### PR DESCRIPTION
## Summary
- Clip salinity field to [0,1] after scalar advection and diffusion in voxel fluid solver
- Add unit test verifying voxel solver keeps salinity in range

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e1a84a96c832a80a15b27f8f40639