### PR TITLE
Fix damping sign and add fluid cage with wrapping

### DIFF
--- a/src/cells/bath/adapter.py
+++ b/src/cells/bath/adapter.py
@@ -141,7 +141,19 @@ class SPHAdapter(BathAdapter):
             vmax = float(np.max(np.linalg.norm(state.v, axis=1))) if state.N > 0 else 0.0
             mass_now = float(np.sum(state.m))
             mass_err = abs(mass_now - prev_mass) / max(prev_mass, 1e-12)
-            metrics = type("M", (), {"max_vel": vmax, "max_flux": vmax, "div_inf": 0.0, "mass_err": mass_err, "osc_flag": False, "stiff_flag": False})()
+            metrics = type(
+                "M",
+                (),
+                {
+                    "max_vel": vmax,
+                    "max_flux": vmax,
+                    "div_inf": 0.0,
+                    "mass_err": mass_err,
+                    "osc_flag": False,
+                    "stiff_flag": False,
+                    "dt_limit": None,
+                },
+            )()
             return True, metrics
         plan = SuperstepPlan(round_max=float(round_max), dt_init=float(self._dt_curr or 1e-6), allow_increase_mid_round=bool(allow_increase_mid_round))
         # For SPH, use smoothing length as spatial scale for CFL
@@ -240,6 +252,7 @@ class MACAdapter(BathAdapter):
                         "mass_err": 0.0,
                         "osc_flag": False,
                         "stiff_flag": False,
+                        "dt_limit": None,
                     },
                 )()
                 return True, metrics
@@ -349,6 +362,7 @@ class HybridAdapter(BathAdapter):
                         "mass_err": 0.0,
                         "osc_flag": False,
                         "stiff_flag": False,
+                        "dt_limit": None,
                     },
                 )()
                 return True, metrics

--- a/src/cells/bath/voxel_fluid.py
+++ b/src/cells/bath/voxel_fluid.py
@@ -164,6 +164,13 @@ class VoxelMACFluid:
             self.T[I, J, K] += (dT[i] * w).reshape(I.shape)
             self.S[I, J, K] = np.clip(self.S[I, J, K] + (dS[i] * w).reshape(I.shape), 0.0, 1.0)
 
+    def minvelocity(self, max_vel: float) -> None:
+        """Clamp all velocity components to ``[-max_vel, max_vel]``."""
+        vmax = float(max_vel)
+        self.u = np.clip(self.u, -vmax, vmax)
+        self.v = np.clip(self.v, -vmax, vmax)
+        self.w = np.clip(self.w, -vmax, vmax)
+
     def add_momentum_sources(self, centers_world: np.ndarray, force_world: np.ndarray, radius: float) -> None:
         """Distribute body force density (N/m^3) to velocities via face weights; crude but useful for jets."""
         assert centers_world.shape == force_world.shape

--- a/src/common/dt_system/classic_mechanics/engines.py
+++ b/src/common/dt_system/classic_mechanics/engines.py
@@ -200,7 +200,8 @@ class PneumaticDamperEngine(DtCompatibleEngine):
             along = rel_v[0] * dir_[0] + rel_v[1] * dir_[1]
             damp_a, damp_b = self.s.pneu_damp[(i, j)]
             coeff = damp_a if along > 0 else damp_b
-            f = v_scale(dir_, -eff * coeff * along)
+            # Apply damping opposite to relative motion so the pair slows down
+            f = v_scale(dir_, eff * coeff * along)
             self.s.acc[i] = v_add(self.s.acc[i], v_scale(f, +1.0 / max(self.s.mass[i], 1e-9)))
             self.s.acc[j] = v_add(self.s.acc[j], v_scale(f, -1.0 / max(self.s.mass[j], 1e-9)))
         return True, Metrics(0.0, 0.0, 0.0, 0.0)

--- a/src/common/dt_system/solids/api.py
+++ b/src/common/dt_system/solids/api.py
@@ -57,7 +57,7 @@ class SolidMesh:
     vertices: np.ndarray  # shape (N, 3), dtype=float32/64
     faces: Optional[np.ndarray] = None  # shape (M, 3), dtype=int32/64
     name: str = "solid"
-    material: SurfaceMaterial = MATERIAL_ELASTIC
+    material: SurfaceMaterial = field(default_factory=lambda: MATERIAL_ELASTIC)
 
     def as_vertex_array(self) -> np.ndarray:
         v = np.asarray(self.vertices)
@@ -130,7 +130,7 @@ class WorldPlane:
 
     normal: np.ndarray  # shape (3,)
     offset: float  # d in plane equation
-    material: SurfaceMaterial = MATERIAL_ELASTIC
+    material: SurfaceMaterial = field(default_factory=lambda: MATERIAL_ELASTIC)
     # Optional plane-level fluid boundary override: "wrap" or "respawn"
     fluid_mode: Optional[Literal["wrap", "respawn"]] = None
 

--- a/src/opengl_render/api.py
+++ b/src/opengl_render/api.py
@@ -27,7 +27,30 @@ from .double_buffer import DoubleBuffer
 try:  # pragma: no cover - tolerate missing OpenGL libs
     from .renderer import MeshLayer, LineLayer, PointLayer, GLRenderer
 except Exception:  # noqa: BLE001
-    MeshLayer = LineLayer = PointLayer = GLRenderer = object  # type: ignore[misc,assignment]
+    from dataclasses import dataclass
+    import numpy as _np
+
+    @dataclass
+    class MeshLayer:  # minimal fallback with attribute storage
+        positions: _np.ndarray
+        indices: _np.ndarray | None = None
+        colors: _np.ndarray | None = None
+
+    @dataclass
+    class LineLayer:
+        positions: _np.ndarray
+        colors: _np.ndarray | None = None
+        width: float = 2.0
+
+    @dataclass
+    class PointLayer:
+        positions: _np.ndarray
+        colors: _np.ndarray | None = None
+        sizes_px: _np.ndarray | None = None
+        size_px_default: float = 6.0
+
+    class GLRenderer:  # type: ignore[empty-body]
+        pass
 
 if TYPE_CHECKING:  # for type hints only
     from .renderer import GLRenderer as _GLRenderer_T

--- a/tests/test_pneumatic_damper_engine.py
+++ b/tests/test_pneumatic_damper_engine.py
@@ -1,0 +1,19 @@
+import numpy as np
+from src.common.dt_system.classic_mechanics.engines import DemoState, PneumaticDamperEngine
+
+def test_pneumatic_damper_slows_relative_motion():
+    s = DemoState(
+        pos=[(0.0, 0.0), (1.0, 0.0)],
+        vel=[(0.0, 0.0), (1.0, 0.0)],
+        acc=[(0.0, 0.0), (0.0, 0.0)],
+        mass=[1.0, 1.0],
+        springs=[(0, 1)],
+        rest_len={(0, 1): 1.0},
+        k_spring={(0, 1): 0.0},
+        pneu_damp={(0, 1): (1.0, 1.0)},
+        ground_k=0.0,
+    )
+    eng = PneumaticDamperEngine(s)
+    eng.step(0.1)
+    assert s.acc[0][0] > 0
+    assert s.acc[1][0] < 0


### PR DESCRIPTION
## Summary
- correct pneumatic damper forces so springs dissipate energy
- add configurable world cage with wrapping fluid boundaries in pygame demo
- provide headless OpenGL layer stubs and VoxelMACFluid velocity clamp

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a18217d868832a8a778678ec74a833