### PR TITLE
Fix tensor shape handling in ASCII classifier and backend utilities

### DIFF
--- a/src/tensors/numpy_backend.py
+++ b/src/tensors/numpy_backend.py
@@ -127,8 +127,8 @@ class NumPyTensorOperations(AbstractTensor):
     def zeros_(self, size, dtype, device):
         return np.zeros(size, dtype=self._torch_dtype_to_numpy(dtype))
 
-    def clone_(self, tensor):
-        tensor = self._AbstractTensor__unwrap(tensor)
+    def clone_(self, tensor=None):
+        tensor = self._AbstractTensor__unwrap(tensor if tensor is not None else self.data)
         return np.array(tensor, copy=True)
 
     def to_device_(self, tensor, device):
@@ -329,8 +329,9 @@ class NumPyTensorOperations(AbstractTensor):
             arr = arr.astype(self._torch_dtype_to_numpy(dtype))
         return arr
 
-    def to_dtype_(self, tensor, dtype: str = "float"):
+    def to_dtype_(self, dtype: str = "float"):
         import numpy as np
+        tensor = self.data
         if dtype in ("float", "float32", "f32"):
             return tensor.astype(np.float32)
         elif dtype in ("float64", "double", "f64"):


### PR DESCRIPTION
## Summary
- Use backend-agnostic shape access in `AsciiKernelClassifier`
- Repair NumPy backend utilities for cloning and dtype conversion
- Lazily register tensor backends and sanitize dtype during conversions

## Testing
- `python - <<'PY'
import numpy as np
from src.rendering.ascii_diff.ascii_kernel_classifier import AsciiKernelClassifier
clf = AsciiKernelClassifier(' .:-')
batch = np.zeros((1,8,8,3), dtype=np.uint8)
print(clf.classify_batch(batch))
PY`
- `pytest` *(fails: JAX initialization; math_rodeo; tensor basic ops)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cda1f0a8832abe99baa7c3390464