### PR TITLE
feat: integrate surface animation into voxel bath sim

### DIFF
--- a/src/cells/bath/__init__.py
+++ b/src/cells/bath/__init__.py
@@ -6,7 +6,14 @@ convenience.
 """
 
 from .fluid import Bath
-from .adapter import BathAdapter, SPHAdapter, MACAdapter
+from .adapter import BathAdapter, SPHAdapter, MACAdapter, HybridAdapter
 from .hybrid_fluid import HybridFluid
 
-__all__ = ["Bath", "BathAdapter", "SPHAdapter", "MACAdapter", "HybridFluid"]
+__all__ = [
+    "Bath",
+    "BathAdapter",
+    "SPHAdapter",
+    "MACAdapter",
+    "HybridAdapter",
+    "HybridFluid",
+]

--- a/tests/test_bath_adapter.py
+++ b/tests/test_bath_adapter.py
@@ -5,9 +5,11 @@ import numpy as np
 # Ensure src is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "src")))
 
-from src.cells.bath import SPHAdapter, MACAdapter
+from src.cells.bath import SPHAdapter, MACAdapter, HybridAdapter
 from src.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
 from src.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+from src.cells.bath.hybrid_fluid import HybridFluid, HybridParams
+from src.cells.bath.surface_animator import Tileset, TileVariant, SurfaceAnimator
 
 
 def test_sph_adapter_deposit_and_sample():
@@ -45,3 +47,38 @@ def test_mac_adapter_deposit_salinity():
     # guard against NaN/inf propagation in solver
     assert np.all(np.isfinite(sample["S"]))
     assert np.all(np.isfinite(sim.pr))
+
+
+def test_adapter_visualization_state_api():
+    """All adapters expose positions, vectors, and surface batches."""
+    # SPH
+    params = FluidParams()
+    sim_sph = DiscreteFluid(
+        positions=np.zeros((1, 3)),
+        velocities=None,
+        temperature=None,
+        salinity=None,
+        params=params,
+    )
+    adapter_sph = SPHAdapter(sim_sph)
+    state_sph = adapter_sph.visualization_state()
+    assert {"positions", "vectors", "surface_batches"} <= set(state_sph)
+
+    # MAC with animator
+    vparams = VoxelFluidParams(nx=1, ny=1, nz=1)
+    sim_mac = VoxelMACFluid(vparams)
+    tileset = Tileset(frames_per_row=1, rows_per_variant=1,
+                      variants={0: TileVariant(mesh_id="q", atlas_row=0, fps_base=1.0)})
+    anim = SurfaceAnimator(tileset, dx=vparams.dx, dim=3)
+    adapter_mac = MACAdapter(sim_mac, animator=anim)
+    adapter_mac.step(0.0)
+    state_mac = adapter_mac.visualization_state()
+    assert {"positions", "vectors", "surface_batches"} <= set(state_mac)
+    assert isinstance(state_mac["surface_batches"], list)
+
+    # Hybrid
+    hparams = HybridParams(dx=0.05)
+    sim_h = HybridFluid(shape=(1, 1, 1), n_particles=0, params=hparams)
+    adapter_h = HybridAdapter(sim_h)
+    state_h = adapter_h.visualization_state()
+    assert {"positions", "vectors", "surface_batches"} <= set(state_h)


### PR DESCRIPTION
## Summary
- integrate optional `SurfaceAnimator` into MAC grid adapter
- add `HybridAdapter` and unify visualization API across adapters
- verify adapter surface-batch API via new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e946b55d4832a9a7b68abf1955e31