### PR TITLE
Use stateful PixelFrameBuffer for ASCII diff rendering

### DIFF
--- a/tests/test_ascii_diff_double_buffer.py
+++ b/tests/test_ascii_diff_double_buffer.py
@@ -1,19 +1,13 @@
 import numpy as np
-import pytest
-
-from src.common.double_buffer import DoubleBuffer
+import time
 
 from src.rendering.ascii_render import AsciiRenderer
-from src.rendering.ascii_diff import PixelFrameBuffer, draw_diff, DEFAULT_DRAW_ASCII_RAMP
-
-
-import time
 
 def test_ascii_diff_animation():
     width, height = 32, 16
     r = AsciiRenderer(width, height)
-    prev_canvas = None
     frames = 20
+    print("\x1b[2J", end="")  # Clear screen once
     for frame in range(frames):
         r.clear()
         # Animate a moving circle and a bouncing line
@@ -21,8 +15,7 @@ def test_ascii_diff_animation():
         cy = int((height // 2) + (height // 3) * np.cos(frame * 2 * np.pi / frames))
         r.circle(cx, cy, 4, value=1)
         r.line(frame % width, 0, width - 1 - (frame % width), height - 1, value=1)
-        # Use the new ascii_diff output method
-        ascii_out = r.to_ascii_diff(prev_buffer=prev_canvas)
-        print(f"\x1b[2J\x1b[HFrame {frame+1}/{frames}\n" + ascii_out)
-        prev_canvas = r.canvas.copy()
-        time.sleep(0.1)
+        # Emit only changed regions
+        ascii_out = r.to_ascii_diff()
+        print(ascii_out, end="")
+        time.sleep(0.05)


### PR DESCRIPTION
## Summary
- persist a PixelFrameBuffer on `AsciiRenderer` for diff tracking
- `to_ascii_diff` now emits only changed regions via `draw_diff`
- update ascii diff animation test to use stateful diff API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5db5bb090832a991b50baf265e90d