### PR TITLE
feat(dt): allow engines to expose compute shaders

### DIFF
--- a/src/transmogrifier/glsl/__init__.py
+++ b/src/transmogrifier/glsl/__init__.py
@@ -1,0 +1,4 @@
+"""GLSL utilities for transpiling dt engine shader specs."""
+from .monolith import MonolithicShader
+
+__all__ = ["MonolithicShader"]

--- a/src/transmogrifier/glsl/monolith.py
+++ b/src/transmogrifier/glsl/monolith.py
@@ -1,0 +1,45 @@
+"""Helpers for assembling GLSL compute shaders."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from ...common.dt_system.engine_api import ComputeShaderSpec
+
+
+@dataclass
+class MonolithicShader:
+    """Bundle multiple :class:`ComputeShaderSpec` objects into a single source.
+
+    The builder concatenates shader sources and merges buffer mappings while
+    preserving the order provided. It performs no validation beyond ensuring
+    buffer name uniqueness.
+    """
+
+    source: str
+    buffers: Mapping[str, object]
+
+    @classmethod
+    def from_specs(
+        cls, specs: Iterable[ComputeShaderSpec], *, version: str = "#version 450"
+    ) -> "MonolithicShader":
+        """Create a monolithic shader from engine specifications.
+
+        Parameters
+        ----------
+        specs:
+            Iterable of :class:`ComputeShaderSpec` objects describing shader
+            stages.
+        version:
+            GLSL version directive to prepend. Defaults to ``"#version 450"``.
+        """
+        parts = [version]
+        buffers: dict[str, object] = {}
+        for spec in specs:
+            parts.append(f"// {spec.name}")
+            parts.append(spec.source)
+            for name, buf in spec.buffers.items():
+                if name in buffers:
+                    raise ValueError(f"buffer '{name}' already bound")
+                buffers[name] = buf
+        return cls("\n".join(parts), buffers)

--- a/tests/dt_system/test_engine_compute_shader_api.py
+++ b/tests/dt_system/test_engine_compute_shader_api.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from src.common.dt_system.engine_api import DtCompatibleEngine, ComputeShaderSpec
+from src.common.dt_system.dt_scaler import Metrics
+
+
+class DummyEngine(DtCompatibleEngine):
+    """Minimal engine exposing a compute shader spec."""
+
+    def __init__(self):
+        super().__init__()
+        self.buf_in = np.zeros(4, dtype=np.float32)
+        self.buf_out = np.zeros(4, dtype=np.float32)
+
+    def step(self, dt: float, state, state_table):
+        return True, Metrics(), state
+
+    def get_state(self, state=None):
+        return state
+
+    def get_compute_shaders(self):
+        src = "layout(local_size_x = 1) in; void main() { }"
+        return [
+            ComputeShaderSpec(
+                name="pass0",
+                source=src,
+                buffers={"in": self.buf_in, "out": self.buf_out},
+                next=["pass1"],
+            )
+        ]
+
+
+def test_engine_provides_compute_spec():
+    eng = DummyEngine()
+    specs = eng.get_compute_shaders()
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.name == "pass0"
+    assert spec.next == ["pass1"]
+    assert spec.buffers["in"].shape == (4,)
+    assert spec.buffers["in"] is not None
+    # Ensure buffers are passed through without conversion
+    assert spec.buffers["in"] is eng.buf_in

--- a/tests/transmogrifier/test_glsl_monolith.py
+++ b/tests/transmogrifier/test_glsl_monolith.py
@@ -1,0 +1,29 @@
+from src.common.dt_system.engine_api import ComputeShaderSpec
+from src.transmogrifier.glsl import MonolithicShader
+
+
+def test_monolithic_shader_concatenates_sources_and_buffers():
+    a_buf, b_buf = object(), object()
+    specs = [
+        ComputeShaderSpec(name="a", source="void main(){}", buffers={"in": a_buf}),
+        ComputeShaderSpec(name="b", source="void main2(){}", buffers={"out": b_buf}),
+    ]
+    monolith = MonolithicShader.from_specs(specs)
+    assert monolith.buffers == {"in": a_buf, "out": b_buf}
+    assert "#version" in monolith.source
+    assert "void main(){}" in monolith.source
+    assert "void main2(){}" in monolith.source
+
+
+def test_buffer_name_collision_raises():
+    shared = object()
+    specs = [
+        ComputeShaderSpec(name="a", source="void main(){}", buffers={"buf": shared}),
+        ComputeShaderSpec(name="b", source="void main2(){}", buffers={"buf": shared}),
+    ]
+    try:
+        MonolithicShader.from_specs(specs)
+    except ValueError as exc:
+        assert "buffer 'buf'" in str(exc)
+    else:  # pragma: no cover
+        assert False, "expected collision to raise"


### PR DESCRIPTION
## Summary
- add `ComputeShaderSpec` dataclass so engines can describe GPU compute stages and buffers
- let `DtCompatibleEngine` expose compute shader specs via new `get_compute_shaders` hook
- add GLSL `MonolithicShader` helper to join engine specs into a single source
- cover compute shader spec API and GLSL assembler with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a34ffdf1a8832a9d15e7652fc8f8d2