### PR TITLE
Fix activation gradient flow and improve XOR demo init

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -114,7 +114,7 @@ class Model:
         for i in reversed(range(len(self.layers))):
             act = self.activations[i]
             if act is not None:
-                g = act.backward(self._post[i], g)
+                g = act.backward(self._pre[i], g)
             g = self.layers[i].backward(g)
         return g
 

--- a/src/common/tensors/abstract_nn/demo_xor.py
+++ b/src/common/tensors/abstract_nn/demo_xor.py
@@ -31,10 +31,13 @@ def run_operator_demo(op_name, loss_type, like, debug_hooks=None, until_stop=Fal
     set_seed(0)
     X, Y = get_operator_dataset(op_name, like)
     model = Model(
-        layers=[Linear(2, 8, like=like), Linear(8, 1, like=like)],
+        layers=[
+            Linear(2, 8, like=like, init="xavier"),
+            Linear(8, 1, like=like, init="xavier"),
+        ],
         activations=[Tanh(), Sigmoid() if loss_type == 'mse' else None],
     )
-    opt = Adam(model.parameters(), lr=1e-2 if loss_type == 'mse' else 1e-3)
+    opt = Adam(model.parameters(), lr=1e-2 if loss_type == 'mse' else 3e-3)
     if loss_type == 'mse':
         loss_fn = MSELoss()
     else:


### PR DESCRIPTION
## Summary
- ensure activation backward functions receive pre-activation tensors
- use Xavier initialization and higher BCE learning rate in XOR demo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f751729c832ab39a8619dce806bb