### PR TITLE
Add comparison dunders and NumPy parity fixes

### DIFF
--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -186,17 +186,20 @@ class JAXTensorOperations(AbstractTensor):
             return tensor
         return jnp.array(tensor)
 
-    def to_device_(self, tensor: Any, device: Any) -> Any:
+    def to_device_(self, device: Any) -> Any:
         """Move tensor to specified device with validation."""
         target_device = device or self.default_device
         if target_device is not None:
             device_str = str(target_device).lower()
-            if ('gpu' in device_str and not self.has_gpu) or \
-               ('tpu' in device_str and not self.has_tpu):
-                print(f"Warning: Requested device {device_str} not available. Using CPU.")
+            if ('gpu' in device_str and not self.has_gpu) or (
+                'tpu' in device_str and not self.has_tpu
+            ):
+                print(
+                    f"Warning: Requested device {device_str} not available. Using CPU."
+                )
                 target_device = jax.devices('cpu')[0]
-        
-        return jax.device_put(self._to_jnp(tensor), target_device)
+
+        return jax.device_put(self.data, target_device)
 
     def _apply_operator__(self, op: str, left: Any, right: Any):
         """Apply arithmetic ops using JAX arrays."""
@@ -286,8 +289,9 @@ class JAXTensorOperations(AbstractTensor):
     def bool_(self, tensor: Any) -> Any:
         return self.to_dtype_(tensor, "bool")
 
-    def not_equal_(self, tensor1: Any, tensor2: Any) -> Any:
-        return jnp.not_equal(self._to_jnp(tensor1), self._to_jnp(tensor2))
+    def not_equal_(self, value: Any) -> Any:
+        value = value.data if isinstance(value, AbstractTensor) else value
+        return jnp.not_equal(self.data, value)
 
     def arange_(self, start: int, end: Optional[int] = None, step: int = 1, device: Any = None, dtype: Any = None) -> Any:
         arr = jnp.arange(start, end, step, dtype=dtype) if end is not None else jnp.arange(start, dtype=dtype)
@@ -397,8 +401,9 @@ class JAXTensorOperations(AbstractTensor):
     def tolist_(self) -> list:
         return list(self._to_jnp(self.data).tolist())
 
-    def less_(self, tensor: Any, value: Any) -> Any:
-        return jnp.less(self._to_jnp(tensor), value)
+    def less_(self, value: Any) -> Any:
+        value = value.data if isinstance(value, AbstractTensor) else value
+        return jnp.less(self.data, value)
 
     def index_select_(self, tensor: Any, dim: int, indices: Any) -> Any:
         return jnp.take(self._to_jnp(tensor), indices, axis=dim)

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -100,6 +100,10 @@ class NumPyTensorOperations(AbstractTensor):
         value = value.data if isinstance(value, AbstractTensor) else value
         return self.data <= value
 
+    def less_(self, value):
+        value = value.data if isinstance(value, AbstractTensor) else value
+        return self.data < value
+
     def equal_(self, value):
         value = value.data if isinstance(value, AbstractTensor) else value
         return self.data == value
@@ -261,14 +265,14 @@ class NumPyTensorOperations(AbstractTensor):
         tensor = self._AbstractTensor__unwrap(tensor if tensor is not None else self.data)
         return np.array(tensor, copy=True)
 
-    def to_device_(self, tensor, device):
-        return self._AbstractTensor__unwrap(tensor)
+    def to_device_(self, device):
+        return self.data
 
-    def get_device_(self, tensor):
-        return 'cpu'
+    def get_device_(self):
+        return "cpu"
 
-    def get_dtype_(self, tensor):
-        tensor = self._AbstractTensor__unwrap(tensor)
+    def get_dtype_(self):
+        tensor = self.data
         if isinstance(tensor, np.ndarray):
             return self._numpy_dtype_to_torch(tensor.dtype)
         return tensor.dtype
@@ -297,8 +301,9 @@ class NumPyTensorOperations(AbstractTensor):
     def bool_(self, tensor):
         return self.to_dtype_(tensor, "bool")
 
-    def not_equal_(self, tensor1, tensor2):
-        return self._AbstractTensor__unwrap(tensor1) != self._AbstractTensor__unwrap(tensor2)
+    def not_equal_(self, value):
+        value = value.data if isinstance(value, AbstractTensor) else value
+        return self.data != value
 
     def arange_(self, start, end=None, step=1, device=None, dtype=None):
         np_dtype = self._torch_dtype_to_numpy(dtype) if dtype is not None else None
@@ -386,7 +391,11 @@ class NumPyTensorOperations(AbstractTensor):
         return np.clip(self.data, a_min=min_val, a_max=max_val)
 
     def shape_(self):
-        return tuple(self.data.shape)
+        v = self.data
+        try:
+            return tuple(v.shape)
+        except Exception:
+            return ()
 
     def numel_(self):
         return self.data.size

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -251,9 +251,9 @@ class PyTorchTensorOperations(AbstractTensor):
     def bool_(self):
         return self.data.bool()
 
-    def not_equal_(self, other):
-        from .abstraction import AbstractTensor
-        return self.data != (other.data if isinstance(other, AbstractTensor) else other)
+    def not_equal_(self, value):
+        value = value.data if isinstance(value, AbstractTensor) else value
+        return self.data != value
 
     def arange_(self, start, end=None, step=1, device=None, dtype=None):
         if end is None:
@@ -357,6 +357,7 @@ class PyTorchTensorOperations(AbstractTensor):
         return self.data.tolist()
 
     def less_(self, value):
+        value = value.data if isinstance(value, AbstractTensor) else value
         return self.data < value
 
     def index_select_(self, dim, indices):


### PR DESCRIPTION
## Summary
- route comparison operators through tensor methods to avoid Python bools
- add strict `less` comparison and tensor truthiness checks
- align NumPy backend with abstract interface and scalar shapes
- propagate comparison hooks and device helpers to torch, JAX, and pure backends

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64dc894c4832aa045458e7a7b676c