### PR TITLE
Fix reverse operator semantics and stabilize XOR training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy>=1.7
 Pillow>=10
 fonttools>=4
 scikit-image>=0.21
+pandas>=2

--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -18,14 +18,16 @@ class Linear:
         if init == "he" or init == "auto_relu":
             scale = math.sqrt(2.0 / float(in_dim))
         elif init == "xavier":
-            scale = math.sqrt(2.0 / float(in_dim + out_dim))
+            # Use a tanh-friendly Xavier gain by default
+            scale = math.sqrt(1.0 / float(in_dim + out_dim))
         else:
             scale = 0.02
         logger.debug(
             f"Linear layer init: in_dim={in_dim}, out_dim={out_dim}, bias={bias}, init={init}, scale={scale}"
         )
         self.W = _randn_matrix(in_dim, out_dim, like=like, scale=scale)
-        self.b = from_list_like([[0.0] * out_dim], like=like) if bias else None
+        # Seed a small positive bias to avoid symmetric stall at init
+        self.b = from_list_like([[0.01] * out_dim], like=like) if bias else None
         logger.debug(
             f"Linear layer weights shape: {getattr(self.W, 'shape', None)}; bias shape: {getattr(self.b, 'shape', None) if self.b is not None else None}"
         )

--- a/src/common/tensors/abstract_nn/demo_xor.py
+++ b/src/common/tensors/abstract_nn/demo_xor.py
@@ -9,6 +9,8 @@ def get_operator_dataset(op_name, like):
     X = from_list_like(
         [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]], like=like
     )
+    # Zero-center the inputs for tanh stability
+    X = X * 2.0 - 1.0
     if op_name == 'xor':
         Y = from_list_like([[0.0], [1.0], [1.0], [0.0]], like=like)
     elif op_name == 'and':
@@ -37,7 +39,8 @@ def run_operator_demo(op_name, loss_type, like, debug_hooks=None, until_stop=Fal
         ],
         activations=[Tanh(), Sigmoid() if loss_type == 'mse' else None],
     )
-    opt = Adam(model.parameters(), lr=1e-2 if loss_type == 'mse' else 3e-3)
+    # Use the same learning rate for both losses; BCE needs a higher LR
+    opt = Adam(model.parameters(), lr=1e-2)
     if loss_type == 'mse':
         loss_fn = MSELoss()
     else:

--- a/src/common/tensors/abstract_nn/losses.py
+++ b/src/common/tensors/abstract_nn/losses.py
@@ -62,8 +62,9 @@ class BCEWithLogitsLoss(Loss):
         self.run_hooks('before_forward', pred=logits, target=target)
         z = logits
         y = target
-        absz = (z * z).sqrt()
-        out = (z.clamp_min(0.0) - z * y + ((absz * -1.0).exp() + 1.0).log()).mean()
+        # softplus(z) - y*z with an explicit abs() to avoid sqrt(z*z)
+        softplus = z.clamp_min(0.0) + ((-abs(z)).exp() + 1.0).log()
+        out = (softplus - z * y).mean()
         self.run_hooks('after_forward', pred=logits, target=target, output=out)
         return out
 

--- a/src/common/tensors/abstract_nn/train.py
+++ b/src/common/tensors/abstract_nn/train.py
@@ -28,7 +28,11 @@ class GradControl:
 
 def _l2(g) -> float:
     # scalar float L2 for any AbstractTensor
-    return float(((g * g).sum()).sqrt().item())
+    s = (g * g).sum()
+    # Some backends return a tensor with sqrt(), others a numeric value
+    if hasattr(s, "sqrt"):
+        return float(s.sqrt().item())
+    return float(s) ** 0.5
 
 
 def _global_l2(grads: List) -> float:

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -206,35 +206,35 @@ class JAXTensorOperations(AbstractTensor):
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":
-            return b + a
+            return a + b
         if op in ("sub", "isub"):
             return a - b
         if op == "rsub":
-            return b - a
+            return a - b
         if op in ("mul", "imul"):
             return a * b
         if op == "rmul":
-            return b * a
+            return a * b
         if op in ("truediv", "itruediv"):
             return a / b
         if op == "rtruediv":
-            return b / a
+            return a / b
         if op in ("floordiv", "ifloordiv"):
             return jnp.floor(a / b)
         if op == "rfloordiv":
-            return jnp.floor(b / a)
+            return jnp.floor(a / b)
         if op in ("mod", "imod"):
             return jnp.mod(a, b)
         if op == "rmod":
-            return jnp.mod(b, a)
+            return jnp.mod(a, b)
         if op in ("pow", "ipow"):
             return jnp.power(a, b)
         if op == "rpow":
-            return jnp.power(b, a)
+            return jnp.power(a, b)
         if op in ("matmul", "imatmul"):
             return a @ b
         if op == "rmatmul":
-            return b @ a
+            return a @ b
         raise NotImplementedError(f"Operator {op} not implemented for JAX backend.")
 
     # ------------------------------------------------------------------

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -184,35 +184,35 @@ class NumPyTensorOperations(AbstractTensor):
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":
-            return b + a
+            return a + b
         if op in ("sub", "isub"):
             return a - b
         if op == "rsub":
-            return b - a
+            return a - b
         if op in ("mul", "imul"):
             return a * b
         if op == "rmul":
-            return b * a
+            return a * b
         if op in ("truediv", "itruediv"):
             return a / b
         if op == "rtruediv":
-            return b / a
+            return a / b
         if op in ("floordiv", "ifloordiv"):
             return np.floor_divide(a, b)
         if op == "rfloordiv":
-            return np.floor_divide(b, a)
+            return np.floor_divide(a, b)
         if op in ("mod", "imod"):
             return np.mod(a, b)
         if op == "rmod":
-            return np.mod(b, a)
+            return np.mod(a, b)
         if op in ("pow", "ipow"):
             return np.power(a, b)
         if op == "rpow":
-            return np.power(b, a)
+            return np.power(a, b)
         if op in ("matmul", "imatmul"):
             return a @ b
         if op == "rmatmul":
-            return b @ a
+            return a @ b
         raise NotImplementedError(f"Operator {op} not implemented for NumPy backend.")
 
     def _torch_dtype_to_numpy(self, dtype):

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -170,19 +170,19 @@ class PurePythonTensorOperations(AbstractTensor):
         if op in ("add", "radd", "iadd"):
             return x + y
         if op in ("sub", "rsub", "isub"):
-            return x - y if op != "rsub" else y - x
+            return x - y
         if op in ("mul", "rmul", "imul"):
             return x * y
         if op in ("truediv", "rtruediv", "itruediv"):
-            return x / y if op != "rtruediv" else y / x
+            return x / y
         if op in ("floordiv", "rfloordiv", "ifloordiv"):
-            return x // y if op != "rfloordiv" else y // x
+            return x // y
         if op in ("mod", "rmod", "imod"):
-            return x % y if op != "rmod" else y % x
+            return x % y
         if op in ("pow", "rpow", "ipow"):
-            return x**y if op != "rpow" else y**x
+            return x**y
         if op in ("matmul", "rmatmul", "imatmul"):
-            return self._matmul(x, y) if op != "rmatmul" else self._matmul(y, x)
+            return self._matmul(x, y)
         raise NotImplementedError(
             f"Operator {op} not implemented for pure Python backend."
         )

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -180,31 +180,31 @@ class PyTorchTensorOperations(AbstractTensor):
         if op in ("sub", "isub"):
             return a - b
         if op == "rsub":
-            return b - a
+            return a - b
         if op in ("mul", "imul"):
             return a * b
         if op == "rmul":
-            return b * a
+            return a * b
         if op in ("truediv", "itruediv"):
             return a / b
         if op == "rtruediv":
-            return b / a
+            return a / b
         if op in ("floordiv", "ifloordiv"):
             return torch.floor_divide(a, b)
         if op == "rfloordiv":
-            return torch.floor_divide(b, a)
+            return torch.floor_divide(a, b)
         if op in ("mod", "imod"):
             return a % b
         if op == "rmod":
-            return b % a
+            return a % b
         if op in ("pow", "ipow"):
             return a ** b
         if op == "rpow":
-            return b ** a
+            return a ** b
         if op in ("matmul", "imatmul"):
             return a @ b
         if op == "rmatmul":
-            return b @ a
+            return a @ b
         raise NotImplementedError(f"Operator {op} not implemented for PyTorch backend.")
 
     def full_(self, size, fill_value, dtype, device):

--- a/tests/test_xor_learning.py
+++ b/tests/test_xor_learning.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src.common.tensors.abstract_nn import Linear, Model, Tanh, Sigmoid, BCEWithLogitsLoss, MSELoss, Adam, train_loop, set_seed
+from src.common.tensors.abstract_nn.utils import from_list_like
+from src.common.tensors.abstraction import AbstractTensor
+
+@pytest.mark.parametrize("loss_type", ["bce", "mse"])
+def test_xor_learns(loss_type):
+    ops = AbstractTensor.get_tensor(faculty=None)
+    set_seed(0)
+    X = from_list_like([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]], like=ops)
+    X = X * 2.0 - 1.0
+    Y = from_list_like([[0.0], [1.0], [1.0], [0.0]], like=ops)
+    model = Model(
+        layers=[Linear(2, 8, like=ops, init="xavier"), Linear(8, 1, like=ops, init="xavier")],
+        activations=[Tanh(), Sigmoid() if loss_type == "mse" else None],
+    )
+    opt = Adam(model.parameters(), lr=1e-2)
+    loss_fn = MSELoss() if loss_type == "mse" else BCEWithLogitsLoss()
+    # Large log_every suppresses internal printing during tests
+    losses = train_loop(model, loss_fn, opt, X, Y, epochs=2000, log_every=10000)
+    assert losses[-1] < 0.1


### PR DESCRIPTION
## Summary
- correct reversed math for `r*` operators across NumPy, Torch, JAX and pure backends
- make tanh models train by softening Xavier init, seeding biases, and refining BCE softplus
- add XOR learning test and zero-centered demo; include pandas dependency

## Testing
- `pytest tests/test_xor_learning.py -q`
- `pytest`
- `pytest tests/test_bce_with_logits_loss.py tests/test_mse_loss.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a607643e18832a95be9ddaf04ae214