### PR TITLE
Integrate timesync clock assets into ascii_diff

### DIFF
--- a/src/rendering/ascii_diff/README.md
+++ b/src/rendering/ascii_diff/README.md
@@ -1,10 +1,19 @@
 # ASCII Diff Package
 
-This package provides a minimal copy of the image-to-ASCII pipeline from the `timesync` clock demo.
-It includes an `AsciiKernelClassifier`, a `PixelFrameBuffer`, and drawing helpers for diff-based rendering.
+This package began as a minimal copy of the image‑to‑ASCII pipeline from the `timesync` clock demo.
+It now also carries the reusable clock and theme utilities so the clock can run directly under
+`ascii_diff` without depending on the full `timesync` project.
 
-Run the demo to display a flipped image diff:
+Available demos:
 
-```bash
-python ascii_diff/demo.py
-```
+* **Image diff** – flips an image and renders the changes:
+
+  ```bash
+  python ascii_diff/demo.py
+  ```
+
+* **Analog clock** – renders an animated clock using theme presets:
+
+  ```bash
+  python ascii_diff/clock_demo.py
+  ```

--- a/src/rendering/ascii_diff/__init__.py
+++ b/src/rendering/ascii_diff/__init__.py
@@ -9,6 +9,10 @@ from .draw import (
     get_changed_subunits,
 )
 from .console import full_clear_and_reset_cursor, reset_cursor_to_top
+from .clock_renderer import ClockRenderer
+from .theme_manager import ThemeManager
+from .time_units import TimeUnit
+from .render_backend import RenderingBackend
 
 __all__ = [
     "AsciiKernelClassifier",
@@ -20,5 +24,9 @@ __all__ = [
     "get_changed_subunits",
     "full_clear_and_reset_cursor",
     "reset_cursor_to_top",
+    "ClockRenderer",
+    "ThemeManager",
+    "TimeUnit",
+    "RenderingBackend",
 ]
 

--- a/src/rendering/ascii_diff/clock_demo.py
+++ b/src/rendering/ascii_diff/clock_demo.py
@@ -1,0 +1,47 @@
+import datetime as _dt
+import time
+import numpy as np
+from PIL import Image
+
+from .clock_renderer import ClockRenderer
+from .theme_manager import ThemeManager
+from .draw import get_changed_subunits, draw_diff, default_subunit_batch_to_chars
+from .console import full_clear_and_reset_cursor, reset_cursor_to_top
+
+
+def main() -> None:
+    """Render a simple analog clock in the terminal using ASCII diff."""
+    theme_manager = ThemeManager()
+    # use default theme's active units
+    units = theme_manager.current_theme.active_time_units
+    # choose pixel diameter that maps nicely to character cells
+    char_h = char_w = 16
+    canvas_size = char_h * 12
+
+    old_frame = np.zeros((canvas_size, canvas_size, 3), dtype=np.uint8)
+    full_clear_and_reset_cursor()
+
+    while True:
+        now = _dt.datetime.utcnow()
+        img = ClockRenderer.render_analog(
+            now,
+            units=units,
+            canvas_size_px=canvas_size,
+            theme_manager=theme_manager,
+        )
+        frame = np.array(img.convert("RGB"))
+        changed = get_changed_subunits(old_frame, frame, char_h, char_w)
+        draw_diff(
+            changed,
+            char_cell_pixel_height=char_h,
+            char_cell_pixel_width=char_w,
+            subunit_to_char_kernel=default_subunit_batch_to_chars,
+            active_ascii_ramp=theme_manager.get_current_ascii_ramp(),
+        )
+        old_frame = frame
+        reset_cursor_to_top()
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rendering/ascii_diff/clock_renderer.py
+++ b/src/rendering/ascii_diff/clock_renderer.py
@@ -1,0 +1,179 @@
+import datetime as _dt
+import math
+from typing import List, Optional, Tuple, Dict, Any
+from PIL import Image, ImageDraw, ImageFont
+from .time_units import TimeUnit
+from .theme_manager import ThemeManager
+from .render_backend import RenderingBackend
+
+class ClockRenderer:
+    @staticmethod
+    def render_analog(
+        time_obj: _dt.datetime | _dt.timedelta,
+        units: Optional[List[TimeUnit]] = None,
+        canvas_size_px: Optional[int] = None,
+        bounding_size: Optional[Tuple[int, int]] = None,  # (width, height) to auto‐size/center
+        backdrop_image_path: Optional[str] = None,
+        theme_manager: Optional[ThemeManager] = None,
+        render_backend: Optional[RenderingBackend] = None,
+        **params: Any
+    ) -> Image.Image:
+        """
+        Draw an analog clock face.
+        If bounding_size=(w,h) is provided and canvas_size_px is None,
+        the clock diameter = min(w,h) and is centered in that box.
+        """
+        # --- determine canvas dimensions & center ---
+        if bounding_size:
+            bw, bh = bounding_size
+            dia = canvas_size_px or min(bw, bh)
+            base = Image.new("RGBA", (bw, bh), (0, 0, 0, 0))
+            draw = ImageDraw.Draw(base)
+            cx, cy = bw // 2, bh // 2
+        else:
+            dia = canvas_size_px or 120
+            # load or new square canvas
+            if backdrop_image_path:
+                try:
+                    base = Image.open(backdrop_image_path).convert("RGBA")
+                    base = base.resize((dia, dia), Image.Resampling.LANCZOS)
+                except Exception:
+                    base = Image.new("RGBA", (dia, dia), (0, 0, 0, 0))
+            else:
+                base = Image.new("RGBA", (dia, dia), (0, 0, 0, 0))
+            draw = ImageDraw.Draw(base)
+            cx = cy = dia // 2
+        radius = dia // 2 - dia // 20
+
+        # --- draw face outline ---
+        stroke = max(1, dia // 50)
+        draw.ellipse(
+            (cx - radius, cy - radius, cx + radius, cy + radius),
+            outline=params.get("face_color", (70, 70, 70, 255)), width=stroke
+        )
+
+        # --- marks ---
+        major_w = max(1, dia // 60)
+        minor_w = max(1, dia // 100)
+        for i in range(12):
+            ang = math.radians(i * 30 - 90)
+            outer = radius
+            inner = radius * (0.88 if i % 3 == 0 else 0.92)
+            x1, y1 = cx + inner * math.cos(ang), cy + inner * math.sin(ang)
+            x2, y2 = cx + outer * math.cos(ang), cy + outer * math.sin(ang)
+            draw.line((x1, y1, x2, y2),
+                      fill=params.get("marks_color", (220, 220, 200, 255)),
+                      width=(major_w if i % 3 == 0 else minor_w))
+
+        # --- hands ---
+        if units is None:
+            units = []
+        hand_default = (200, 200, 200, 255)
+        for u in units:
+            val = u.get_value(time_obj)
+            ang = math.radians((val / u.max_value) * 360 - 90)
+            length = radius * u.hand_length_factor
+            width = max(1, int(dia * u.hand_width_factor))
+            color = hand_default
+            # fetch per-unit theme color if available
+            if theme_manager and u.hand_color_key in theme_manager.current_theme.palette:
+                color = tuple(theme_manager.current_theme.palette[u.hand_color_key])
+            x2 = cx + length * math.cos(ang)
+            y2 = cy + length * math.sin(ang)
+            draw.line((cx, cy, x2, y2), fill=color, width=width)
+
+        # --- center dot ---
+        dot_r = max(2, dia // 30)
+        draw.ellipse((cx - dot_r, cy - dot_r, cx + dot_r, cy + dot_r),
+                     fill=params.get("center_dot_color", (255, 255, 255, 255)))
+
+        # --- post-processing ---
+        img = base
+        if render_backend:
+            img = render_backend.process(img)
+        elif theme_manager:
+            img = theme_manager.apply_effects(img)
+            img = theme_manager.apply_theme(img)
+        return img
+
+    @staticmethod
+    def render_digital(
+        time_obj: _dt.datetime | _dt.timedelta,
+        format_str: str = "{hours:02d}:{minutes:02d}:{seconds:02d}",
+        image_size: Tuple[int, int] = (200, 50),
+        font_path: Optional[str] = None,
+        font_size: int = 40,
+        backdrop_image_path: Optional[str] = None,
+        theme_manager: Optional[ThemeManager] = None,
+        render_backend: Optional[RenderingBackend] = None,
+        **params: Any
+    ) -> Image.Image:
+        """
+        Draw a digital clock face to a PIL RGBA image.
+        'format_str' can use keys hours, minutes, seconds, milliseconds.
+        Other text params (colors/shadow) in **params.
+        """
+        # --- compute time fields ---
+        if isinstance(time_obj, _dt.datetime):
+            h, m, s = time_obj.hour, time_obj.minute, time_obj.second
+            ms = int(time_obj.microsecond / 1000)
+        else:
+            total_ms = int(time_obj.total_seconds() * 1000)
+            h, rem = divmod(total_ms, 3600*1000)
+            m, rem = divmod(rem, 60*1000)
+            s, ms = divmod(rem, 1000)
+        text = format_str.format(hours=h, minutes=m, seconds=s, milliseconds=ms, time=time_obj)
+
+        # --- defaults & override ---
+        defaults: Dict[str, Any] = {
+            "text_color": (255, 255, 255, 255),
+            "outline_color": (0, 0, 0, 200),
+            "outline_width": 2,
+            "shadow_color": (0, 0, 0, 100),
+            "shadow_offset": (2, 2),
+        }
+        defaults.update(params)
+
+        # --- load or new canvas ---
+        w, h_px = image_size
+        if backdrop_image_path:
+            try:
+                base = Image.open(backdrop_image_path).convert("RGBA")
+                base = base.resize((w, h_px), Image.Resampling.LANCZOS)
+            except Exception:
+                base = Image.new("RGBA", (w, h_px), (0, 0, 0, 0))
+        else:
+            base = Image.new("RGBA", (w, h_px), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(base)
+
+        # --- load font ---
+        try:
+            font = ImageFont.truetype(font_path or "DejaVuSansMono.ttf", font_size)
+        except Exception:
+            font = ImageFont.load_default()
+
+        # --- measure & center ---
+        bbox = draw.textbbox((0, 0), text, font=font,
+                             stroke_width=defaults["outline_width"])
+        tx = (w - (bbox[2] - bbox[0])) // 2 - bbox[0]
+        ty = (h_px - (bbox[3] - bbox[1])) // 2 - bbox[1]
+
+        # --- draw shadow ---
+        sx = tx + defaults["shadow_offset"][0]
+        sy = ty + defaults["shadow_offset"][1]
+        draw.text((sx, sy), text, font=font, fill=defaults["shadow_color"])
+
+        # --- draw main text with outline ---
+        draw.text((tx, ty), text, font=font,
+                  fill=defaults["text_color"],
+                  stroke_width=defaults["outline_width"],
+                  stroke_fill=defaults["outline_color"])
+
+        # --- post-processing ---
+        img = base
+        if render_backend:
+            img = render_backend.process(img)
+        elif theme_manager:
+            img = theme_manager.apply_effects(img)
+            img = theme_manager.apply_theme(img)
+        return img

--- a/src/rendering/ascii_diff/presets/default_themes.json
+++ b/src/rendering/ascii_diff/presets/default_themes.json
@@ -1,0 +1,290 @@
+{
+  "color_palettes": {
+    "cyberpunk": {
+      "text": [255, 0, 255, 255],
+      "outline": [0, 255, 255, 255],
+      "shadow": [255, 0, 128, 150],
+      "accent1": [0, 255, 128, 255],
+      "accent2": [128, 0, 255, 255],      
+      "hour_hand_color": [255, 100, 100, 255],
+      "minute_hand_color": [100, 255, 100, 255],
+      "second_hand_color": [100, 100, 255, 255],
+      "subsecond_hand_color": [200, 200, 0, 255],
+      "background": [10, 5, 20, 255]
+    },
+    "matrix": {
+      "text": [0, 255, 0, 255],
+      "outline": [0, 128, 0, 255],
+      "shadow": [0, 50, 0, 150],
+      "accent1": [144, 238, 144, 255],
+      "accent2": [0, 100, 0, 255],
+      "background": [0, 10, 0, 255],
+      "hour_hand_color": [0, 200, 0, 255],
+      "minute_hand_color": [100, 255, 100, 255],
+      "second_hand_color": [0, 150, 0, 255],
+      "subsecond_hand_color": [150, 255, 150, 255]
+    },
+    "retro": {
+      "text": [255, 200, 0, 255],
+      "outline": [200, 100, 0, 255],
+      "shadow": [100, 50, 0, 150],
+      "accent1": [255, 140, 0, 255],
+      "accent2": [255, 69, 0, 255],
+      "background": [20, 10, 0, 255],
+      "hour_hand_color": [255, 165, 0, 255],
+      "minute_hand_color": [255, 195, 0, 255],
+      "second_hand_color": [255, 100, 0, 255],
+      "subsecond_hand_color": [255, 225, 50, 255]
+    },
+    "vaporwave": {
+      "text": [255, 113, 206, 255],
+      "outline": [113, 206, 255, 255],
+      "shadow": [147, 51, 255, 150],
+      "accent1": [64, 224, 208, 255],
+      "accent2": [255, 182, 193, 255],
+      "background": [25, 0, 51, 255],
+      "hour_hand_color": [255, 182, 193, 255],
+      "minute_hand_color": [64, 224, 208, 255],
+      "second_hand_color": [147, 51, 255, 255],
+      "subsecond_hand_color": [113, 206, 255, 255]
+    },
+    "northern_lights": {
+      "text": [170, 255, 188, 255],
+      "outline": [88, 214, 141, 255],
+      "shadow": [46, 134, 193, 150],
+      "accent1": [133, 193, 233, 255],
+      "accent2": [93, 173, 226, 255],
+      "background": [23, 32, 42, 255],
+      "hour_hand_color": [46, 204, 113, 255],
+      "minute_hand_color": [82, 190, 128, 255],
+      "second_hand_color": [52, 152, 219, 255],
+      "subsecond_hand_color": [155, 89, 182, 255]
+    }
+  },
+  "effects_presets": {
+    "neon": {
+      "glow_radius": 3,
+      "glow_intensity": 0.7,
+      "outline_thickness": 2,
+      "shadow_offset": [3, 3],
+      "shadow_blur": 2
+    },
+    "crisp": {
+      "glow_radius": 0,
+      "glow_intensity": 0,
+      "outline_thickness": 1,
+      "shadow_offset": [1, 1],
+      "shadow_blur": 0
+    },
+    "dramatic": {
+      "glow_radius": 2,
+      "glow_intensity": 0.5,
+      "outline_thickness": 3,
+      "shadow_offset": [4, 4],
+      "shadow_blur": 3
+    },
+    "ethereal": {
+      "glow_radius": 5,
+      "glow_intensity": 0.4,
+      "outline_thickness": 1,
+      "shadow_offset": [2, 2],
+      "shadow_blur": 4
+    },
+    "crystalline": {
+      "glow_radius": 2,
+      "glow_intensity": 0.9,
+      "outline_thickness": 2,
+      "shadow_offset": [1, -1],
+      "shadow_blur": 1
+    },
+    "ghostly": {
+      "glow_radius": 8,
+      "glow_intensity": 0.3,
+      "outline_thickness": 1,
+      "shadow_offset": [0, 0],
+      "shadow_blur": 6
+    },
+    "vivid": {
+      "glow_radius": 4,
+      "glow_intensity": 0.8,
+      "outline_thickness": 2,
+      "shadow_offset": [2, 2],
+      "shadow_blur": 2
+    },
+    "soft_glow": {
+      "glow_radius": 6,
+      "glow_intensity": 0.6,
+      "outline_thickness": 1,
+      "shadow_offset": [3, 3],
+      "shadow_blur": 4
+    },
+    "shadowed": {
+      "glow_radius": 1,
+      "glow_intensity": 0.2,
+      "outline_thickness": 2,
+      "shadow_offset": [5, 5],
+      "shadow_blur": 5
+    },
+    "vintage_bright": {
+      "glow_radius": 2,
+      "glow_intensity": 0.4,
+      "outline_thickness": 2,
+      "shadow_offset": [1, 1],
+      "shadow_blur": 3
+    },
+    "dreamlike": {
+      "glow_radius": 7,
+      "glow_intensity": 0.5,
+      "outline_thickness": 1,
+      "shadow_offset": [0, 0],
+      "shadow_blur": 7
+    },
+    "sketch": {
+      "glow_radius": 0,
+      "glow_intensity": 0,
+      "outline_thickness": 3,
+      "shadow_offset": [2, -2],
+      "shadow_blur": 1
+    }
+  },
+  "ascii_styles": {
+    "block": " .:░▒▓█",
+    "detailed": " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$",
+    "minimal": ".:-=+*#%@",
+    "dots": "․⁚⁖⁘⁙",
+    "shapes": "○◔◑◕●",
+    "circuit": "╋┃┇╏║│┆┊├┝┞┟┠┡┢┣┤┥┦┧┨┩┪┫┬┭┮┯┰┱┲┳┴┵┶┷┸┹┺┻┼┽┾┿╀╁╂╃╄╅╆╇╈╉╊╋",
+    "boxes": "□▢▣▤▥▦▧▨▩▪▫▬▭▮▯▰▱◀◁◂◃◄◅◆◇◈◉◊○◌◍◎●◐◑◒◓◔◕◖◗◘◙◚◛◜◝◞◟◠◡◢◣◤◥◦◧◨◩◪◫◬◭◮◯◰◱◲◳◴◵◶◷◸◹◺◻◼◽◾◿",
+    "weather": "☀☁☂☃☄★☆☇☈☉☊☋☌☍☎☏☐☑☒☓☔☕☖☗☘☙☚☛☜☝☞☟☠☡☢☣☤☥☦☧☨☩☪☫☬☭☮☯",
+    "cards": "♠♡♢♣♤♥♦♧♨♩♪♫♬♭♮♯"
+  },
+  "post_processing": {
+    "high_contrast": {
+      "brightness": 1.2,
+      "contrast": 1.4,
+      "saturation": 1.2
+    },
+    "soft": {
+      "brightness": 0.9,
+      "contrast": 0.8,
+      "saturation": 0.9
+    },
+    "monochrome": {
+      "brightness": 1.0,
+      "contrast": 1.2,
+      "saturation": 0.0
+    },
+    "vintage": {
+      "brightness": 0.9,
+      "contrast": 1.1,
+      "saturation": 0.7,
+      "sepia": 0.3
+    },
+    "neon_glow": {
+      "brightness": 1.3,
+      "contrast": 1.2,
+      "saturation": 1.4,
+      "bloom": 0.4
+    },
+    "matrix_code": {
+      "brightness": 1.1,
+      "contrast": 1.3,
+      "saturation": 0.8,
+      "green_tint": 0.7
+    },
+    "cyberdream": {
+      "brightness": 1.2,
+      "contrast": 1.5,
+      "saturation": 1.3,
+      "chromatic_aberration": 0.2
+    },
+    "night_vision": {
+      "brightness": 0.8,
+      "contrast": 1.1,
+      "saturation": 0.6,
+      "green_tint": 0.9
+    },
+    "sepia_tone": {
+      "brightness": 1.0,
+      "contrast": 1.0,
+      "saturation": 0.8,
+      "sepia": 0.6
+    },
+    "cold_wave": {
+      "brightness": 0.9,
+      "contrast": 1.3,
+      "saturation": 1.1,
+      "blue_tint": 0.5
+    },
+    "hot_warm": {
+      "brightness": 1.2,
+      "contrast": 1.2,
+      "saturation": 1.4,
+      "red_tint": 0.5
+    },
+    "comic_book": {
+      "brightness": 1.1,
+      "contrast": 1.6,
+      "saturation": 1.2,
+      "halftone": 0.4
+    },
+    "vibrant": {
+      "brightness": 1.4,
+      "contrast": 1.4,
+      "saturation": 1.5
+    },
+    "low_light": {
+      "brightness": 0.7,
+      "contrast": 1.2,
+      "saturation": 0.7
+    }
+  },
+  "time_units_definitions": {
+    "hours_12_cycle": {
+      "max_value": 12, "accessor_key": "dt_hour12_float", "format_template": "{value:02.0f}",
+      "hand_length_factor": 0.5, "hand_width_factor": 0.06, "hand_color_key": "hour_hand_color"
+    },
+    "minutes_60_cycle": {
+      "max_value": 60, "accessor_key": "dt_minute_float", "format_template": "{value:02.0f}",
+      "hand_length_factor": 0.75, "hand_width_factor": 0.04, "hand_color_key": "minute_hand_color"
+    },
+    "seconds_60_cycle": {
+      "max_value": 60, "accessor_key": "dt_second_float", "format_template": "{value:02.0f}",
+      "hand_length_factor": 0.9, "hand_width_factor": 0.02, "hand_color_key": "second_hand_color"
+    },
+    "milliseconds_1000_cycle": {
+      "max_value": 1000, "accessor_key": "dt_millisecond_float", "format_template": "{value:03.0f}",
+      "hand_length_factor": 0.9, "hand_width_factor": 0.01, "hand_color_key": "subsecond_hand_color"
+    },
+    "stopwatch_total_seconds_60_cycle": {
+      "max_value": 60, "accessor_key": "td_seconds_float", "format_template": "{value:05.2f}",
+      "hand_length_factor": 0.9, "hand_width_factor": 0.02, "hand_color_key": "second_hand_color"
+    },
+    "stopwatch_total_minutes_60_cycle": {
+      "max_value": 60, "accessor_key": "td_minutes_float", "format_template": "{value:02.0f}",
+      "hand_length_factor": 0.75, "hand_width_factor": 0.04, "hand_color_key": "minute_hand_color"
+    },
+    "stopwatch_total_hours_24_cycle": {
+      "max_value": 24, "accessor_key": "td_hours_float", "format_template": "{value:02.0f}",
+      "hand_length_factor": 0.5, "hand_width_factor": 0.06, "hand_color_key": "hour_hand_color"
+    }
+  },
+  "time_unit_sets": {
+    "default_analog": ["hours_12_cycle", "minutes_60_cycle", "seconds_60_cycle"],
+    "default_digital_hms": ["hours_12_cycle", "minutes_60_cycle", "seconds_60_cycle"],
+    "digital_hms_ms": ["hours_12_cycle", "minutes_60_cycle", "seconds_60_cycle", "milliseconds_1000_cycle"],
+    "analog_fast_sms": ["seconds_60_cycle", "milliseconds_1000_cycle"],
+    "digital_fast_sms": ["seconds_60_cycle", "milliseconds_1000_cycle"],
+    "stopwatch_analog_ms": ["stopwatch_total_minutes_60_cycle", "stopwatch_total_seconds_60_cycle"], 
+    "stopwatch_digital_hms_ms": ["stopwatch_total_hours_24_cycle", "stopwatch_total_minutes_60_cycle", "stopwatch_total_seconds_60_cycle"],
+    "analog_all_hands_datetime": ["hours_12_cycle", "minutes_60_cycle", "seconds_60_cycle", "milliseconds_1000_cycle"]
+  },
+  "digital_format_strings": {
+    "default_hms": "{hours_12_cycle}:{minutes_60_cycle}:{seconds_60_cycle}",
+    "hms_ms": "{hours_12_cycle}:{minutes_60_cycle}:{seconds_60_cycle}.{milliseconds_1000_cycle}",
+    "fast_s_ms": "{seconds_60_cycle}.{milliseconds_1000_cycle}",
+    "stopwatch_hms_ms": "{stopwatch_total_hours_24_cycle}:{stopwatch_total_minutes_60_cycle}:{stopwatch_total_seconds_60_cycle}",
+    "debug_all_datetime": "H:{hours_12_cycle} M:{minutes_60_cycle} S:{seconds_60_cycle} MS:{milliseconds_1000_cycle}",
+    "debug_all_stopwatch": "H:{stopwatch_total_hours_24_cycle} M:{stopwatch_total_minutes_60_cycle} S:{stopwatch_total_seconds_60_cycle}"
+  }
+}

--- a/src/rendering/ascii_diff/render_backend.py
+++ b/src/rendering/ascii_diff/render_backend.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Image rendering helper for theme effects and post-processing."""
+from __future__ import annotations
+
+from PIL import Image, ImageEnhance, ImageFilter
+from typing import Optional
+from .theme_manager import ThemeManager
+# --- END HEADER ---
+
+class RenderingBackend:
+    """Apply theme effects and post-processing in a single pipeline."""
+
+    def __init__(self, theme_manager: ThemeManager) -> None:
+        self.theme_manager = theme_manager
+
+    def apply_effects(self, image: Image.Image) -> Image.Image:
+        """Apply visual effects defined in the current theme."""
+        effects = self.theme_manager.current_theme.effects
+        if not effects:
+            return image
+
+        if effects.get("glow_radius", 0) > 0:
+            glow = image.filter(ImageFilter.GaussianBlur(effects["glow_radius"]))
+            image = Image.blend(image, glow, effects.get("glow_intensity", 0.5))
+
+        if effects.get("shadow_blur", 0) > 0:
+            if image.mode != "RGBA":
+                image = image.convert("RGBA")
+            offset_x, offset_y = effects.get("shadow_offset", (2, 2))
+            shadow_color = tuple(self.theme_manager.current_theme.palette.get("shadow", (0, 0, 0, 150)))
+            shadow = Image.new("RGBA", image.size, shadow_color)
+            shadow = shadow.filter(ImageFilter.GaussianBlur(effects["shadow_blur"]))
+            base = Image.new("RGBA", image.size, (0, 0, 0, 0))
+            base.paste(shadow, (offset_x, offset_y), shadow)
+            base.paste(image, (0, 0), image)
+            image = base
+        return image
+
+    def apply_post_processing(self, image: Image.Image) -> Image.Image:
+        """Apply post-processing adjustments from the current theme."""
+        if self.theme_manager.current_theme.invert_clock:
+            image = Image.eval(image, lambda x: 255 - x)
+
+        pp = self.theme_manager.current_theme.post_processing
+        if pp:
+            brightness = pp.get("brightness", 1.0)
+            contrast = pp.get("contrast", 1.0)
+            saturation = pp.get("saturation", 1.0)
+
+            enhancer = ImageEnhance.Brightness(image)
+            image = enhancer.enhance(brightness)
+            enhancer = ImageEnhance.Contrast(image)
+            image = enhancer.enhance(contrast)
+            image = ImageEnhance.Color(image).enhance(saturation)
+        return image
+
+    def process(self, image: Image.Image) -> Image.Image:
+        """Apply effects then post-processing to ``image``."""
+        image = self.apply_effects(image)
+        image = self.apply_post_processing(image)
+        return image
+
+    def list_available_operations(self) -> list[str]:
+        """Return a curated list of extra Pillow operations."""
+        # This implementation merely exposes a handful of common transforms.
+        # Future versions may inspect PIL dynamically and provide richer
+        # metadata for configuration files.
+        return [
+            "rotate",
+            "transpose_left_right",
+            "transpose_top_bottom",
+            "blur",
+            "sharpen",
+            "posterize",
+            "resize",
+            "crop",
+            "color_enhance",
+        ]

--- a/src/rendering/ascii_diff/theme_manager.py
+++ b/src/rendering/ascii_diff/theme_manager.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Manage color themes and post-processing for clock rendering."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+from PIL import Image, ImageEnhance, ImageFilter
+# --- END HEADER ---
+from .time_units import TimeUnit # Import the new TimeUnit class
+
+@dataclass
+class ClockTheme:
+    palette: dict
+    effects: dict
+    ascii_style: str
+    post_processing: dict
+    active_time_units: List[TimeUnit] = field(default_factory=list) # For analog/digital
+    digital_format_key: str = "default_hms" # Key to lookup in presets.digital_format_strings
+    invert_clock: bool = False
+    current_backdrop_path: Optional[str] = None # Added for backdrop cycling
+    invert_backdrop: bool = False
+
+# Determine the directory of the current module to reliably locate presets
+_MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_PRESETS_PATH = os.path.join(_MODULE_DIR, "presets", "default_themes.json")
+
+class ThemeManager:
+    def __init__(self, presets_path: str = DEFAULT_PRESETS_PATH):
+        self.presets_path = presets_path
+        self.current_theme = ClockTheme({}, {}, "block", {}, [])
+        self._load_presets()
+        if not self.current_theme.active_time_units: # Ensure a default set of units
+            self.set_time_unit_set("default_analog") 
+        if not self.current_theme.digital_format_key:
+            self.set_digital_format_key("default_hms")
+
+    def _load_presets(self) -> None:
+        """Loads presets from the JSON file.
+        Initializes self.presets to an empty structure if loading fails.
+        """
+        empty_presets = {"color_palettes": {}, "effects_presets": {},
+                         "ascii_styles": {}, "post_processing": {}, "digital_format_strings": {},
+                         "time_units_definitions": {}, "time_unit_sets": {}}
+        try:
+            if not os.path.exists(self.presets_path):
+                print(f"Error loading presets: File not found at '{self.presets_path}'")
+                self.presets = empty_presets
+                return
+
+            with open(self.presets_path, 'r', encoding='utf-8') as f:
+                self.presets = json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"Error loading presets: Could not decode JSON from '{self.presets_path}'. Error: {e}")
+            self.presets = empty_presets
+        except Exception as e:
+            # Catch other potential errors like IO errors after file exists check
+            print(f"Error loading presets: An unexpected error occurred with '{self.presets_path}'. Error: {e}")
+            self.presets = empty_presets
+
+    def apply_theme(self, image: Image.Image) -> Image.Image:
+        """Apply current theme's post-processing to image"""
+        # Ensure image is in a mode that supports enhancement (e.g., RGB)
+        if self.current_theme.invert_clock:
+            image = Image.eval(image, lambda x: 255 - x)
+        
+        pp = self.current_theme.post_processing
+        if pp:
+            brightness = pp.get("brightness", 1.0)
+            contrast = pp.get("contrast", 1.0)
+            saturation = pp.get("saturation", 1.0)
+
+            enhancer = ImageEnhance.Brightness(image)
+            image = enhancer.enhance(brightness)
+            enhancer = ImageEnhance.Contrast(image)
+            image = enhancer.enhance(contrast)
+            enhancer = ImageEnhance.Color(image) # For saturation
+            image = ImageEnhance.Color(image).enhance(saturation)
+
+        return image
+
+    def apply_effects(self, image: Image.Image) -> Image.Image:
+        """Apply current theme's effects to image"""
+        effects = self.current_theme.effects
+        if effects:
+            if effects.get("glow_radius", 0) > 0:
+                glow = image.filter(ImageFilter.GaussianBlur(effects["glow_radius"]))
+                image = Image.blend(image, glow, effects.get("glow_intensity", 0.5))
+
+            if effects.get("shadow_blur", 0) > 0:
+                if image.mode != "RGBA":
+                    image = image.convert("RGBA")
+                offset_x, offset_y = effects.get("shadow_offset", (2, 2))
+                shadow_color = tuple(self.current_theme.palette.get("shadow", (0, 0, 0, 150)))
+                shadow = Image.new("RGBA", image.size, shadow_color)
+                shadow = shadow.filter(ImageFilter.GaussianBlur(effects["shadow_blur"]))
+                base = Image.new("RGBA", image.size, (0, 0, 0, 0))
+                base.paste(shadow, (offset_x, offset_y), shadow)
+                base.paste(image, (0, 0), image)
+                image = base
+
+        return image
+
+    def get_current_ascii_ramp(self) -> str:
+        """Get current ASCII style ramp.
+        Falls back to "block" style if current is not found,
+        then to a hardcoded default if "block" is also not found (e.g. due to loading error).
+        """
+        # Hardcoded default ramp, matching the "block" style in default_themes.json
+        DEFAULT_FALLBACK_RAMP = " .:░▒▓█"
+
+        ascii_styles_preset = self.presets.get("ascii_styles", {})
+
+        # 1. Try to get the ramp for the current theme's ascii_style
+        current_style_ramp = ascii_styles_preset.get(self.current_theme.ascii_style)
+        if current_style_ramp is not None: # Check for None in case a style has an empty string ramp
+            return current_style_ramp
+
+        # 2. If current theme's style not found, try to get the "block" style ramp
+        block_style_ramp = ascii_styles_preset.get("block")
+        if block_style_ramp is not None:
+            return block_style_ramp
+        
+        # 3. If "block" style is also not found, return the hardcoded default fallback ramp.
+        return DEFAULT_FALLBACK_RAMP
+
+    def cycle_ascii_style(self, step: int = 1) -> str:
+        """Cycle the active ASCII style forward or backward by ``step``."""
+        styles = list(self.presets.get("ascii_styles", {}).keys())
+        if not styles:  # Fallback if no styles are loaded
+            self.current_theme.ascii_style = "block"  # Default to "block" style name
+            return self.current_theme.ascii_style
+
+        try:
+            idx = styles.index(self.current_theme.ascii_style)
+        except ValueError:
+            idx = 0
+
+        new_idx = (idx + step) % len(styles)
+        self.current_theme.ascii_style = styles[new_idx]
+        return self.current_theme.ascii_style
+
+    def toggle_clock_inversion(self) -> bool:
+        self.current_theme.invert_clock = not self.current_theme.invert_clock
+        return self.current_theme.invert_clock
+
+    def toggle_backdrop_inversion(self) -> bool:
+        self.current_theme.invert_backdrop = not self.current_theme.invert_backdrop
+        return self.current_theme.invert_backdrop
+
+    def set_palette(self, palette_name: str) -> None:
+        """Set the color palette by name"""
+        if palette_name in self.presets["color_palettes"]:
+            palette = self.presets["color_palettes"][palette_name].copy()
+            palette["name"] = palette_name
+            self.current_theme.palette = palette
+        else:
+            print(f"Palette '{palette_name}' not found.")
+
+    def set_effects(self, effects_name: str) -> None:
+        """Set the effects preset by name"""
+        if effects_name in self.presets["effects_presets"]:
+            effects = self.presets["effects_presets"][effects_name].copy()
+            effects["name"] = effects_name
+            self.current_theme.effects = effects
+        else:
+            print(f"Effects preset '{effects_name}' not found.")
+
+    def set_post_processing(self, pp_name: str) -> None:
+        """Set the post-processing preset by name"""
+        if pp_name in self.presets["post_processing"]:
+            post_processing = self.presets["post_processing"][pp_name].copy()
+            post_processing["name"] = pp_name
+            self.current_theme.post_processing = post_processing
+        else:
+            print(f"Post-processing preset '{pp_name}' not found.")
+
+    def get_palette_names(self) -> List[str]:
+        """Return the available palette names."""
+        return list(self.presets.get("color_palettes", {}).keys())
+
+    def cycle_palette(self, step: int = 1) -> str:
+        """Cycle the active palette forward or backward by ``step``."""
+        names = self.get_palette_names()
+        if not names:
+            return ""
+        current = self.current_theme.palette.get("name", names[0])
+        try:
+            idx = names.index(current)
+        except ValueError:
+            idx = 0
+        new_idx = (idx + step) % len(names)
+        self.set_palette(names[new_idx])
+        return names[new_idx]
+
+    def get_effects_preset_names(self) -> List[str]:
+        return list(self.presets.get("effects_presets", {}).keys())
+
+    def cycle_effects_preset(self, step: int = 1) -> str:
+        names = self.get_effects_preset_names()
+        if not names: return ""
+        current = self.current_theme.effects.get("name", names[0])
+        try: idx = names.index(current)
+        except ValueError: idx = 0
+        new_idx = (idx + step) % len(names)
+        self.set_effects(names[new_idx])
+        return names[new_idx]
+
+    def get_post_processing_preset_names(self) -> List[str]:
+        return list(self.presets.get("post_processing", {}).keys())
+
+    def cycle_post_processing_preset(self, step: int = 1) -> str:
+        names = self.get_post_processing_preset_names()
+        if not names: return ""
+        current = self.current_theme.post_processing.get("name", names[0])
+        try: idx = names.index(current)
+        except ValueError: idx = 0
+        new_idx = (idx + step) % len(names)
+        self.set_post_processing(names[new_idx])
+        return names[new_idx]
+
+    def get_time_unit_set_names(self) -> List[str]:
+        return list(self.presets.get("time_unit_sets", {}).keys())
+
+    def cycle_time_unit_set(self, current_set_name: str, step: int = 1) -> str:
+        names = self.get_time_unit_set_names()
+        if not names: return current_set_name
+        try: idx = names.index(current_set_name)
+        except ValueError: idx = 0
+        new_idx = (idx + step) % len(names)
+        # self.set_time_unit_set(names[new_idx]) # This would set for current_theme.active_time_units
+        return names[new_idx] # Return the name, clock_demo will manage which clock uses it
+
+    def get_digital_format_key_names(self) -> List[str]:
+        return list(self.presets.get("digital_format_strings", {}).keys())
+
+    def cycle_digital_format_key(self, current_format_key: str, step: int = 1) -> str:
+        names = self.get_digital_format_key_names()
+        if not names: return current_format_key
+        try: idx = names.index(current_format_key)
+        except ValueError: idx = 0
+        new_idx = (idx + step) % len(names)
+        return names[new_idx] # Return the key name
+
+    def get_time_unit_definitions(self) -> Dict[str, TimeUnit]:
+        """Returns all defined TimeUnit objects."""
+        defs = self.presets.get("time_units_definitions", {})
+        return {name: TimeUnit.from_dict(name, data) for name, data in defs.items()}
+
+    def set_time_unit_set(self, set_name: str) -> None:
+        """Sets the active time units based on a predefined set name."""
+        unit_sets = self.presets.get("time_unit_sets", {})
+        unit_names_in_set = unit_sets.get(set_name)
+
+        if unit_names_in_set:
+            all_defined_units = self.get_time_unit_definitions()
+            active_units = []
+            for unit_name in unit_names_in_set:
+                if unit_name in all_defined_units:
+                    active_units.append(all_defined_units[unit_name])
+                else:
+                    print(f"Warning: Time unit '{unit_name}' in set '{set_name}' not defined.")
+            self.current_theme.active_time_units = active_units[:5] # Max 5 units
+        else:
+            print(f"Time unit set '{set_name}' not found. Using current or empty.")
+
+    def set_digital_format_key(self, key_name: str) -> None:
+        """Sets the key for the digital format string to be used from presets."""
+        if key_name in self.presets.get("digital_format_strings", {}):
+            self.current_theme.digital_format_key = key_name
+        else:
+            print(f"Digital format key '{key_name}' not found. Using current or default.")
+
+    def get_current_digital_format_string(self) -> str:
+        """Gets the actual format string based on the current_theme.digital_format_key."""
+        formats = self.presets.get("digital_format_strings", {})
+        # Fallback to a simple H:M:S if the key or "default_hms" is not found
+        return formats.get(self.current_theme.digital_format_key, formats.get("default_hms", "{value:02.0f}:{value:02.0f}:{value:02.0f}"))
+
+    def cycle_backdrop(self, available_backdrop_paths: List[str], step: int = 1) -> Optional[str]:
+        if not available_backdrop_paths:
+            self.current_theme.current_backdrop_path = None
+            return None
+        
+        try:
+            current_idx = available_backdrop_paths.index(self.current_theme.current_backdrop_path) if self.current_theme.current_backdrop_path else -1
+        except ValueError:
+            current_idx = -1 # If current path not in list, start from beginning
+        
+        new_idx = (current_idx + step) % len(available_backdrop_paths)
+        self.current_theme.current_backdrop_path = available_backdrop_paths[new_idx]
+        return self.current_theme.current_backdrop_path

--- a/src/rendering/ascii_diff/time_units.py
+++ b/src/rendering/ascii_diff/time_units.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Defines TimeUnit class and utilities for configurable clock units."""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+from typing import Callable, Any, List, Tuple, Dict
+# --- END HEADER ---
+
+# --- Accessor Functions ---
+# These functions extract a specific time component from a datetime or timedelta object.
+# They should handle either type gracefully or be specific if needed.
+
+def _get_dt_hour_12_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.hour % 12 + obj.minute / 60 if isinstance(obj, _dt.datetime) else 0.0
+
+def _get_dt_hour_24_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.hour + obj.minute / 60 if isinstance(obj, _dt.datetime) else 0.0
+
+def _get_dt_minute_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.minute + obj.second / 60 if isinstance(obj, _dt.datetime) else 0.0
+
+def _get_dt_second_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.second + obj.microsecond / 1_000_000 if isinstance(obj, _dt.datetime) else 0.0
+
+def _get_dt_millisecond_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.microsecond / 1000 if isinstance(obj, _dt.datetime) else 0.0
+
+def _get_td_days_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.days if isinstance(obj, _dt.timedelta) else 0.0
+
+def _get_td_hours_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    # Total hours in the timedelta, not just the hour part
+    return (obj.total_seconds() / 3600) if isinstance(obj, _dt.timedelta) else 0.0
+
+def _get_td_minutes_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    # Total minutes in the timedelta
+    return (obj.total_seconds() / 60) if isinstance(obj, _dt.timedelta) else 0.0
+
+def _get_td_seconds_float(obj: _dt.datetime | _dt.timedelta) -> float:
+    return obj.total_seconds() if isinstance(obj, _dt.timedelta) else 0.0
+
+
+ACCESSOR_REGISTRY: Dict[str, Callable[[_dt.datetime | _dt.timedelta], float]] = {
+    "dt_hour12_float": _get_dt_hour_12_float,
+    "dt_hour24_float": _get_dt_hour_24_float,
+    "dt_minute_float": _get_dt_minute_float,
+    "dt_second_float": _get_dt_second_float,
+    "dt_millisecond_float": _get_dt_millisecond_float,
+    "td_days_float": _get_td_days_float,
+    "td_hours_float": _get_td_hours_float,
+    "td_minutes_float": _get_td_minutes_float,
+    "td_seconds_float": _get_td_seconds_float,
+}
+
+@dataclass
+class TimeUnit:
+    name: str
+    max_value: float  # Value for a full cycle (e.g., 12 for hours on analog, 60 for minutes)
+    accessor_key: str # Key into ACCESSOR_REGISTRY
+    # Python's str.format() style, e.g., "{value:02.0f}" for digital
+    # For analog, this can be used to derive hand properties or ignored
+    format_template: str = "{value:02.0f}"
+    # Analog clock hand properties (can be overridden by theme)
+    hand_length_factor: float = 0.5 # Relative to clock radius
+    hand_width_factor: float = 0.05 # Relative to clock effective diameter
+    hand_color_key: str = "default_hand_color" # Key in theme palette for this hand's color
+
+    def get_value(self, time_obj: _dt.datetime | _dt.timedelta) -> float:
+        """Extracts the unit's value from the given time object."""
+        accessor_func = ACCESSOR_REGISTRY.get(self.accessor_key)
+        if accessor_func:
+            return accessor_func(time_obj)
+        # Fallback or error for unknown accessor
+        print(f"Warning: Accessor key '{self.accessor_key}' not found for unit '{self.name}'. Returning 0.")
+        return 0.0
+
+    def format_value(self, time_obj: _dt.datetime | _dt.timedelta) -> str:
+        """Formats the unit's value as a string for digital display."""
+        value = self.get_value(time_obj)
+        try:
+            return self.format_template.format(value=value)
+        except Exception as e: # Broad except for various formatting issues
+            print(f"Warning: Could not format value {value} for unit '{self.name}' with template '{self.format_template}'. Error: {e}")
+            return str(value) # Fallback to simple string conversion
+
+    @classmethod
+    def from_dict(cls, name: str, data: dict) -> TimeUnit:
+        """Creates a TimeUnit instance from a dictionary (e.g., from JSON)."""
+        return cls(name=name, **data)


### PR DESCRIPTION
## Summary
- Expose clock and theme utilities from timesync inside ascii_diff
- Add analog clock demo and default theme presets
- Document new demos in ascii_diff README

## Testing
- `python -m py_compile src/rendering/ascii_diff/clock_renderer.py src/rendering/ascii_diff/theme_manager.py src/rendering/ascii_diff/time_units.py src/rendering/ascii_diff/render_backend.py src/rendering/ascii_diff/clock_demo.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a3dae91908832a80d4fb69f34e4d36