### PR TITLE
feat: add debug mode runner for opengl sims

### DIFF
--- a/src/opengl_render/__init__.py
+++ b/src/opengl_render/__init__.py
@@ -1,15 +1,32 @@
-"""Minimal OpenGL renderer package with mesh, line and point layers."""
+"""Minimal OpenGL renderer package with mesh, line and point layers.
 
-from .renderer import GLRenderer, MeshLayer, LineLayer, PointLayer, DebugRenderer
-from .api import (
-    rainbow_colors,
-    rainbow_history_points,
-    pack_mesh,
-    pack_lines,
-    pack_points,
-    cellsim_layers,
-    fluid_layers,
-)
+This module attempts to import the heavy OpenGL-backed :mod:`renderer` and
+associated helpers. In headless environments without an OpenGL context these
+imports may fail; in that case ``None`` placeholders are exported so that other
+modules (e.g., the debug simulation coordinator) can still be imported without
+raising ``ImportError``.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - best effort in headless CI
+    from .renderer import GLRenderer, MeshLayer, LineLayer, PointLayer, DebugRenderer
+except Exception:  # noqa: BLE001 - tolerate missing OpenGL libs
+    GLRenderer = MeshLayer = LineLayer = PointLayer = DebugRenderer = None  # type: ignore
+
+try:  # pragma: no cover - best effort in headless CI
+    from .api import (
+        rainbow_colors,
+        rainbow_history_points,
+        pack_mesh,
+        pack_lines,
+        pack_points,
+        cellsim_layers,
+        fluid_layers,
+    )
+except Exception:  # noqa: BLE001 - tolerate missing OpenGL libs
+    rainbow_colors = rainbow_history_points = pack_mesh = None  # type: ignore
+    pack_lines = pack_points = cellsim_layers = fluid_layers = None  # type: ignore
 
 __all__ = [
     "GLRenderer",

--- a/src/opengl_render/render_sim_coordinator.py
+++ b/src/opengl_render/render_sim_coordinator.py
@@ -6,11 +6,13 @@ with predefined argument sets; visualization is handled separately by the
 """
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
+from typing import Iterable, Mapping, Sequence
 
 
-OPTIONS = {
+OPTIONS: Mapping[str, tuple[str, Sequence[str]]] = {
     "1": ("Voxel fluid demo", ["--fluid", "voxel"]),
     "2": ("Discrete fluid demo", ["--fluid", "discrete"]),
     "3": ("Hybrid fluid demo", ["--fluid", "hybrid"]),
@@ -18,18 +20,59 @@ OPTIONS = {
 }
 
 
-def main() -> None:
-    print("Select NumPy simulation to run:\n")
-    for key, (name, _) in OPTIONS.items():
-        print(f" {key}) {name}")
-    choice = input("\nChoice: ").strip()
+def run_option(choice: str, *, debug: bool = False) -> subprocess.CompletedProcess:
+    """Run a predefined NumPy simulation option.
+
+    Parameters
+    ----------
+    choice:
+        Key from :data:`OPTIONS` selecting which demo to run.
+    debug:
+        When ``True`` the underlying simulator is invoked with ``--debug``
+        flags and a single frame to emit layer positions and metadata.
+
+    Returns
+    -------
+    :class:`subprocess.CompletedProcess`
+        The completed process object from :func:`subprocess.run`.
+    """
+
+    if choice not in OPTIONS:
+        raise ValueError("Unknown option")
+    _, args = OPTIONS[choice]
+    cmd = [sys.executable, "-m", "src.cells.softbody.demo.numpy_sim_coordinator", *args]
+    if debug:
+        cmd += ["--debug-render", "--debug", "--frames", "1", "--dt", "1e-4"]
+        return subprocess.run(cmd, check=False, capture_output=True, text=True)
+    return subprocess.run(cmd, check=False)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--choice", choices=list(OPTIONS.keys()), help="Run a specific option without prompting")
+    parser.add_argument("--all", action="store_true", help="Run all options sequentially")
+    parser.add_argument("--debug", action="store_true", help="Enable debug rendering and logging")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.all:
+        for key in OPTIONS:
+            proc = run_option(key, debug=args.debug)
+            if args.debug:
+                print(proc.stdout)
+        return
+
+    choice = args.choice
+    if choice is None:
+        print("Select NumPy simulation to run:\n")
+        for key, (name, _) in OPTIONS.items():
+            print(f" {key}) {name}")
+        choice = input("\nChoice: ").strip()
     if choice not in OPTIONS:
         print("Unknown option")
         return
-    name, args = OPTIONS[choice]
-    # Run the NumPy simulation coordinator; rendering is expected to be handled externally
-    cmd = [sys.executable, "-m", "src.cells.softbody.demo.numpy_sim_coordinator", *args]
-    subprocess.run(cmd, check=False)
+    proc = run_option(choice, debug=args.debug)
+    if args.debug:
+        print(proc.stdout)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual utility

--- a/tests/test_opengl_menu_debug.py
+++ b/tests/test_opengl_menu_debug.py
@@ -1,0 +1,10 @@
+import pytest
+from src.opengl_render.render_sim_coordinator import run_option, OPTIONS
+
+@pytest.mark.parametrize('choice', list(OPTIONS.keys()))
+def test_menu_runs_in_debug(choice):
+    proc = run_option(choice, debug=True)
+    assert proc.returncode == 0
+    out = (proc.stdout or '').lower()
+    assert 'points' in out or 'positions' in out
+    assert 'dtype' in out  # metadata vector info


### PR DESCRIPTION
## Summary
- allow running OpenGL sim menu choices non-interactively
- handle headless environments and voxel fluids in debug mode
- test that all menu modes output layer positions and metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f565f2f24832a8250e9647a987389