### PR TITLE
Fix bias broadcasting in Linear layer

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -31,7 +31,10 @@ class Linear:
         self._x = x
         out = x @ self.W
         if self.b is not None:
-            out = out + self.b
+            b = self.b
+            if b.shape[0] != out.shape[0]:
+                b = b.repeat((out.shape[0], 1))
+            out = out + b
         return out
 
     def backward(self, grad_out: AbstractTensor) -> AbstractTensor:


### PR DESCRIPTION
## Summary
- ensure Linear layer bias broadcasts across batch dimension by repeating when needed

## Testing
- `pytest` *(fails: TypeError in `test_ascii_diff_animation`, assertion in `test_self_contact_broad_phase_scaling`)*

------
https://chatgpt.com/codex/tasks/task_e_68a54a2bf5cc832a87d5bad1f3ae55a2