### PR TITLE
Add deterministic seeding helper for tensor demos and tests

### DIFF
--- a/src/common/tensors/abstract_nn/__init__.py
+++ b/src/common/tensors/abstract_nn/__init__.py
@@ -3,3 +3,4 @@ from .activations import ReLU, Sigmoid, Tanh, Identity
 from .losses import MSELoss, CrossEntropyLoss
 from .optimizer import Adam
 from .train import train_step, train_loop
+from .utils import set_seed

--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -28,7 +28,7 @@ class Linear:
             self.gb = zeros_like(self.b)
 
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        # core.py (inside Linear.forward)
+        self._x = x
         out = x @ self.W
         if self.b is not None:
             b = self.b.broadcast_rows(out.shape[0], label="Linear.forward(bias)")

--- a/src/common/tensors/abstract_nn/demo_xor.py
+++ b/src/common/tensors/abstract_nn/demo_xor.py
@@ -1,6 +1,8 @@
 from ..abstraction import AbstractTensor
-from . import Linear, Model, ReLU, MSELoss, Adam, train_loop
+from . import Linear, Model, ReLU, MSELoss, Adam, train_loop, set_seed
 from .utils import from_list_like
+
+set_seed(0)
 
 # Instantiate a 'like' tensor to choose backend (DEFAULT_FACULTY)
 ops = AbstractTensor.get_tensor(faculty=None)

--- a/src/common/tensors/abstract_nn/utils.py
+++ b/src/common/tensors/abstract_nn/utils.py
@@ -1,6 +1,33 @@
 from __future__ import annotations
+
+import random
 from typing import Any, Callable, List, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - torch is optional
+    import torch
+except Exception:  # pragma: no cover - torch is optional
+    torch = None
+
 from ..abstraction import AbstractTensor
+
+
+def set_seed(seed: int) -> None:
+    """Seed Python, NumPy and (optionally) PyTorch RNGs.
+
+    Parameters
+    ----------
+    seed:
+        The seed value used for all available random number generators.
+    """
+
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
 
 def as_list(t: AbstractTensor) -> list:
     return t.tolist()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ import time
 from pathlib import Path
 
 import pytest
+from src.common.tensors.abstract_nn import set_seed
+
+set_seed(0)
 
 def pytest_addoption(parser):
     parser.addoption(


### PR DESCRIPTION
## Summary
- add `set_seed` utility to seed Python, NumPy and optional PyTorch RNGs
- expose `set_seed` in `abstract_nn` package and use it in XOR demo
- seed test suite via `tests/conftest.py` and store inputs during `Linear.forward`

## Testing
- `pytest` *(fails: tests/test_ascii_diff_double_buffer.py::test_ascii_diff_animation - TypeError: only integer scalar arrays can be converted to a scalar index)*

------
https://chatgpt.com/codex/tasks/task_e_68a55bdcf480832a906093c01ebefbe3