### PR TITLE
fix demos respect fluid tags

### DIFF
--- a/src/cells/softbody/demo/run_ascii_demo.py
+++ b/src/cells/softbody/demo/run_ascii_demo.py
@@ -12,6 +12,7 @@ from .run_numpy_demo import (
     build_numpy_parser,
     get_numpy_tag_names,
     extract_numpy_kwargs,
+    run_fluid_demo,
 )
 
 # ---- color helpers ---------------------------------------------------------
@@ -293,6 +294,11 @@ def main():
                         help="Character for 1D cell spans")
     args = parser.parse_args()
     color_mode = args.color
+
+    # Delegate to fluid demo when --fluid tag is present
+    if getattr(args, "fluid", ""):
+        run_fluid_demo(args)
+        return
 
     # If streaming from NPZ, bypass simulation entirely
     if getattr(args, "stream_npz", ""):

--- a/src/cells/softbody/demo/run_opengl_demo.py
+++ b/src/cells/softbody/demo/run_opengl_demo.py
@@ -11,6 +11,7 @@ from .run_numpy_demo import (
     build_numpy_parser,
     get_numpy_tag_names,
     extract_numpy_kwargs,
+    run_fluid_demo,
 )
 
 
@@ -607,6 +608,11 @@ def main():
     parser.add_argument("--flat2d", action="store_true",
                         help="Render in a fixed top-down 2D orthographic view")
     args = parser.parse_args()
+
+    # When a fluid demo is requested, delegate to shared numpy handler
+    if getattr(args, "fluid", ""):
+        run_fluid_demo(args)
+        return
 
     # If streaming mode, we still init pygame/GL, but won't step the sim.
     streaming = bool(getattr(args, "stream_npz", ""))


### PR DESCRIPTION
## Summary
- ensure ASCII demo delegates to fluid runner when `--fluid` is provided
- allow OpenGL demo to hand off fluid requests to shared numpy handler

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f0ebdb05c832aa526e5aa2782b971