### PR TITLE
Implement ShapeAccessor interface

### DIFF
--- a/src/rendering/ascii_diff/ascii_kernel_classifier.py
+++ b/src/rendering/ascii_diff/ascii_kernel_classifier.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+from pathlib import Path
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 from ...tensors import AbstractTensor, Faculty
@@ -26,18 +27,21 @@ def _backend_torch(ops: AbstractTensor) -> bool:
     """Return True if ``ops`` uses a PyTorch backend."""
     return isinstance(ops, PyTorchTensorOperations)
 
+DEFAULT_FONT_PATH = Path(__file__).with_name("consola.ttf")
+
+
 class AsciiKernelClassifier:
     def __init__(
         self,
         ramp: str,
-        font_path: str = "C:\\dev\\Powershell\\turing\\src\\rendering\\ascii_diff\\consola.ttf",
+        font_path: str | Path = DEFAULT_FONT_PATH,
         font_size: int = 16,
         char_size: tuple[int, int] = (16, 16),
         loss_mode: str = "sad",
     ) -> None:
         self.ramp = ramp
         self.vocab_size = len(ramp)
-        self.font_path = font_path
+        self.font_path = str(font_path)
         self.font_size = font_size
         self.char_size = char_size
         self.loss_mode = loss_mode  # "sad" or "ssim"

--- a/src/rendering/ascii_diff/demo.py
+++ b/src/rendering/ascii_diff/demo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from PIL import Image
 import numpy as np
 import sys
@@ -13,6 +14,9 @@ from .draw import (
     default_subunit_batch_to_chars,
 )
 from .console import full_clear_and_reset_cursor, reset_cursor_to_top
+
+# Module-relative default image path
+DEFAULT_IMAGE_PATH = Path(__file__).with_name("analogback.png")
 
 
 def load_pixels(path: str) -> np.ndarray:
@@ -44,7 +48,6 @@ def main(image_path: str) -> None:
 
 
 if __name__ == "__main__":
-    import sys
-    img_path = sys.argv[1] if len(sys.argv) > 1 else "C:\\dev\\Powershell\\turing\\src\\rendering\\ascii_diff\\analogback.png"
-    main(img_path)
+    img_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_IMAGE_PATH
+    main(str(img_path))
 

--- a/src/rendering/ascii_diff/draw.py
+++ b/src/rendering/ascii_diff/draw.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 import numpy as np
 from colorama import Style, Fore, Back
+from pathlib import Path
 from .ascii_kernel_classifier import AsciiKernelClassifier
 
 
@@ -62,6 +63,9 @@ _classifier_cache = {
     "classifier": None,
 }
 
+# Module-relative default font path
+DEFAULT_FONT_PATH = Path(__file__).with_name("consola.ttf")
+
 def default_subunit_batch_to_chars(
     subunit_batch: np.ndarray,
     ramp: str = DEFAULT_DRAW_ASCII_RAMP,
@@ -79,7 +83,7 @@ def default_subunit_batch_to_chars(
         # AsciiKernelClassifier expects char_size as (width, height)
         classifier = AsciiKernelClassifier(ramp, char_size=(char_width, char_height))
         # font_size is for rendering reference characters, which are then scaled to char_size
-        classifier.set_font(font_path="C:\\dev\\Powershell\\turing\\src\\rendering\\ascii_diff\\consola.ttf", font_size=16, char_size=(char_width, char_height))
+        classifier.set_font(font_path=str(DEFAULT_FONT_PATH), font_size=16, char_size=(char_width, char_height))
         _classifier_cache["ramp_char_size"] = cache_key
         _classifier_cache["classifier"] = classifier
     else:

--- a/src/tensors/abstraction.py
+++ b/src/tensors/abstraction.py
@@ -37,8 +37,31 @@ def register_conversion(*args, **kwargs):
 CONVERSION_REGISTRY = dict()
 DEBUG = False
 class ShapeAccessor:
+    """Utility wrapper exposing tensor ``shape`` like NumPy/PyTorch."""
+
     def __init__(self, tensor):
         self.tensor = tensor
+
+    def _shape_tuple(self) -> tuple[int, ...]:
+        """Fetch the concrete shape tuple from the underlying tensor."""
+        # ``shape_`` is the backend hook returning a tuple[int, ...]
+        return self.tensor.shape_()
+
+    # Iterable / sequence protocol -------------------------------------------------
+    def __call__(self) -> tuple[int, ...]:
+        return self._shape_tuple()
+
+    def __iter__(self):
+        return iter(self._shape_tuple())
+
+    def __len__(self) -> int:
+        return len(self._shape_tuple())
+
+    def __getitem__(self, idx):
+        return self._shape_tuple()[idx]
+
+    def __repr__(self) -> str:
+        return repr(self._shape_tuple())
 
 
 # --- Backend Registry Pattern ---


### PR DESCRIPTION
## Summary
- flesh out ShapeAccessor so it behaves like a tuple
- resolve TypeError when accessing tensor shapes
- use module-relative paths for demo assets and fonts

## Testing
- `TERM=dumb python -m src.rendering.ascii_diff.demo` *(fails: stack trace terminates during charset preparation)*
- `pytest` *(fails: TypeError: 'NoneType' object is not callable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c6b005d4832aab4c2a8a9213f627