### PR TITLE
Display simulation dt and timing overlay

### DIFF
--- a/src/opengl_render/api.py
+++ b/src/opengl_render/api.py
@@ -262,6 +262,13 @@ def draw_layers(
     if viewport is None:
         viewport = getattr(renderer, "_window_size", (640, 480))
 
+    hud = layers.get("hud_text")
+    if hud is not None and hasattr(renderer, "set_overlay_text"):
+        try:
+            renderer.set_overlay_text(hud)  # type: ignore[call-arg]
+        except Exception:
+            pass
+
     mesh = layers.get("membrane")
     if isinstance(mesh, MeshLayer):
         renderer.set_mesh(mesh)


### PR DESCRIPTION
## Summary
- Track per-simulator dt and accumulated simulation time
- Add renderer HUD text layer for dt and sim/real-time comparison
- Render overlay text in OpenGL renderer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0a5bd4f74832a9f57dd750ecd4d46