### PR TITLE
feat: centralize dt metrics and scaling utilities

### DIFF
--- a/src/cells/bath/discrete_fluid.py
+++ b/src/cells/bath/discrete_fluid.py
@@ -30,7 +30,8 @@ from typing import Callable, Dict, Optional, Tuple, Iterable
 
 import numpy as np
 import copy
-from src.cells.bath.dt_controller import Metrics, Targets, STController, step_with_dt_control
+from src.common.dt_scaler import Metrics
+from src.cells.bath.dt_controller import Targets, STController, step_with_dt_control
 
 
 # ------------------------------ Kernels -------------------------------------

--- a/src/cells/bath/dt_controller.py
+++ b/src/cells/bath/dt_controller.py
@@ -6,15 +6,7 @@ from dataclasses import dataclass
 import math
 import numpy as np
 
-
-@dataclass
-class Metrics:
-    max_vel: float
-    max_flux: float
-    div_inf: float
-    mass_err: float
-    osc_flag: bool = False
-    stiff_flag: bool = False
+from src.common.dt_scaler import Metrics
 
 
 @dataclass

--- a/src/cells/bath/hybrid_fluid.py
+++ b/src/cells/bath/hybrid_fluid.py
@@ -49,7 +49,8 @@ from typing import Dict, Iterable, Tuple, List, Optional
 import copy
 import numpy as np
 
-from .dt_controller import Metrics, Targets, STController, step_with_dt_control
+from src.common.dt_scaler import Metrics
+from .dt_controller import Targets, STController, step_with_dt_control
 
 try:
     # Local sibling import; adjust path if packaging differs

--- a/src/cells/bath/voxel_fluid.py
+++ b/src/cells/bath/voxel_fluid.py
@@ -39,7 +39,8 @@ from typing import Tuple, Dict, Optional
 import numpy as np
 import warnings
 import copy
-from src.cells.bath.dt_controller import Metrics, Targets, STController, step_with_dt_control
+from src.common.dt_scaler import Metrics
+from src.cells.bath.dt_controller import Targets, STController, step_with_dt_control
 
 # Default CFL number exposed for external callers.  A value of 0.5 is
 # reasonably conservative for the semi-Lagrangian scheme employed here.

--- a/src/cells/cellsim/api/saline.py
+++ b/src/cells/cellsim/api/saline.py
@@ -13,7 +13,8 @@ from ..mechanics.softbody0d import Softbody0DProvider, SoftbodyProviderCfg
 from ..data.state import Cell, Bath, Organelle
 from ..core.geometry import sphere_area_from_volume
 from tqdm.auto import tqdm  # type: ignore
-from src.cells.bath.dt_controller import STController, Targets, Metrics, step_with_dt_control, run_superstep_plan
+from src.common.dt_scaler import Metrics
+from src.cells.bath.dt_controller import STController, Targets, step_with_dt_control, run_superstep_plan
 from src.common.dt import SuperstepPlan, SuperstepResult
 
 # Module logger (DEBUG by default so logs appear without extra setup)

--- a/src/cells/softbody/engine/hierarchy.py
+++ b/src/cells/softbody/engine/hierarchy.py
@@ -2,7 +2,8 @@
 import numpy as np
 from dataclasses import dataclass, field
 from typing import List
-from src.cells.bath.dt_controller import Metrics, Targets, STController, step_with_dt_control
+from src.common.dt_scaler import Metrics
+from src.cells.bath.dt_controller import Targets, STController, step_with_dt_control
 import copy
 
 from .mesh import (

--- a/src/common/dt.py
+++ b/src/common/dt.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from src.cells.bath.dt_controller import Metrics
+from src.common.dt_scaler import Metrics
 
 
 @dataclass
@@ -76,7 +76,7 @@ class SuperstepResult:
     clamped:
         True if any halving/clamp events occurred due to instability.
     metrics:
-        The last-step :class:`~src.cells.bath.dt_controller.Metrics` for UI or
+        The last-step :class:`~src.common.dt_scaler.Metrics` for UI or
         logging. Optional and engine-dependent.
     """
     advanced: float

--- a/src/common/dt_scaler.py
+++ b/src/common/dt_scaler.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Common metrics and scaling utilities for adaptive dt control."""
+
+from dataclasses import dataclass
+from typing import Tuple, Optional
+import math
+
+
+@dataclass
+class Metrics:
+    """Simulation diagnostics collected during a micro-step.
+
+    These fields are intentionally generic so they can be shared across
+    simulators. Individual engines may ignore a subset of them.
+    """
+
+    max_vel: float
+    max_flux: float
+    div_inf: float
+    mass_err: float
+    osc_flag: bool = False
+    stiff_flag: bool = False
+
+
+class ScalerControl:
+    """Optional side-channel gain applied after scaling.
+
+    The ``gain`` can be adjusted at runtime to impose additional control on
+    the scaled value. When ``enabled`` is False, :meth:`apply` returns the
+    input unchanged.
+    """
+
+    def __init__(self, gain: float = 1.0, enabled: bool = True) -> None:
+        self.gain = gain
+        self.enabled = enabled
+
+    def apply(self, value: float) -> float:
+        return value * self.gain if self.enabled else value
+
+
+def scale_metric(
+    value: float,
+    window: Tuple[float, float],
+    *,
+    method: str = "linear",
+    compression: str = "none",
+    control: Optional[ScalerControl] = None,
+) -> float:
+    """Scale ``value`` into ``[0, 1]`` according to ``window`` and ``method``.
+
+    Parameters
+    ----------
+    value:
+        Raw metric value to scale.
+    window:
+        ``(lo, hi)`` bounds defining the target range. ``hi`` must be greater
+        than ``lo``.
+    method:
+        ``"harsh"`` performs a step at ``hi``; ``"linear"`` interpolates; and
+        ``"curve"`` applies a smooth nonlinear curve (cubic smoothstep).
+    compression:
+        Optional post-scaling compression: ``"log"`` or ``"sqrt"``.
+    control:
+        Optional :class:`ScalerControl` to apply after scaling.
+    """
+
+    lo, hi = window
+    if hi <= lo:
+        raise ValueError("window upper bound must exceed lower bound")
+    x = (value - lo) / (hi - lo)
+
+    if method == "harsh":
+        scaled = 0.0 if x < 1.0 else 1.0
+    elif method == "curve":
+        x = min(max(x, 0.0), 1.0)
+        scaled = x * x * (3.0 - 2.0 * x)  # cubic smoothstep
+    else:  # linear
+        scaled = min(max(x, 0.0), 1.0)
+
+    if compression == "log":
+        scaled = math.log1p(max(scaled, 0.0))
+    elif compression == "sqrt":
+        scaled = math.sqrt(max(scaled, 0.0))
+
+    if control is not None:
+        scaled = control.apply(scaled)
+    return float(scaled)

--- a/tests/test_dt_controller.py
+++ b/tests/test_dt_controller.py
@@ -1,9 +1,9 @@
 import copy
 
+from src.common.dt_scaler import Metrics
 from src.cells.bath.dt_controller import (
     STController,
     Targets,
-    Metrics,
     step_with_dt_control,
 )
 

--- a/tests/test_dt_scale_response.py
+++ b/tests/test_dt_scale_response.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from src.cells.bath.dt_controller import STController, Targets, Metrics, step_with_dt_control_used
+from src.common.dt_scaler import Metrics
+from src.cells.bath.dt_controller import STController, Targets, step_with_dt_control_used
 
 
 @dataclass

--- a/tests/test_dt_superstep.py
+++ b/tests/test_dt_superstep.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 import pytest
 
 from src.cells.bath.dt_controller import (
-    Metrics,
     Targets,
     STController,
     run_superstep_plan,
 )
+from src.common.dt_scaler import Metrics
 from src.common.dt import SuperstepPlan
 
 


### PR DESCRIPTION
## Summary
- add `dt_scaler` package exposing shared `Metrics`, `ScalerControl`, and `scale_metric` helpers for dt management
- update controllers, fluids, and tests to reference the new metrics package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c0136e24832a9cd4c8ca0f236c7b