### PR TITLE
Allow timestep controller to grow across rounds

### DIFF
--- a/tests/test_dt_superstep.py
+++ b/tests/test_dt_superstep.py
@@ -160,3 +160,22 @@ def test_update_dt_max_decay_envelope():
         f"dt_max did not recover after velocity drop:\n"
         f"after_spike={dt_after_spike:.3e} after_calm={dt_after_calm:.3e}"
     )
+
+
+def test_superstep_returns_unclamped_proposal():
+    """Controller proposals must survive the round cap for next frame."""
+    dx = 1.0
+    targets = Targets(cfl=0.5, div_max=1e-3, mass_max=1e-6)
+    ctrl = STController(dt_min=1e-6)
+
+    state = FakeState()
+
+    def vel_fn(_t):
+        return 0.0
+
+    plan = SuperstepPlan(round_max=1e-6, dt_init=1e-6)
+    res = run_superstep_plan(state, plan, dx, targets, ctrl, make_advance(vel_fn))
+
+    assert res.dt_next > plan.dt_init, (
+        f"expected dt_next > dt_init when velocity is zero; got {res.dt_next}"
+    )


### PR DESCRIPTION
## Summary
- preserve dt controller proposals instead of clamping to in-round caps
- add regression test ensuring superstep returns unclamped dt for zero velocity

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9307a04832ab319ed57f381de39