### PR TITLE
Add unary operator support and backend implementations

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -788,6 +788,7 @@ class AbstractTensor:
             "add","sub","mul","truediv","floordiv","mod","pow",
             "iadd","isub","imul","itruediv","ifloordiv","imod","ipow",
             "radd","rsub","rmul","rtruediv","rfloordiv","rmod","rpow",
+            "neg","abs","invert",
         }
         div_ops = {"truediv","rtruediv","itruediv"}
 

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -109,6 +109,33 @@ class JAXTensorOperations(AbstractTensor):
         import jax.numpy as jnp
         return jnp.log(self.data)
 
+    def neg_(self):
+        return -self.data
+
+    def abs_(self):
+        import jax.numpy as jnp
+        return jnp.abs(self.data)
+
+    def invert_(self):
+        import jax.numpy as jnp
+        return jnp.invert(self.data)
+
+    def round_(self, n=None):
+        import jax.numpy as jnp
+        return jnp.round(self.data, n or 0)
+
+    def trunc_(self):
+        import jax.numpy as jnp
+        return jnp.trunc(self.data)
+
+    def floor_(self):
+        import jax.numpy as jnp
+        return jnp.floor(self.data)
+
+    def ceil_(self):
+        import jax.numpy as jnp
+        return jnp.ceil(self.data)
+
     def softmax_(self, dim):
         import jax.numpy as jnp
         x = self.data
@@ -170,6 +197,12 @@ class JAXTensorOperations(AbstractTensor):
         from .abstraction import AbstractTensor
         a = self._to_jnp(left._AbstractTensor__unwrap() if isinstance(left, AbstractTensor) else left)
         b = self._to_jnp(right._AbstractTensor__unwrap() if isinstance(right, AbstractTensor) else right)
+        if op == "neg":
+            return -a
+        if op == "abs":
+            return jnp.abs(a)
+        if op == "invert":
+            return jnp.invert(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -120,6 +120,33 @@ class NumPyTensorOperations(AbstractTensor):
         import numpy as np
         return np.log(self.data)
 
+    def neg_(self):
+        return -self.data
+
+    def abs_(self):
+        import numpy as np
+        return np.abs(self.data)
+
+    def invert_(self):
+        import numpy as np
+        return np.invert(self.data)
+
+    def round_(self, n=None):
+        import numpy as np
+        return np.round(self.data, n)
+
+    def trunc_(self):
+        import numpy as np
+        return np.trunc(self.data)
+
+    def floor_(self):
+        import numpy as np
+        return np.floor(self.data)
+
+    def ceil_(self):
+        import numpy as np
+        return np.ceil(self.data)
+
     def softmax_(self, dim):
         import numpy as np
         x = self.data
@@ -148,6 +175,12 @@ class NumPyTensorOperations(AbstractTensor):
         from .abstraction import AbstractTensor
         a = left._AbstractTensor__unwrap() if isinstance(left, AbstractTensor) else left
         b = right._AbstractTensor__unwrap() if isinstance(right, AbstractTensor) else right
+        if op == "neg":
+            return -a
+        if op == "abs":
+            return np.abs(a)
+        if op == "invert":
+            return np.invert(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -116,6 +116,33 @@ class PyTorchTensorOperations(AbstractTensor):
         import torch
         return torch.log(self.data)
 
+    def neg_(self):
+        return -self.data
+
+    def abs_(self):
+        import torch
+        return torch.abs(self.data)
+
+    def invert_(self):
+        import torch
+        return torch.bitwise_not(self.data)
+
+    def round_(self, n=None):
+        import torch
+        return torch.round(self.data, decimals=n) if n is not None else torch.round(self.data)
+
+    def trunc_(self):
+        import torch
+        return torch.trunc(self.data)
+
+    def floor_(self):
+        import torch
+        return torch.floor(self.data)
+
+    def ceil_(self):
+        import torch
+        return torch.ceil(self.data)
+
     def softmax_(self, dim):
         import torch
         return torch.softmax(self.data, dim=dim)
@@ -139,7 +166,13 @@ class PyTorchTensorOperations(AbstractTensor):
         # torch is imported in __init__ and assigned to self._torch
         a = left._AbstractTensor__unwrap() if isinstance(left, AbstractTensor) else left
         b = right._AbstractTensor__unwrap() if isinstance(right, AbstractTensor) else right
-        
+
+        if op == "neg":
+            return -a
+        if op == "abs":
+            return torch.abs(a)
+        if op == "invert":
+            return torch.bitwise_not(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":


### PR DESCRIPTION
## Summary
- add Python unary operator methods (__neg__, __abs__, __invert__, etc.)
- route symbol-based unary operators through _apply_operator and keep function-like ones unimplemented
- implement neg/abs/invert/round/trunc/floor/ceil across numpy, torch, jax, and pure Python backends

## Testing
- `pytest` *(fails: assert np.float64(2.1089748784774587) < 2.1 in tests/test_self_contact_solver.py::test_self_contact_broad_phase_scaling)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e77c834c832a810b8834ff04d3e9