### PR TITLE
feat: add adaptive timestep controller and metrics

### DIFF
--- a/src/cells/bath/dt_controller.py
+++ b/src/cells/bath/dt_controller.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+"""Simple adaptive timestep controller with PI smoothing."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import numpy as np
+
+
+@dataclass
+class Metrics:
+    max_vel: float
+    max_flux: float
+    div_inf: float
+    mass_err: float
+    osc_flag: bool = False
+    stiff_flag: bool = False
+
+
+@dataclass
+class Targets:
+    cfl: float
+    div_max: float
+    mass_max: float
+
+
+@dataclass
+class STController:
+    Kp: float = 0.4
+    Ki: float = 0.05
+    A: float = 1.5
+    shrink: float = 0.5
+    dt_min: float = 1e-6
+    dt_max: float = 1.0
+    acc: float = 0.0
+    max_vel_ever: float = 1e-30
+    clamp_events: int = 0
+
+    def update_dt_max(self, max_vel: float, dx: float) -> None:
+        self.max_vel_ever = max(self.max_vel_ever, max_vel)
+        self.dt_max = 0.25 * dx / max(self.max_vel_ever, 1e-30)
+
+    def pi_update(self, dt_prev: float, dt_pen: float, osc: bool) -> float:
+        e = math.log(max(dt_pen, self.dt_min)) - math.log(max(dt_prev, self.dt_min))
+        self.acc = float(np.clip(self.acc + self.Ki * e, -self.A, self.A))
+        log_dt = math.log(max(dt_prev, self.dt_min)) + self.Kp * e + self.acc
+        dt_new = float(np.clip(math.exp(log_dt), self.dt_min, self.dt_max))
+        if osc:
+            dt_new = max(dt_new * self.shrink, self.dt_min)
+        return dt_new
+
+
+def step_with_dt_control(state, dt, dx, targets: Targets, ctrl: STController, advance, retries: int = 0):
+    saved = state.copy_shallow()
+    ok, metrics = advance(state, dt)
+    if (not ok) or (metrics.mass_err > targets.mass_max) or (metrics.div_inf > targets.div_max * 10.0):
+        state.restore(saved)
+        if retries >= 3:
+            ctrl.clamp_events += 1
+            return metrics, dt
+        dt = max(dt * 0.5, ctrl.dt_min)
+        return step_with_dt_control(state, dt, dx, targets, ctrl, advance, retries + 1)
+
+    dt_cfl = targets.cfl * dx / max(metrics.max_vel, 1e-30)
+    penalty = max(
+        metrics.div_inf / targets.div_max,
+        metrics.mass_err / targets.mass_max,
+        1.0,
+    )
+    dt_pen = dt_cfl / penalty
+    dt_next = ctrl.pi_update(dt_prev=dt, dt_pen=dt_pen, osc=(metrics.osc_flag or metrics.stiff_flag))
+    ctrl.update_dt_max(metrics.max_vel, dx)
+    return metrics, dt_next
+
+
+# Thermodynamics stubs ----------------------------------------------------
+
+def ideal_gas_eos(cell) -> float:
+    rho = getattr(cell, "rho", 1.0)
+    R = getattr(cell, "R", 1.0)
+    T = getattr(cell, "T", 0.0)
+    return rho * R * T
+
+
+def noop_energy_step(cell, dt_half: float) -> None:
+    return None

--- a/tests/test_dt_controller.py
+++ b/tests/test_dt_controller.py
@@ -1,0 +1,53 @@
+import copy
+
+from src.cells.bath.dt_controller import (
+    STController,
+    Targets,
+    Metrics,
+    step_with_dt_control,
+)
+
+
+class DummyState:
+    def __init__(self):
+        self.mass = 1.0
+        self.vel = 0.1
+
+    def copy_shallow(self):
+        return copy.deepcopy(self)
+
+    def restore(self, saved):
+        self.__dict__.update(copy.deepcopy(saved.__dict__))
+
+    def step(self, dt):
+        # constant velocity, mass stays the same
+        pass
+
+    def total_mass(self):
+        return self.mass
+
+    def compute_metrics(self, prev_mass):
+        return Metrics(
+            max_vel=self.vel,
+            max_flux=self.vel,
+            div_inf=0.0,
+            mass_err=abs(self.mass - prev_mass) / prev_mass,
+        )
+
+
+def test_dt_controller_step():
+    state = DummyState()
+    targets = Targets(cfl=0.5, div_max=1e-3, mass_max=1e-6)
+    ctrl = STController(dt_min=1e-6, dt_max=1e-2)
+    dx = 0.1
+
+    def advance(state, dt):
+        prev_mass = getattr(state, "_last_mass", state.total_mass())
+        state.step(dt)
+        metrics = state.compute_metrics(prev_mass)
+        state._last_mass = state.total_mass()
+        return True, metrics
+
+    metrics, dt_next = step_with_dt_control(state, 1e-4, dx, targets, ctrl, advance)
+    assert dt_next > 0
+    assert isinstance(metrics.max_vel, float)


### PR DESCRIPTION
## Summary
- add PI-based timestep controller with rollback and thermodynamics stubs
- expose metrics and vertex tape helpers on HybridFluid
- test controller step on dummy state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ebc7b660c832a959ea79f88e83813