### PR TITLE
Add OpenGL and headless hooks for Bath adapters

### DIFF
--- a/src/cells/bath/__init__.py
+++ b/src/cells/bath/__init__.py
@@ -6,7 +6,14 @@ convenience.
 """
 
 from .fluid import Bath
-from .adapter import BathAdapter, SPHAdapter, MACAdapter, HybridAdapter
+from .adapter import (
+    BathAdapter,
+    SPHAdapter,
+    MACAdapter,
+    HybridAdapter,
+    run_headless,
+    run_opengl,
+)
 from .hybrid_fluid import HybridFluid
 
 __all__ = [
@@ -16,4 +23,6 @@ __all__ = [
     "MACAdapter",
     "HybridAdapter",
     "HybridFluid",
+    "run_headless",
+    "run_opengl",
 ]

--- a/src/cells/bath/adapter.py
+++ b/src/cells/bath/adapter.py
@@ -86,7 +86,13 @@ class SPHAdapter(BathAdapter):
 
     def visualization_state(self) -> Dict[str, np.ndarray | List]:
         pos, vec = self.sim.export_positions_vectors()
-        return {"positions": pos, "vectors": vec, "surface_batches": []}
+        return {
+            "positions": pos,
+            "point_vectors": vec,
+            "vector_positions": pos,
+            "vectors": vec,
+            "surface_batches": [],
+        }
 
 
 @dataclass
@@ -123,7 +129,13 @@ class MACAdapter(BathAdapter):
 
     def visualization_state(self) -> Dict[str, np.ndarray | List]:
         pos, vec = self.sim.export_vector_field()
-        state: Dict[str, np.ndarray | List] = {"positions": pos, "vectors": vec, "surface_batches": []}
+        state: Dict[str, np.ndarray | List] = {
+            "positions": np.zeros((0, 3), dtype=float),
+            "point_vectors": np.zeros((0, 3), dtype=float),
+            "vector_positions": pos,
+            "vectors": vec,
+            "surface_batches": [],
+        }
         if self.animator is not None:
             try:
                 state["surface_batches"] = self.animator.instance_batches()
@@ -165,11 +177,129 @@ class HybridAdapter(BathAdapter):
                 pass
 
     def visualization_state(self) -> Dict[str, np.ndarray | List]:
-        pos, vec = self.sim.export_vector_field()
-        state: Dict[str, np.ndarray | List] = {"positions": pos, "vectors": vec, "surface_batches": []}
+        parts = self.sim.export_particles()
+        p_pos = parts.get("x", np.zeros((0, 3), dtype=float))
+        p_vel = parts.get("v", np.zeros_like(p_pos))
+        v_pos, v_vec = self.sim.export_vector_field()
+        state: Dict[str, np.ndarray | List] = {
+            "positions": p_pos,
+            "point_vectors": p_vel,
+            "vector_positions": v_pos,
+            "vectors": v_vec,
+            "surface_batches": [],
+        }
         if self.animator is not None:
             try:
                 state["surface_batches"] = self.animator.instance_batches()
             except Exception:
                 state["surface_batches"] = []
         return state
+
+
+def run_headless(adapter: BathAdapter, steps: int, dt: float) -> List[Dict[str, np.ndarray | List]]:
+    """Advance ``adapter`` for ``steps`` without drawing.
+
+    The function returns a list of visualization states gathered after each
+    step, allowing callers (including tests or CLI tools) to post-process the
+    data.  It performs no rendering and is safe for headless environments.
+    """
+
+    frames: List[Dict[str, np.ndarray | List]] = []
+    for _ in range(int(steps)):
+        adapter.step(dt)
+        frames.append(adapter.visualization_state())
+    return frames
+
+
+def run_opengl(
+    adapter: BathAdapter,
+    steps: int,
+    dt: float,
+    *,
+    draw: str = "points+vectors",
+    scale: float | None = None,
+) -> List[Dict[str, Dict[str, np.ndarray]]]:
+    """Prepare OpenGL-friendly primitives for ``adapter`` over ``steps``.
+
+    Parameters
+    ----------
+    adapter:
+        Any :class:`BathAdapter` instance.
+    steps, dt:
+        Simulation steps and time step.
+    draw:
+        Drawing mode – ``"points"``, ``"vectors"`` or ``"points+vectors"``.
+    scale:
+        Optional vector scale.  Defaults to ``0.5*dx`` when available.
+
+    Returns
+    -------
+    list of dict
+        One entry per step containing "points" and/or "vectors" geometries.
+        Each geometry dictionary holds NumPy arrays ready for GL buffers.
+    """
+
+    modes = {m.strip() for m in draw.split("+") if m.strip()}
+    frames: List[Dict[str, Dict[str, np.ndarray]]] = []
+
+    for _ in range(int(steps)):
+        adapter.step(dt)
+        state = adapter.visualization_state()
+
+        p_pos = np.asarray(state.get("positions", np.zeros((0, 3))), dtype=float)
+        p_vec = state.get("point_vectors")
+        if p_vec is not None:
+            p_vec = np.asarray(p_vec, dtype=float)
+        v_pos = np.asarray(state.get("vector_positions", p_pos), dtype=float)
+        v_vec = np.asarray(state.get("vectors", np.zeros_like(v_pos)), dtype=float)
+
+        frame: Dict[str, Dict[str, np.ndarray]] = {}
+
+        # Points -------------------------------------------------------------
+        if "points" in modes and p_pos.size:
+            if p_vec is not None and p_vec.shape == p_pos.shape:
+                speed = np.linalg.norm(p_vec, axis=1)
+            else:
+                speed = np.zeros(p_pos.shape[0], dtype=float)
+            size = 5.0 + 5.0 * speed
+            frame["points"] = {"positions": p_pos, "size": size}
+
+        # Vectors ------------------------------------------------------------
+        if "vectors" in modes and v_vec.size:
+            if scale is None:
+                dx_val = None
+                if hasattr(adapter, "sim"):
+                    sim = getattr(adapter, "sim")
+                    if hasattr(sim, "params") and hasattr(sim.params, "dx"):
+                        dx_val = float(getattr(sim.params, "dx"))
+                    elif hasattr(sim, "dx"):
+                        dx_val = float(getattr(sim, "dx"))
+                vec_scale = 0.5 * dx_val if dx_val is not None else 1.0
+            else:
+                vec_scale = scale
+
+            start = v_pos
+            end = v_pos + v_vec * vec_scale
+            colors = np.ones((start.shape[0], 4), dtype=float)
+            base_alpha = 0.25 if isinstance(adapter, HybridAdapter) else 1.0
+            if start.shape[0] and start.shape[1] >= 3:
+                z = start[:, 2]
+                z_norm = (z - z.min()) / (np.ptp(z) + 1e-9)
+                colors[:, 3] = base_alpha * (1.0 - z_norm)
+            else:
+                colors[:, 3] = base_alpha
+            frame["vectors"] = {"start": start, "end": end, "color": colors}
+
+        frames.append(frame)
+
+    return frames
+
+
+__all__ = [
+    "BathAdapter",
+    "SPHAdapter",
+    "MACAdapter",
+    "HybridAdapter",
+    "run_headless",
+    "run_opengl",
+]

--- a/tests/test_bath_run_hooks.py
+++ b/tests/test_bath_run_hooks.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import numpy as np
+
+# Ensure src is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "src")))
+
+from src.cells.bath import (
+    SPHAdapter,
+    MACAdapter,
+    HybridAdapter,
+    run_headless,
+    run_opengl,
+)
+from src.cells.bath.discrete_fluid import DiscreteFluid, FluidParams
+from src.cells.bath.voxel_fluid import VoxelMACFluid, VoxelFluidParams
+from src.cells.bath.hybrid_fluid import HybridFluid, HybridParams
+
+
+def _make_sph_adapter():
+    params = FluidParams()
+    sim = DiscreteFluid(
+        positions=np.zeros((1, 3)),
+        velocities=None,
+        temperature=None,
+        salinity=None,
+        params=params,
+    )
+    return SPHAdapter(sim)
+
+
+def _make_mac_adapter():
+    vparams = VoxelFluidParams(nx=1, ny=1, nz=1)
+    sim = VoxelMACFluid(vparams)
+    return MACAdapter(sim)
+
+
+def _make_hybrid_adapter():
+    hparams = HybridParams(dx=0.05)
+    sim = HybridFluid(shape=(1, 1, 1), n_particles=1, params=hparams)
+    return HybridAdapter(sim)
+
+
+def test_run_headless_collects_states():
+    adapter = _make_sph_adapter()
+    frames = run_headless(adapter, steps=2, dt=1e-4)
+    assert len(frames) == 2
+    assert all("positions" in f for f in frames)
+
+
+def test_run_opengl_draw_modes():
+    # SPH: points only
+    sph = _make_sph_adapter()
+    frames = run_opengl(sph, steps=1, dt=0.0, draw="points")
+    assert "points" in frames[0] and "vectors" not in frames[0]
+
+    # MAC: vectors only
+    mac = _make_mac_adapter()
+    frames_mac = run_opengl(mac, steps=1, dt=0.0, draw="vectors")
+    assert "vectors" in frames_mac[0] and "points" not in frames_mac[0]
+
+    # Hybrid: both with low alpha
+    hyb = _make_hybrid_adapter()
+    frames_h = run_opengl(hyb, steps=1, dt=0.0, draw="points+vectors")
+    assert "points" in frames_h[0] and "vectors" in frames_h[0]
+    colors = frames_h[0]["vectors"]["color"]
+    assert np.all(colors[:, 3] <= 0.25 + 1e-6)
+


### PR DESCRIPTION
## Summary
- expose `run_headless` and `run_opengl` hooks for Bath adapters
- enrich adapter visualization state for SPH, MAC and Hybrid fluids
- cover draw modes with new tests

## Testing
- `pytest tests/test_bath_run_hooks.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ea36fc23c832abdcec7cac34897c2