### PR TITLE
Handle DiscreteFluid OpenGL streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ Below is a current inventory of the repository’s Python modules, grouped by pa
   - bridge/: `__init__.py`, `state_io.py`
   - resources/: `field_library.py`
   - demo/: `__init__.py`, `run_ascii_demo.py`, `run_numpy_demo.py`, `run_opengl_demo.py`
+    - Stream the discrete fluid demo with OpenGL points:
+
+      ```bash
+      python src/cells/softbody/demo/run_numpy_demo.py --fluid discrete --stream opengl-points
+      ```
 
 ### src/transmogrifier
 

--- a/src/cells/softbody/demo/run_numpy_demo.py
+++ b/src/cells/softbody/demo/run_numpy_demo.py
@@ -1037,15 +1037,26 @@ def run_fluid_demo(args):
         return
 
     if getattr(args, "stream", "") == "opengl-points":
-        stream_fluid_points(
-            args,
-            gather,
-            step,
-            show_vectors=args.show_vectors,
-            color_metric=args.color_metric,
-            arrow_scale=args.arrow_scale,
-            flow_anim_speed=args.flow_anim_speed,
-        )
+        if args.fluid == "discrete":
+            stream_fluid_points(
+                args,
+                fluid.export_positions_vectors,
+                fluid.step,
+                show_vectors=args.show_vectors,
+                color_metric=args.color_metric,
+                arrow_scale=args.arrow_scale,
+                flow_anim_speed=args.flow_anim_speed,
+            )
+        else:
+            stream_fluid_points(
+                args,
+                gather,
+                step,
+                show_vectors=args.show_vectors,
+                color_metric=args.color_metric,
+                arrow_scale=args.arrow_scale,
+                flow_anim_speed=args.flow_anim_speed,
+            )
         return
 
     dt = float(getattr(args, "dt", 1e-3))


### PR DESCRIPTION
## Summary
- ensure DiscreteFluid streams correctly to the OpenGL points viewer
- document command to run the discrete fluid OpenGL points demo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e6b9892e4832aa1dd14ffec40f8c5