### PR TITLE
Add threaded OpenGL renderer with buffer queue and history

### DIFF
--- a/src/opengl_render/__init__.py
+++ b/src/opengl_render/__init__.py
@@ -9,6 +9,8 @@ raising ``ImportError``.
 
 from __future__ import annotations
 
+from .threaded import GLRenderThread
+
 try:  # pragma: no cover - best effort in headless CI
     from .renderer import GLRenderer, MeshLayer, LineLayer, PointLayer, DebugRenderer
 except Exception:  # noqa: BLE001 - tolerate missing OpenGL libs
@@ -23,13 +25,17 @@ try:  # pragma: no cover - best effort in headless CI
         pack_points,
         cellsim_layers,
         fluid_layers,
+        make_draw_hook,
+        make_threaded_draw_hook,
     )
 except Exception:  # noqa: BLE001 - tolerate missing OpenGL libs
     rainbow_colors = rainbow_history_points = pack_mesh = None  # type: ignore
     pack_lines = pack_points = cellsim_layers = fluid_layers = None  # type: ignore
+    make_draw_hook = make_threaded_draw_hook = None  # type: ignore
 
 __all__ = [
     "GLRenderer",
+    "GLRenderThread",
     "DebugRenderer",
     "MeshLayer",
     "LineLayer",
@@ -42,4 +48,6 @@ __all__ = [
     "pack_points",
     "cellsim_layers",
     "fluid_layers",
+    "make_draw_hook",
+    "make_threaded_draw_hook",
 ]

--- a/src/opengl_render/renderer.py
+++ b/src/opengl_render/renderer.py
@@ -409,5 +409,7 @@ class GLRenderer:
     # ---- disposal ----
     def dispose(self):
         for pid in (self.prog_mesh, self.prog_line, self.prog_point):
-            try: glDeleteProgram(pid)
-            except Exception: pass
+            try:
+                glDeleteProgram(pid)
+            except Exception:
+                pass

--- a/src/opengl_render/threaded.py
+++ b/src/opengl_render/threaded.py
@@ -1,0 +1,97 @@
+"""Thread-backed helpers for the OpenGL renderer."""
+
+from __future__ import annotations
+
+from collections import deque
+import queue
+import threading
+import time
+from typing import Callable, Mapping, Tuple
+
+
+class GLRenderThread:
+    """Run a renderer in its own thread with a frame queue and history.
+
+    Parameters
+    ----------
+    renderer:
+        Object with :func:`print_layers` or OpenGL ``draw`` methods.
+    viewport:
+        Tuple ``(width, height)`` describing the viewport in pixels.
+    history:
+        Maximum number of past frames to retain. ``0`` keeps an unbounded
+        history.
+    loop:
+        When ``True`` the stored history is replayed whenever the input queue is
+        empty.
+    bounce:
+        When ``True`` and :paramref:`loop` is enabled, the history is played
+        forwards then backwards (ping-pong).
+    """
+
+    def __init__(
+        self,
+        renderer: object,
+        *,
+        viewport: Tuple[int, int],
+        history: int = 0,
+        loop: bool = False,
+        bounce: bool = False,
+    ) -> None:
+        self.renderer = renderer
+        self.viewport = viewport
+        maxlen = history if history > 0 else None
+        self.history: deque[Mapping[str, object]] = deque(maxlen=maxlen)
+        self.queue: "queue.Queue[Mapping[str, object] | None]" = queue.Queue()
+        self.loop = loop
+        self.bounce = bounce
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    # Public API -----------------------------------------------------
+    def submit(self, layers: Mapping[str, object]) -> None:
+        """Enqueue a new frame to be drawn by the thread."""
+        self.queue.put(layers)
+
+    def get_submit_hook(self) -> Callable[[Mapping[str, object]], None]:
+        """Return a function that enqueues frames."""
+
+        def hook(layers: Mapping[str, object]) -> None:
+            self.submit(layers)
+
+        return hook
+
+    def stop(self) -> None:
+        """Signal the thread to exit and wait for completion."""
+        self._stop.set()
+        self.queue.put(None)
+        self._thread.join()
+
+    # Internal worker ------------------------------------------------
+    def _run(self) -> None:  # pragma: no cover - thread loop
+        from .api import draw_layers  # local import to avoid circular deps
+
+        while not self._stop.is_set():
+            try:
+                item = self.queue.get(timeout=0.01)
+            except queue.Empty:
+                item = None
+
+            if item is None:
+                # queue empty or sentinel; replay history if requested
+                if self.loop and self.history:
+                    seq = list(self.history)
+                    if self.bounce and len(seq) > 1:
+                        seq = seq + seq[-2:0:-1]
+                    for frame in seq:
+                        if self._stop.is_set():
+                            break
+                        draw_layers(self.renderer, frame, self.viewport)
+                        time.sleep(0.001)
+                continue
+
+            # Normal frame: draw and store in history
+            self.history.append(item)
+            draw_layers(self.renderer, item, self.viewport)
+            self.queue.task_done()

--- a/tests/test_threaded_glrenderer.py
+++ b/tests/test_threaded_glrenderer.py
@@ -1,0 +1,39 @@
+import time
+import numpy as np
+
+from src.opengl_render.api import make_threaded_draw_hook
+
+
+class Recorder:
+    """Simple stand-in for DebugRenderer that records frames."""
+
+    def __init__(self):
+        self.frames: list[dict] = []
+
+    def print_layers(self, layers):
+        self.frames.append(layers)
+
+
+def test_threaded_glrenderer_collects_history():
+    rec = Recorder()
+    hook, thread = make_threaded_draw_hook(rec, (1, 1), history=2)
+    f1 = {"points": np.zeros((1, 3), np.float32)}
+    f2 = {"points": np.ones((1, 3), np.float32)}
+    hook(f1)
+    hook(f2)
+    thread.queue.join()
+    thread.stop()
+    assert list(thread.history) == [f1, f2]
+    assert rec.frames == [f1, f2]
+
+
+def test_threaded_glrenderer_loops():
+    rec = Recorder()
+    hook, thread = make_threaded_draw_hook(rec, (1, 1), history=1, loop=True)
+    frame = {"points": np.zeros((1, 3), np.float32)}
+    hook(frame)
+    thread.queue.join()
+    # Give the thread a moment to replay history
+    time.sleep(0.05)
+    thread.stop()
+    assert len(rec.frames) >= 2


### PR DESCRIPTION
## Summary
- introduce `GLRenderThread` to render frames on a dedicated thread with queue, history, looping and bounce playback
- add `make_threaded_draw_hook` helper to obtain a no-hassle enqueue hook for asynchronous drawing
- cover threaded renderer with tests ensuring history retention and looping behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f5cb932fc832aa498c9006237be16