### PR TITLE
Add sim frame counter to dt metrics

### DIFF
--- a/src/common/dt_scaler.py
+++ b/src/common/dt_scaler.py
@@ -12,7 +12,9 @@ class Metrics:
     """Simulation diagnostics collected during a micro-step.
 
     These fields are intentionally generic so they can be shared across
-    simulators. Individual engines may ignore a subset of them.
+    simulators. Individual engines may ignore a subset of them. ``sim_frame``
+    tracks the outer simulation frame index associated with the metrics, which
+    can be useful when aggregating statistics across frames.
     """
 
     max_vel: float
@@ -21,6 +23,7 @@ class Metrics:
     mass_err: float
     osc_flag: bool = False
     stiff_flag: bool = False
+    sim_frame: int = 0
 
 
 class ScalerControl:

--- a/tests/test_dt_scale_response.py
+++ b/tests/test_dt_scale_response.py
@@ -64,7 +64,7 @@ def test_dt_scaler_step_response(capsys):
         # Metrics for current loop index (bound via closure on v_series length)
         i = len(v_series)
         v = _schedule_piecewise(i)
-        m = Metrics(max_vel=v, max_flux=v, div_inf=0.0, mass_err=0.0)
+        m = Metrics(max_vel=v, max_flux=v, div_inf=0.0, mass_err=0.0, sim_frame=i)
         return True, m
 
     for i in range(N):


### PR DESCRIPTION
## Summary
- track outer loop simulation frame on dt metrics via new `sim_frame` field
- supply `sim_frame` in dt scaler response test metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0d72ef2d4832a8d0c6b7a2d910e02