### PR TITLE
Add fluid factory constructors and integrate demo

### DIFF
--- a/src/cells/bath/make_hybrid.py
+++ b/src/cells/bath/make_hybrid.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterable, Tuple
+
+from .hybrid_fluid import HybridFluid, HybridParams
+
+
+def make_hybrid(
+    *,
+    dim: int = 3,
+    resolution: Iterable[int] | int = 8,
+    n_particles: int = 512,
+    viscosity: float = 1.0e-6,
+    buoyancy: Tuple[float, float, float] = (0.0, -9.81, 0.0),
+    phi_condense: float = 0.85,
+    phi_shatter: float = 0.25,
+    p_shatter_max: float = 0.0,
+) -> SimpleNamespace:
+    """Create a HybridFluid solver (particle+grid) for demos."""
+
+    if isinstance(resolution, int):
+        res = (resolution,) * dim
+    else:
+        res = tuple(resolution)
+        if len(res) != dim:
+            raise ValueError("resolution length must match dim")
+
+    params = HybridParams(
+        nu=viscosity,
+        gravity=buoyancy,
+        phi_condense=phi_condense,
+        phi_shatter=phi_shatter,
+        p_shatter_max=p_shatter_max,
+    )
+    engine = HybridFluid(shape=res, n_particles=n_particles, params=params)
+
+    # Seed a block occupying roughly half the domain for quick visual tests
+    try:  # pragma: no cover - seeding not critical for unit tests
+        hi = tuple(r * params.dx * 0.5 for r in res)
+        lo = tuple(0.0 for _ in res)
+        engine.seed_block(lo, hi, mode="both")
+    except Exception:
+        pass
+
+    def export_positions_vectors_droplets():
+        data = engine.export_particles()
+        return data["x"], data["v"], None
+
+    return SimpleNamespace(
+        engine=engine,
+        step=engine.step,
+        export_particles=engine.export_particles,
+        export_vector_field=engine.export_vector_field,
+        export_positions_vectors=lambda: (
+            engine.export_particles()["x"], engine.export_particles()["v"]
+        ),
+        export_droplets=lambda: None,
+        export_positions_vectors_droplets=export_positions_vectors_droplets,
+        sample_at=getattr(engine, "sample_at", None),
+        apply_sources=getattr(engine, "apply_sources", None),
+    )
+
+
+__all__ = ["make_hybrid"]

--- a/src/cells/bath/make_mac.py
+++ b/src/cells/bath/make_mac.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterable, Tuple
+
+from .voxel_fluid import VoxelMACFluid, VoxelFluidParams
+
+
+def make_mac(
+    *,
+    dim: int = 3,
+    resolution: Iterable[int] | int = 8,
+    viscosity: float = 1.0e-6,
+    buoyancy: Tuple[float, float, float] = (0.0, -9.81, 0.0),
+) -> SimpleNamespace:
+    """Construct a VoxelMACFluid solver wrapped for demos."""
+
+    if isinstance(resolution, int):
+        res = (resolution,) * dim
+    else:
+        res = tuple(resolution)
+        if len(res) != dim:
+            raise ValueError("resolution length must match dim")
+    res3 = list(res) + [1] * (3 - dim)
+    nx, ny, nz = res3
+
+    params = VoxelFluidParams(
+        nx=nx,
+        ny=ny,
+        nz=nz,
+        nu=viscosity,
+        gravity=buoyancy,
+    )
+    engine = VoxelMACFluid(params)
+
+    def export_positions_vectors_droplets():
+        pts, vec = engine.export_vector_field()
+        return pts, vec, None
+
+    return SimpleNamespace(
+        engine=engine,
+        step=engine.step,
+        export_vector_field=engine.export_vector_field,
+        export_positions_vectors=engine.export_vector_field,
+        export_droplets=lambda: None,
+        export_positions_vectors_droplets=export_positions_vectors_droplets,
+        sample_at=getattr(engine, "sample_at", None),
+    )
+
+
+__all__ = ["make_mac"]

--- a/src/cells/bath/make_sph.py
+++ b/src/cells/bath/make_sph.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+
+from .discrete_fluid import DiscreteFluid, FluidParams
+
+
+def make_sph(
+    *,
+    dim: int = 3,
+    resolution: Iterable[int] | int = 8,
+    viscosity: float = 1.0e-6,
+    buoyancy: Tuple[float, float, float] = (0.0, -9.81, 0.0),
+) -> SimpleNamespace:
+    """Create a weakly compressible SPH fluid configured for demos.
+
+    Parameters
+    ----------
+    dim:
+        Spatial dimension (1, 2 or 3).
+    resolution:
+        Number of particles per axis.  If an int is supplied it is used for
+        all axes.  For ``dim < 3`` the remaining axes are filled with ``1``.
+    viscosity:
+        Kinematic viscosity (``nu``) in ``m^2/s``.
+    buoyancy:
+        Gravity vector.
+
+    Returns
+    -------
+    ``SimpleNamespace``
+        Wrapper exposing ``step`` and ``export_*`` helpers used by demos.
+    """
+
+    if isinstance(resolution, int):
+        res = (resolution,) * dim
+    else:
+        res = tuple(resolution)
+        if len(res) != dim:
+            raise ValueError("resolution length must match dim")
+    res3 = list(res) + [1] * (3 - dim)
+    n_x, n_y, n_z = res3
+
+    # Simple rectangular block of particles similar to demo_dam_break
+    h = 0.05
+    dx = h * 0.9
+    xs = np.arange(n_x) * dx
+    ys = np.arange(n_y) * dx
+    zs = np.arange(n_z) * dx
+    X, Y, Z = np.meshgrid(xs, ys, zs, indexing="ij")
+    pos = np.stack([X.ravel(), Y.ravel(), Z.ravel()], axis=1)
+    pos[:, 1] += 0.2
+
+    params = FluidParams(
+        smoothing_length=h,
+        particle_mass=0.02,
+        viscosity_nu=viscosity,
+        gravity=buoyancy,
+        bounce_damping=0.2,
+    )
+    engine = DiscreteFluid(
+        pos,
+        velocities=None,
+        temperature=None,
+        salinity=None,
+        params=params,
+        bounds_min=(0.0, 0.0, 0.0),
+        bounds_max=(2.0, 2.0, 2.0),
+    )
+
+    def export_positions_vectors_droplets():
+        pts, vec = engine.export_positions_vectors()
+        drops = engine.droplet_p.copy()
+        return pts, vec, drops
+
+    return SimpleNamespace(
+        engine=engine,
+        step=engine.step,
+        export_positions_vectors=engine.export_positions_vectors,
+        export_vertices=engine.export_vertices,
+        export_droplets=lambda: engine.droplet_p.copy(),
+        export_positions_vectors_droplets=export_positions_vectors_droplets,
+        apply_sources=getattr(engine, "apply_sources", None),
+        sample_at=getattr(engine, "sample_at", None),
+    )
+
+
+__all__ = ["make_sph"]


### PR DESCRIPTION
## Summary
- Introduce `make_sph`, `make_mac`, and `make_hybrid` factories for SPH, MAC and hybrid fluid engines with unified export helpers
- Extend `run_numpy_demo.py` to use the new constructors and support a hybrid fluid option
- Update Bath–fluid coupling setup to rely on factory-built engines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e96540738832ab159353db5819430