### PR TITLE
Add droplet emission and integration

### DIFF
--- a/tests/test_droplet_emit.py
+++ b/tests/test_droplet_emit.py
@@ -1,0 +1,24 @@
+import numpy as np
+from src.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+
+def make_fluid(velocities):
+    positions = np.zeros((len(velocities), 3), dtype=float)
+    velocities = np.array(velocities, dtype=float)
+    params = FluidParams()
+    return DiscreteFluid(positions, velocities, None, None, params)
+
+def test_emit_droplets_threshold():
+    df = make_fluid([[0,0,0],[6,0,0]])
+    df.emit_droplets(threshold=5.0)
+    assert df.droplet_p.shape[0] == 1
+    assert np.allclose(df.droplet_v[0], [6,0,0])
+
+def test_droplet_integration_gravity_drag():
+    df = make_fluid([[1,0,0]])
+    df.droplet_drag = 0.5
+    df.emit_droplets(indices=[0])
+    df._substep(0.1)
+    expected_v = np.array([1.0,0.0,0.0]) + 0.1*(np.array(df.params.gravity) - 0.5*np.array([1.0,0.0,0.0]))
+    expected_p = 0.1*expected_v
+    assert np.allclose(df.droplet_v[0], expected_v)
+    assert np.allclose(df.droplet_p[0], expected_p)


### PR DESCRIPTION
## Summary
- allow DiscreteFluid to emit ballistic droplets by velocity threshold or explicit indices
- integrate detached droplets with gravity and linear drag
- add regression tests for droplet emission and motion

## Testing
- `pytest tests/test_droplet_emit.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e6d4a8ca8832abeb55ae55d4381d3