### PR TITLE
feat: allow using BitBitItem as index

### DIFF
--- a/src/bitbitbuffer/helpers/bitbititem.py
+++ b/src/bitbitbuffer/helpers/bitbititem.py
@@ -36,6 +36,10 @@ class BitBitItem:
         raw = self.buffer.indexer.access(spec)
         return (raw[0] >> 7) & 1
 
+    def __index__(self):
+        """Return int value so BitBitItem can act as a slice index."""
+        return self.__int__()
+
     def __getitem__(self, key):
             # Allow default plane indexing with int or slice
             second_key = None

--- a/tests/bitbitbuffer/test_slice_offsets.py
+++ b/tests/bitbitbuffer/test_slice_offsets.py
@@ -22,3 +22,11 @@ def test_cell_slice_does_not_overlap():
     cell1 = buf[128:256]
     assert cell1.hex() == '00' * 16
     assert cell1[0:128].hex() == '00' * 16
+
+
+def test_bitbititem_as_index():
+    buf = BitBitBuffer(mask_size=8)
+    buf[0:8] = [0, 1, 0, 1, 0, 1, 0, 1]
+    index = buf[1]
+    values = ['zero', 'one']
+    assert values[index] == 'one'


### PR DESCRIPTION
## Summary
- allow `BitBitItem` to act directly as an integer index via new `__index__` implementation
- add regression test verifying `BitBitItem` works in Python indexing expressions

## Testing
- `pytest tests/bitbitbuffer/test_slice_offsets.py -q`
- `pytest -q` *(fails: TypeError in ascii_diff, ModuleNotFoundError for pandas in double buffer tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a4035786a0832a96b92ad16943fc66