### PR TITLE
Clamp voxel salinity after advection and diffusion

### DIFF
--- a/src/transmogrifier/cells/bath/voxel_fluid.py
+++ b/src/transmogrifier/cells/bath/voxel_fluid.py
@@ -37,6 +37,7 @@ from dataclasses import dataclass
 from typing import Tuple, Dict, Optional
 
 import numpy as np
+import warnings
 
 
 @dataclass
@@ -204,7 +205,9 @@ class VoxelMACFluid:
         T0 = self.T.copy(); S0 = self.S.copy()
         self.T = self._advect_scalar_cc(T0, dt)
         self.S = self._advect_scalar_cc(S0, dt)
+        self._clip_salinity("after advection")
         self._diffuse_scalars(dt)
+        self._clip_salinity("after diffusion")
 
     # ---------------------------------------------------------------------
     # Forces
@@ -338,6 +341,12 @@ class VoxelMACFluid:
             self.T = self._diffuse_cc_explicit(self.T, kT, dt)
         if kS > 0.0:
             self.S = self._diffuse_cc_explicit(self.S, kS, dt)
+
+    def _clip_salinity(self, stage: str) -> None:
+        clipped = np.clip(self.S, 0.0, 1.0)
+        if not np.array_equal(clipped, self.S):
+            warnings.warn(f"Salinity outside [0,1] {stage}; clipping", RuntimeWarning)
+        self.S = clipped
 
     # ---------------------------------------------------------------------
     # Boundaries & masks

--- a/tests/test_voxel_salinity_clamp.py
+++ b/tests/test_voxel_salinity_clamp.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from src.transmogrifier.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def test_salinity_clamp():
+    params = VoxelFluidParams(nx=3, ny=3, nz=3, solute_diffusivity=1.0e-9)
+    fluid = VoxelMACFluid(params)
+    fluid.S = np.linspace(-0.1, 1.1, fluid.S.size).reshape(fluid.S.shape)
+    with pytest.warns(RuntimeWarning):
+        fluid.step(1e-3)
+    assert fluid.S.min() >= 0.0
+    assert fluid.S.max() <= 1.0
+


### PR DESCRIPTION
## Summary
- Clip salinity field to [0,1] after scalar advection and diffusion in voxel fluid solver
- Warn whenever salinity values are clipped out of range
- Add unit test verifying solver clamps salinity and emits a warning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1a84a96c832a80a15b27f8f40639