### PR TITLE
Fix MSELoss.backward normalization and add tests

### DIFF
--- a/src/common/tensors/abstract_nn/losses.py
+++ b/src/common/tensors/abstract_nn/losses.py
@@ -14,7 +14,18 @@ class MSELoss(Loss):
         return (diff * diff).mean()
     def backward(self, pred: AbstractTensor, target: AbstractTensor) -> AbstractTensor:
         diff = pred - target
-        N = len(pred) if hasattr(pred, '__len__') else 1
+        if hasattr(pred, "numel"):
+            N = pred.numel()
+        elif hasattr(pred, "numel_"):
+            N = pred.numel_()
+        elif hasattr(pred, "shape"):
+            N = 1
+            for d in pred.shape:
+                N *= d
+        else:
+            def _count(x):
+                return sum(_count(v) for v in x) if isinstance(x, list) else 1
+            N = _count(as_list(pred)) if hasattr(pred, "__len__") else 1
         return (2.0 / float(N)) * diff
 
 class CrossEntropyLoss(Loss):

--- a/tests/test_mse_loss.py
+++ b/tests/test_mse_loss.py
@@ -1,0 +1,48 @@
+import importlib.util
+import pytest
+
+from src.common.tensors.abstract_nn.losses import MSELoss
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.common.tensors.torch_backend import PyTorchTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    PyTorchTensorOperations = None
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    NumPyTensorOperations = None
+
+try:
+    from src.common.tensors.jax_backend import JAXTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    JAXTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+if PyTorchTensorOperations is not None and importlib.util.find_spec("torch") is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+if JAXTensorOperations is not None and importlib.util.find_spec("jax") is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_mse_loss_backward_multi_dim(backend_name, Backend):
+    pred = Backend.tensor_from_list([[1.0, 2.0], [3.0, 4.0]])
+    target = Backend.zeros((2, 2))
+    loss = MSELoss()
+    grad = loss.backward(pred, target)
+    assert grad.tolist() == [[0.5, 1.0], [1.5, 2.0]]
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_mse_loss_forward_multi_dim(backend_name, Backend):
+    pred = Backend.tensor_from_list([[1.0, 2.0], [3.0, 4.0]])
+    target = Backend.zeros((2, 2))
+    loss = MSELoss()
+    val = loss.forward(pred, target)
+    if hasattr(val, "tolist"):
+        val = val.tolist()
+    assert pytest.approx(float(val), rel=1e-6) == 7.5


### PR DESCRIPTION
## Summary
- correct MSELoss backward normalization by counting all elements
- add tests covering multi-dimensional inputs for MSELoss forward and backward

## Testing
- `pytest tests/test_mse_loss.py -q`
- `pytest -q` *(fails: test_ascii_diff_animation, test_linear_bias_broadcast_and_grad[PurePython-PurePythonTensorOperations], test_linear_bias_broadcast_and_grad[NumPy-NumPyTensorOperations], test_self_contact_broad_phase_scaling)*

------
https://chatgpt.com/codex/tasks/task_e_68a55bc9ec8c832a8c9cac6776ad9b13