### PR TITLE
docs: outline bath-fluid coupling handshake

### DIFF
--- a/src/cells/bath/coupling.py
+++ b/src/cells/bath/coupling.py
@@ -1,7 +1,9 @@
 """Lightweight coupling between Bath (0D) and stateful fluid solvers.
 
 This module provides a minimal adapter that exchanges mass/pressure signals
-between the 0D Bath model and spatial fluid engines:
+between the 0D Bath model and spatial fluid engines.  Inside-cell fluids
+default to a voxel (MAC grid) representation; discrete particle clouds are
+opt-in to keep the lighter grid path cheap:
 
 - DiscreteFluid (SPH): supports mass sources/sinks around cell COMs via
   ``apply_sources`` using dM = -rho * dV per cell.
@@ -35,9 +37,11 @@ class BathFluidCoupler:
     engine:
         A fluid engine instance.  Supported kinds:
           - "discrete": must implement ``apply_sources`` and ``step``.
-          - "voxel": must implement ``step`` and ``sample_at``.
+          - "voxel": must implement ``step`` and ``sample_at`` (default).
     kind:
-        Fluid kind selector: "discrete" or "voxel".
+        Fluid kind selector. Defaults to ``"voxel"`` so that inside-cell fluids
+        use a MAC grid unless a caller explicitly requests the ``"discrete"``
+        particle cloud mode.
     radius:
         Source influence radius in world units when applying mass sources
         (used by discrete/SPH coupling).  Ignored for voxel.
@@ -48,7 +52,7 @@ class BathFluidCoupler:
 
     bath: object
     engine: object
-    kind: FluidKind
+    kind: FluidKind = "voxel"
     radius: float = 0.05
     density_hint: Optional[float] = None
 

--- a/src/cells/bath/coupling_handshake.md
+++ b/src/cells/bath/coupling_handshake.md
@@ -1,0 +1,29 @@
+# Bath–Fluid Coupling Handshake
+
+Roadmap section **C** sketches the handshake between the zero-dimensional `Bath` model and a spatial fluid solver. This document describes the data exchanged and the ordering of operations used in the simulator.
+
+## Data exchanged
+
+The coupling operates on a minimal set of fields:
+
+| Symbol | Description |
+|---|---|
+| `centers` | `(N,3)` array of cell center-of-mass positions. |
+| `vols` | `(N,)` array of cell volumes used to compute `dV`. |
+| `dV` | Per-cell volume change over the last step. Converted to mass when using discrete SPH. |
+| `dS` | Per-cell solute changes (currently zeroed by the coupler). |
+| `P` | Pressure samples returned by the fluid engine for feedback. |
+
+Inside-cell fluids default to a **voxel** (MAC grid) representation. Discrete particle clouds are enabled only when a caller explicitly requests the `"discrete"` kind.
+
+## Step ordering
+
+1. **Softbody update** – advance cell mechanics and obtain tentative volumes.
+2. **Osmotic step** – compute osmotic fluxes and update proposed `dV`, `dS`.
+3. **Coupling A** – `BathFluidCoupler.exchange` converts `dV` into fluid sources and primes the engine.
+4. **Fluid step** – advance the voxel or discrete fluid solver by `dt`.
+5. **Coupling B** – sample fluid pressure around each cell and blend into `Bath.pressure`.
+6. **Feedback** – corrected fluxes are returned to the softbody and osmotic engines.
+7. **Conservation check** – verify global volume and solute conservation across Bath and fluid.
+
+This handshake keeps the bulk Bath model authoritative while allowing higher-fidelity fluid solvers to participate in the simulation only when desired.


### PR DESCRIPTION
## Summary
- document Bath<->fluid coupling data and step order
- default BathFluidCoupler to voxel representation so discrete clouds are opt-in

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea16d0274832a9ead9bf45f363028