### PR TITLE
Expose positions and velocities from discrete fluid simulator

### DIFF
--- a/src/cells/bath/adapter.py
+++ b/src/cells/bath/adapter.py
@@ -79,7 +79,8 @@ class SPHAdapter(BathAdapter):
         self.sim.step(dt)
 
     def visualization_state(self) -> Dict[str, np.ndarray]:
-        return {"vertices": self.sim.export_vertices()}
+        pos, vec = self.sim.export_positions_vectors()
+        return {"positions": pos, "vectors": vec}
 
 
 @dataclass

--- a/src/cells/bath/discrete_fluid.py
+++ b/src/cells/bath/discrete_fluid.py
@@ -234,6 +234,10 @@ class DiscreteFluid:
         """Return a copy of particle positions for visualization."""
         return self.p.copy()
 
+    def export_positions_vectors(self) -> Tuple[np.ndarray, np.ndarray]:
+        """Return copies of particle positions and velocity vectors."""
+        return self.p.copy(), self.v.copy()
+
     def apply_sources(self, centers: np.ndarray, dM: np.ndarray, dS_mass: np.ndarray,
                       radius: float) -> Dict[str, np.ndarray]:
         """

--- a/src/cells/softbody/demo/run_numpy_demo.py
+++ b/src/cells/softbody/demo/run_numpy_demo.py
@@ -945,7 +945,7 @@ def run_fluid_demo(args):
         fluid = DiscreteFluid.demo_dam_break(n_x=8, n_y=12, n_z=8, h=0.05)
 
         def gather():
-            return fluid.export_vertices(), None
+            return fluid.export_positions_vectors()
 
         step = fluid.step
     elif args.fluid == "voxel":


### PR DESCRIPTION
## Summary
- add `export_positions_vectors` to the discrete SPH fluid solver
- return position and velocity vectors from the SPH adapter and demo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e5d425bb8832abfa3e6d0bac1999f