### PR TITLE
Zero gradients at start of training step

### DIFF
--- a/src/common/tensors/abstract_nn/train.py
+++ b/src/common/tensors/abstract_nn/train.py
@@ -29,6 +29,7 @@ def _to_scalar(x):
 
 
 def train_step(model: Model, loss_fn: Loss, optimizer: Adam, x: AbstractTensor, y: AbstractTensor) -> Tuple[float, float]:
+    model.zero_grad()
     pred = model.forward(x)
     loss = loss_fn.forward(pred, y)
     grad_pred = loss_fn.backward(pred, y)


### PR DESCRIPTION
## Summary
- Zero accumulated gradients at the start of `train_step` to align with typical training loops.

## Testing
- `pytest` *(fails: missing pandas dependency; `Linear.backward` requires stored inputs; ascii diff animation type error)*

------
https://chatgpt.com/codex/tasks/task_e_68a55c3b0930832aa4c5b6667c6e8633