### PR TITLE
Fix DEC validation and add package alias

### DIFF
--- a/abstract_convolution/__init__.py
+++ b/abstract_convolution/__init__.py
@@ -1,0 +1,27 @@
+"""Compatibility package for tests.
+
+This thin wrapper re-exports the abstract convolution
+implementation located under ``src.common.tensors`` so that it can
+be imported as ``abstract_convolution`` in tests and examples.
+"""
+
+from importlib import import_module as _import_module
+
+# Re-export the laplace_nd module and its public API.
+laplace_nd = _import_module("src.common.tensors.abstract_convolution.laplace_nd")
+
+# Lift common classes/functions into the package namespace for convenience.
+from src.common.tensors.abstract_convolution import (
+    BuildLaplace3D,
+    GridDomain,
+    Transform,
+    RectangularTransform,
+)
+
+__all__ = [
+    "laplace_nd",
+    "BuildLaplace3D",
+    "GridDomain",
+    "Transform",
+    "RectangularTransform",
+]

--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -1278,12 +1278,18 @@ def validate_transform_hub():
     hub = IdentityTransform(1.0, 1.0, (True, True, True, True))
     geometry = hub.calculate_geometry(U, V, W, edge_index=edge_index, detect_faces=True)
 
-    # Validate d0^T d0 = 0
+    # Validate that each edge has zero net incidence.
+    # In a proper incidence matrix every row should sum to zero
+    # because edges connect exactly two vertices with opposite
+    # orientation.  This property ensures that a constant 0-form
+    # lies in the kernel of d0.
     d0 = geometry["DEC"]["d_operators"]["d0"]
-    d0t_d0 = torch.mm(d0.T, d0)
-    assert torch.allclose(d0t_d0, torch.zeros_like(d0t_d0), atol=1e-8), "d0^T d0 != 0. Exactness violated."
+    row_sum = d0.sum(dim=1)
+    assert torch.allclose(
+        row_sum, torch.zeros_like(row_sum), atol=1e-8
+    ), "Edge incidences should sum to zero."
 
-    print("Validation successful. d0^T d0 = 0 and faces detected (if any).")
+    print("Validation successful. Edge incidences sum to zero and faces detected (if any).")
 
 if __name__ == "__main__":
     validate_transform_hub()


### PR DESCRIPTION
## Summary
- fix transform validation to check edge incidence properly
- add `abstract_convolution` compatibility package for tests

## Testing
- `python -m src.common.tensors.abstract_convolution.laplace_nd`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'resolution_u'; relative error too high)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ec778cc832a90bc0a2ef378fb1a