### PR TITLE
Expose step_with_controller in fluid helpers

### DIFF
--- a/src/cells/bath/make_hybrid.py
+++ b/src/cells/bath/make_hybrid.py
@@ -50,6 +50,7 @@ def make_hybrid(
     return SimpleNamespace(
         engine=engine,
         step=engine.step,
+        step_with_controller=engine.step_with_controller,
         export_particles=engine.export_particles,
         export_vector_field=engine.export_vector_field,
         export_positions_vectors=lambda: (

--- a/src/cells/bath/make_mac.py
+++ b/src/cells/bath/make_mac.py
@@ -42,6 +42,7 @@ def make_mac(
     return SimpleNamespace(
         engine=engine,
         step=engine.step,
+        step_with_controller=engine.step_with_controller,
         export_vector_field=engine.export_vector_field,
         export_positions_vectors=engine.export_vector_field,
         export_droplets=lambda: None,

--- a/src/cells/bath/make_sph.py
+++ b/src/cells/bath/make_sph.py
@@ -79,6 +79,7 @@ def make_sph(
     return SimpleNamespace(
         engine=engine,
         step=engine.step,
+        step_with_controller=engine.step_with_controller,
         export_positions_vectors=engine.export_positions_vectors,
         export_vertices=engine.export_vertices,
         export_droplets=lambda: engine.droplet_p.copy(),

--- a/tests/test_make_fluid_step_controller.py
+++ b/tests/test_make_fluid_step_controller.py
@@ -1,0 +1,16 @@
+import pytest
+
+from src.cells.bath.make_sph import make_sph
+from src.cells.bath.make_mac import make_mac
+from src.cells.bath.make_hybrid import make_hybrid
+@pytest.mark.parametrize(
+    "factory, kwargs",
+    [
+        (make_sph, {"resolution": 1}),
+        (make_mac, {"resolution": 1}),
+        (make_hybrid, {"resolution": 1, "n_particles": 1}),
+    ],
+)
+def test_step_with_controller_available(factory, kwargs):
+    fluid = factory(**kwargs)
+    assert callable(getattr(fluid, "step_with_controller", None))


### PR DESCRIPTION
## Summary
- expose `step_with_controller` in SPH, MAC, and hybrid fluid demo factories
- add regression test ensuring fluid helpers expose `step_with_controller`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f02acc374832ab82698829428873d