### PR TITLE
Auto-fit OpenGL view and refine threaded renderer

### DIFF
--- a/src/opengl_render/threaded.py
+++ b/src/opengl_render/threaded.py
@@ -108,6 +108,8 @@ class GLRenderThread:
                 item = None
 
             if item is None:
+                if self._stop.is_set():
+                    break
                 # queue empty or sentinel; replay history if requested
                 if self.loop_mode in {"loop", "bounce"} and self.history:
                     seq = list(self.history)


### PR DESCRIPTION
## Summary
- compute perspective and view matrices to fit rendered meshes and fluid points in view
- allow renderer instances in threaded hooks and disable ghost trails by default
- stop GL render thread cleanly without drawing an extra frame

## Testing
- `pytest tests/test_threaded_glrenderer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0981733a0832a8e20ff27018d275d