### PR TITLE
Coerce list operands in tensor ops

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -801,6 +801,14 @@ class AbstractTensor:
         - for true division            -> cast bool to float
         Promotion happens BEFORE unwrap; backends never see bool arithmetic.
         """
+        # Coerce list-like operands into tensors so that operator logic remains
+        # backend-agnostic. This ensures raw Python lists interoperate with
+        # tensors without requiring callers to explicitly convert them.
+        if isinstance(left, AbstractTensor) and isinstance(right, (list, tuple)):
+            right = left.ensure_tensor(right)
+        elif isinstance(right, AbstractTensor) and isinstance(left, (list, tuple)):
+            left = right.ensure_tensor(left)
+
         arithmetic_ops = {
             "add","sub","mul","truediv","floordiv","mod","pow",
             "iadd","isub","imul","itruediv","ifloordiv","imod","ipow",

--- a/tests/test_tensor_list_coercion.py
+++ b/tests/test_tensor_list_coercion.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pytest
+
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.common.tensors.torch_backend import PyTorchTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    PyTorchTensorOperations = None
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    NumPyTensorOperations = None
+
+try:
+    from src.common.tensors.jax_backend import JAXTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    JAXTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+torch_spec = importlib.util.find_spec("torch")
+if PyTorchTensorOperations is not None and torch_spec is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+jax_spec = importlib.util.find_spec("jax")
+if JAXTensorOperations is not None and jax_spec is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_python_list_operands(backend_name, Backend):
+    t = Backend.tensor_from_list([1, 2, 3])
+    assert (t - [1, 1, 1]).tolist() == [0, 1, 2]
+    assert ([1, 1, 1] - t).tolist() == [0, -1, -2]


### PR DESCRIPTION
## Summary
- Handle Python list or tuple operands in `_apply_operator` to automatically convert them into tensors, preventing backend mismatches.
- Add regression test verifying list operands work on all available tensor backends.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61f7aca44832ab68b74801e4ca81f