### PR TITLE
Fix MVP orientation and document row-major matrices

### DIFF
--- a/src/opengl_render/api.py
+++ b/src/opengl_render/api.py
@@ -142,8 +142,12 @@ def pack_points(
 # Minimal camera helpers
 # ---------------------------------------------------------------------------
 
+# NOTE: Matrices are **row-major** (NumPy convention).  When sending them to
+# OpenGL uniforms, transpose first so the data is interpreted correctly as
+# column-major.
+
 def _perspective(fovy_deg: float, aspect: float, znear: float, zfar: float) -> np.ndarray:
-    """Return a column-major perspective projection matrix."""
+    """Return a row-major perspective projection matrix."""
     f = 1.0 / math.tan(math.radians(fovy_deg) * 0.5)
     m = np.zeros((4, 4), dtype=np.float32)
     m[0, 0] = f / aspect
@@ -155,7 +159,7 @@ def _perspective(fovy_deg: float, aspect: float, znear: float, zfar: float) -> n
 
 
 def _look_at(eye: np.ndarray, center: np.ndarray, up: np.ndarray) -> np.ndarray:
-    """Return a column-major view matrix."""
+    """Return a row-major view matrix."""
     eye = np.asarray(eye, dtype=np.float32)
     center = np.asarray(center, dtype=np.float32)
     up = np.asarray(up, dtype=np.float32)
@@ -311,7 +315,8 @@ def draw_layers(
             aspect = float(viewport[0]) / float(viewport[1])
             mvp = _perspective(45.0, aspect, 0.1, radius * 10.0) @ _look_at(eye, center, up)
             try:
-                renderer.set_mvp(mvp)
+                # Transpose because OpenGL expects column-major matrices
+                renderer.set_mvp(mvp.T)
             except Exception:
                 pass
 

--- a/src/opengl_render/cli.py
+++ b/src/opengl_render/cli.py
@@ -114,7 +114,8 @@ def run():
                       [  0, 1,   0, 0],
                       [-sa, 0,  ca, 0],
                       [  0, 0,   0, 1]], np.float32)
-        r.set_mvp((P @ V @ R).astype(np.float32))
+        # Matrices are row-major; transpose before uploading to OpenGL
+        r.set_mvp((P @ V @ R).astype(np.float32).T)
 
         # Slightly wobble the point cloud so "fluid" visibly updates
         t += 0.015

--- a/tests/test_opengl_matrices.py
+++ b/tests/test_opengl_matrices.py
@@ -1,0 +1,80 @@
+import numpy as np
+from dataclasses import dataclass
+
+from src.opengl_render import api as gl_api
+from src.opengl_render.api import _perspective, _look_at, draw_layers
+from src.cells.softbody.geometry.geodesic import icosahedron
+
+# Provide minimal stand-ins for GL dataclasses when OpenGL is unavailable
+if gl_api.MeshLayer is object:  # pragma: no cover - depends on environment
+    @dataclass
+    class MeshLayer:
+        positions: np.ndarray
+        indices: np.ndarray
+        colors: np.ndarray | None = None
+
+    class LineLayer:
+        pass
+
+    class PointLayer:
+        positions: np.ndarray
+
+    gl_api.MeshLayer = MeshLayer  # type: ignore
+    gl_api.LineLayer = LineLayer  # type: ignore
+    gl_api.PointLayer = PointLayer  # type: ignore
+else:  # pragma: no cover - real OpenGL path
+    MeshLayer = gl_api.MeshLayer
+
+class _StubRenderer:
+    def __init__(self):
+        self.mesh = None
+        self.mvp = None
+        self.viewport = None
+    def set_mesh(self, mesh):
+        self.mesh = mesh
+    def set_lines(self, lines):
+        self.lines = lines
+    def set_points(self, points):
+        self.points = points
+    def set_mvp(self, mvp):
+        self.mvp = mvp
+    def draw(self, viewport):
+        self.viewport = viewport
+
+
+def test_perspective_and_look_at_row_major():
+    p = _perspective(60.0, 1.0, 0.1, 100.0)
+    # Last row contains perspective canonical values in row-major layout
+    assert np.allclose(p[3], [0.0, 0.0, -1.0, 0.0])
+
+    eye = np.array([0.0, 0.0, 5.0], np.float32)
+    center = np.zeros(3, np.float32)
+    up = np.array([0.0, 1.0, 0.0], np.float32)
+    v = _look_at(eye, center, up)
+    # Translation appears in final column, not final row
+    assert np.allclose(v[3, :], [0.0, 0.0, 0.0, 1.0])
+    assert np.allclose(v[:3, 3], -v[:3, :3] @ eye)
+
+
+def test_draw_layers_transposes_mvp_and_handles_icosahedron():
+    V, F = icosahedron()
+    mesh = MeshLayer(V.astype(np.float32), F.astype(np.uint32))
+    renderer = _StubRenderer()
+    viewport = (640, 480)
+    draw_layers(renderer, {"membrane": mesh}, viewport)
+    # Geometry was uploaded
+    assert renderer.mesh is not None and renderer.mesh.positions.shape == (12, 3)
+    assert renderer.viewport == viewport
+
+    # Compute expected MVP as used in draw_layers
+    pts = mesh.positions
+    center = pts.mean(axis=0)
+    radius = float(np.linalg.norm(pts - center, axis=1).max())
+    eye = center + np.array([0.0, 0.0, radius * 3.0], np.float32)
+    up = np.array([0.0, 1.0, 0.0], np.float32)
+    aspect = viewport[0] / viewport[1]
+    expected = (
+        _perspective(45.0, aspect, 0.1, radius * 10.0)
+        @ _look_at(eye, center, up)
+    ).T
+    assert np.allclose(renderer.mvp, expected)


### PR DESCRIPTION
## Summary
- Document row-major matrix convention for perspective and view helpers
- Transpose MVP before uploading to OpenGL
- Add tests ensuring row-major matrices and correct MVP with default icosahedron

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a09d4f3810832ab5a4294622f05bb2