### PR TITLE
Enable sim dimension and hybrid fluid demos

### DIFF
--- a/src/cells/bath/make_hybrid.py
+++ b/src/cells/bath/make_hybrid.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Iterable, Tuple
 
+import numpy as np
+
 from .hybrid_fluid import HybridFluid, HybridParams
 
 
@@ -44,8 +46,11 @@ def make_hybrid(
         pass
 
     def export_positions_vectors_droplets():
-        data = engine.export_particles()
-        return data["x"], data["v"], None
+        parts = engine.export_particles()
+        grid_pts, grid_vecs = engine.export_vector_field()
+        pts = np.concatenate([parts["x"], grid_pts], axis=0)
+        vecs = np.concatenate([parts["v"], grid_vecs], axis=0)
+        return pts, vecs, None
 
     return SimpleNamespace(
         engine=engine,

--- a/src/opengl_render/run_numpy_menu.py
+++ b/src/opengl_render/run_numpy_menu.py
@@ -14,8 +14,9 @@ import subprocess
 OPTIONS = {
     "1": ("Voxel fluid demo", ["--fluid", "voxel"]),
     "2": ("Discrete fluid demo", ["--fluid", "discrete"]),
-    "3": ("Cells + fluid (mesh)", ["--couple-fluid", "voxel"]),
-    "4": ("Point cloud export", ["--export-kind", "opengl-points"]),
+    "3": ("Hybrid fluid demo", ["--fluid", "hybrid"]),
+    "4": ("Cells + fluid (mesh)", ["--couple-fluid", "voxel"]),
+    "5": ("Point cloud export", ["--export-kind", "opengl-points"]),
 }
 
 


### PR DESCRIPTION
## Summary
- add `--sim-dim` CLI option for numpy demo and propagate to fluid engines
- support hybrid fluid selection in CLI and numpy menu
- export combined particle and grid vectors from hybrid fluid helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f31e4ffb8832a82dc5c6c031fadab