### PR TITLE
Document tensor modules and add backend tests

### DIFF
--- a/MODULES.md
+++ b/MODULES.md
@@ -44,6 +44,21 @@ A hyperlinked index of modules and capabilities in this repository.
 - [src/hardware/lane_tuner.py](src/hardware/lane_tuner.py)
 - [src/hardware/nand_wave.py](src/hardware/nand_wave.py)
 
+## src/tensors
+
+- [src/tensors/__init__.py](src/tensors/__init__.py)
+- [src/tensors/abstraction.py](src/tensors/abstraction.py)
+- [src/tensors/pure_backend.py](src/tensors/pure_backend.py)
+- [src/tensors/numpy_backend.py](src/tensors/numpy_backend.py)
+- [src/tensors/torch_backend.py](src/tensors/torch_backend.py)
+- [src/tensors/jax_backend.py](src/tensors/jax_backend.py)
+- accelerator_backends
+  - [src/tensors/accelerator_backends/c_backend.py](src/tensors/accelerator_backends/c_backend.py)
+  - [src/tensors/accelerator_backends/rust_backend/__init__.py](src/tensors/accelerator_backends/rust_backend/__init__.py)
+  - [src/tensors/accelerator_backends/glsl_kernels/__init__.py](src/tensors/accelerator_backends/glsl_kernels/__init__.py)
+- models
+  - [src/tensors/models/__init__.py](src/tensors/models/__init__.py)
+
 ## src/turing_machine
 
 - [src/turing_machine/__init__.py](src/turing_machine/__init__.py)

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ Below is a current inventory of the repository’s Python modules, grouped by pa
 - `lane_tuner.py` — frequency lane tuning and helpers
 - `nand_wave.py` — NAND tone synthesis/decoding
 
+### src/tensors
+
+- `abstraction.py` — shared `AbstractTensor` interface and backend registry
+- `pure_backend.py` — reference backend built on nested Python lists
+- `numpy_backend.py`, `torch_backend.py`, `jax_backend.py` — NumPy, PyTorch, and JAX implementations
+- `accelerator_backends/` — experimental C, Rust, and GLSL kernels
+- `models/` — higher level tensor utilities
+
 ### src/turing_machine
 
 - `__init__.py`

--- a/tests/test_math_rodeo.py
+++ b/tests/test_math_rodeo.py
@@ -1,10 +1,8 @@
 import pytest
 import numpy as np
 
-from src.tensors import (
-    AbstractTensor,
-    PurePythonTensorOperations,
-)
+from src.tensors.abstraction import AbstractTensor
+from src.tensors.pure_backend import PurePythonTensorOperations
 
 # Try to import optional backends
 try:
@@ -104,3 +102,4 @@ def test_math_rodeo(backend_name, BackendCls):
         print(f"[FAILURES] {backend_name}: {failures}")
     else:
         print(f"[SUCCESS] {backend_name}: All math ops passed!")
+    assert not failures

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -1,0 +1,36 @@
+import pytest
+
+from src.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.tensors.torch_backend import PyTorchTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    PyTorchTensorOperations = None
+
+try:
+    from src.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    NumPyTensorOperations = None
+
+try:
+    from src.tensors.jax_backend import JAXTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    JAXTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+if PyTorchTensorOperations is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+if JAXTensorOperations is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_basic_add_and_zeros(backend_name, Backend):
+    a = Backend.tensor_from_list([[1, 2], [3, 4]])
+    b = Backend.tensor_from_list([[5, 6], [7, 8]])
+    result = a + b
+    assert result.tolist() == [[6, 8], [10, 12]]
+    zeros = Backend.zeros((2, 2))
+    assert zeros.tolist() == [[0, 0], [0, 0]]


### PR DESCRIPTION
## Summary
- document tensor backends in README and module index
- add basic backend-agnostic tensor tests
- harden math rodeo test to report failures

## Testing
- `pytest` *(fails: `TypeError: 'NoneType' object is not callable`)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c5767ecc832a8831a2b452da3283