### PR TITLE
Enforce explicit engine registration in dt-system

### DIFF
--- a/src/common/dt_system/engine_api.py
+++ b/src/common/dt_system/engine_api.py
@@ -12,7 +12,7 @@ nonlinearize dt proposals relative to metric ranges.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Optional, Iterable, Mapping, Any
 
 from .dt_scaler import Metrics
 from .dt_controller import Targets, STController
@@ -45,11 +45,57 @@ class DtCompatibleEngine:
     def step(self, dt: float, state, state_table) -> tuple[bool, Metrics]:  # pragma: no cover - interface
         raise NotImplementedError
 
+    # --- Registration -------------------------------------------------
+    def register(
+        self,
+        state_table,
+        schema: Callable[[Any], Mapping[str, Any]],
+        items: Iterable[Any],
+        *,
+        group_label: Optional[str] = None,
+        dedup: bool = True,
+    ) -> list[str]:
+        """Register a set of identities with ``state_table``.
+
+        ``schema`` maps each item in ``items`` to a dict describing the
+        identity fields (at minimum ``pos`` and optional ``mass``). Any
+        additional fields are merged into the identity object after
+        creation. Registered UUIDs are tracked internally so stepping
+        without prior registration raises an error.
+        """
+        if state_table is None:
+            raise ValueError("state_table is required for registration")
+
+        self._state_table = state_table
+        existing = getattr(self, "_registration", set())
+        uuids: list[str] = []
+        for item in items:
+            data = dict(schema(item))
+            pos = data.get("pos")
+            mass = data.get("mass", 0.0)
+            uuid_str = state_table.register_identity(pos, mass, dedup=dedup)
+            identity = state_table.get_identity(uuid_str)
+            for k, v in data.items():
+                if k not in ("pos", "mass") and identity is not None:
+                    identity[k] = v
+            uuids.append(uuid_str)
+        if group_label is not None:
+            state_table.register_group(group_label, set(uuids))
+        existing.update(uuids)
+        self._registration = existing
+        return uuids
+
+    def _require_registration(self) -> None:
+        if getattr(self, "_registration", None) is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} has no registered identities; call register() first"
+            )
+
     # New required capability for compliant engines
     def step_with_state(
         self, state: object, dt: float, *, realtime: bool = False, state_table = None
     ) -> tuple[bool, Metrics, object]:  # pragma: no cover - default bridge
-        
+
         self.world_time += dt
 
         if isinstance(self.causal_ceiling_dt, float) and self.causal_ceiling_dt < dt or isinstance(self.causal_ceiling_dt, Callable) and self.causal_ceiling_dt() < dt:
@@ -67,6 +113,10 @@ class DtCompatibleEngine:
             state_table = getattr(self, '_state_table', None)
         if state_table is None:
             raise ValueError("state_table is required for step_with_state")
+        if getattr(self, "_registration", None) is None:
+            raise RuntimeError(
+                f"{self.__class__.__name__} has no registered identities; call register() first"
+            )
         ok, m, state = self.step(float(dt), state, state_table=state_table)
         state = self.get_state() if state is None else state
         return ok, m, state

--- a/src/common/dt_system/fluid_mechanics/discrete_fluid_engine.py
+++ b/src/common/dt_system/fluid_mechanics/discrete_fluid_engine.py
@@ -126,8 +126,8 @@ class BathDiscreteFluidEngine(DtCompatibleEngine):
                 bounds_min=(float(sim_min[0]), float(sim_min[1]), float(sim_min[2])),
                 bounds_max=(float(sim_max[0]), float(sim_max[1]), float(sim_max[2])),
             )
-        else:
-            exit()
+        elif self.sim is None:
+            raise RuntimeError("BathDiscreteFluidEngine requires a DiscreteFluid simulation")
         self.causal_ceiling_dt = getattr(self.sim, "_stable_dt", None)
 
     # -------- Bridge factories ------------------------------------------------

--- a/tests/test_discrete_fluid_dt_sidechain.py
+++ b/tests/test_discrete_fluid_dt_sidechain.py
@@ -35,7 +35,7 @@ def test_discrete_fluid_dt_sidechain_clamps_next_dt():
 
     # Advance callback integrates via the engine to capture its Metrics (with dt_limit)
     def advance(state, dt):
-        ok, m = eng.step(float(dt))
+        ok, m, _ = eng.step(float(dt))
         return ok, m
 
     # Use the fluid as the 'state' since it provides copy_shallow/restore

--- a/tests/test_pneumatic_damper_engine.py
+++ b/tests/test_pneumatic_damper_engine.py
@@ -1,5 +1,6 @@
 import numpy as np
 from src.common.dt_system.classic_mechanics.engines import DemoState, PneumaticDamperEngine
+from src.common.dt_system.state_table import StateTable
 
 def test_pneumatic_damper_slows_relative_motion():
     s = DemoState(
@@ -13,7 +14,9 @@ def test_pneumatic_damper_slows_relative_motion():
         pneu_damp={(0, 1): (1.0, 1.0)},
         ground_k=0.0,
     )
-    eng = PneumaticDamperEngine(s)
-    eng.step(0.1)
-    assert s.acc[0][0] > 0
-    assert s.acc[1][0] < 0
+    table = StateTable()
+    eng = PneumaticDamperEngine(s, state_table=table)
+    eng.step(0.1, state_table=table)
+    u0, u1 = eng.uuids
+    assert table.identity_registry[u0]['acc'][0] > 0
+    assert table.identity_registry[u1]['acc'][0] < 0


### PR DESCRIPTION
## Summary
- add unified `register` API on `DtCompatibleEngine` and guard steps without registration
- refactor classic mechanics engines to use centralized registration and fail early if unregistered
- remove stray `exit()` from BathDiscreteFluidEngine setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a325398ebc832ab38e53f05d85333d