### PR TITLE
Capture draw-time for HUD timer in softbody demo

### DIFF
--- a/src/opengl_render/api.py
+++ b/src/opengl_render/api.py
@@ -265,7 +265,10 @@ def draw_layers(
     hud = layers.get("hud_text")
     if hud is not None and hasattr(renderer, "set_overlay_text"):
         try:
-            renderer.set_overlay_text(hud)  # type: ignore[call-arg]
+            # Allow ``hud_text`` to be a callable so timestamps can be evaluated
+            # at draw time rather than when the frame was generated.
+            hud_lines = hud() if callable(hud) else hud
+            renderer.set_overlay_text(hud_lines)  # type: ignore[call-arg]
         except Exception:
             pass
 

--- a/tests/test_hud_timer_draws.py
+++ b/tests/test_hud_timer_draws.py
@@ -1,0 +1,48 @@
+import src.opengl_render.api as api
+from src.cells.softbody.demo.numpy_sim_coordinator import DtStats
+import pytest
+
+
+class DummyRenderer:
+    def __init__(self) -> None:
+        self.overlay = None
+
+    def set_overlay_text(self, text):
+        self.overlay = text
+
+    def draw(self, viewport):  # pragma: no cover - side-effect free
+        pass
+
+    def set_mesh(self, mesh):  # pragma: no cover - side-effect free
+        pass
+
+    def set_lines(self, lines):  # pragma: no cover - side-effect free
+        pass
+
+    def set_points(self, pts):  # pragma: no cover - side-effect free
+        pass
+
+    def set_mvp(self, mvp):  # pragma: no cover - side-effect free
+        pass
+
+
+def test_hud_text_callable_updates_real_time(monkeypatch: pytest.MonkeyPatch):
+    """``hud_text`` callables should be evaluated during drawing."""
+
+    class _Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    # Replace OpenGL-dependent layer classes with simple stand-ins so the
+    # helper can run in this headless test environment.
+    monkeypatch.setattr(api, "MeshLayer", _Dummy, raising=False)
+    monkeypatch.setattr(api, "LineLayer", _Dummy, raising=False)
+    monkeypatch.setattr(api, "PointLayer", _Dummy, raising=False)
+
+    stats = DtStats()
+    renderer = DummyRenderer()
+    assert stats.real_t == 0.0
+    api.draw_layers(renderer, {"hud_text": stats.lines})
+    assert stats.real_t > 0.0
+    assert renderer.overlay is not None
+    assert any(line.startswith("real t:") for line in renderer.overlay)


### PR DESCRIPTION
## Summary
- Capture wall-clock timestamp when frames are drawn and store in `DtStats`
- Let render helpers evaluate `hud_text` callables at draw time and forward updated timer to HUD
- Cover draw-time timing update with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d3b100e4832abcc03a053359e8fd