### PR TITLE
Add cumsum to tensor abstraction and track missing laplace functions

### DIFF
--- a/src/common/tensors/LAPLACE_BACKLOG.md
+++ b/src/common/tensors/LAPLACE_BACKLOG.md
@@ -1,0 +1,35 @@
+# Laplace Torch Function Backlog
+
+Torch functions invoked in `abstract_convolution/laplace_nd.py` that are not yet
+covered by the `AbstractTensor` API. Each entry is a task to implement the
+function across all backends and add the underscore redirect in
+`abstraction.py`.
+
+- [ ] all
+- [ ] allclose
+- [ ] any
+- [ ] cos
+- [ ] cross
+- [x] cumsum
+- [ ] det
+- [ ] diag
+- [ ] dot
+- [ ] einsum
+- [ ] empty
+- [ ] full_like
+- [ ] inverse
+- [ ] isfinite
+- [ ] isinf
+- [ ] isnan
+- [ ] linspace
+- [ ] meshgrid
+- [ ] nonzero
+- [ ] norm
+- [ ] ones
+- [ ] ones_like
+- [ ] prod
+- [ ] randn
+- [ ] sin
+- [ ] sparse_coo_tensor
+- [ ] tan
+- [ ] zeros_like

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -392,6 +392,12 @@ class AbstractTensor:
         """Return the sum of the tensor along the specified dimension(s)."""
         return self.sum_(dim=dim, keepdim=keepdim)
 
+    def cumsum(self, dim: int = 0) -> "AbstractTensor":
+        """Return the cumulative sum of the tensor along a dimension."""
+        result = type(self)(track_time=self.track_time)
+        result.data = self.cumsum_(dim)
+        return result
+
     def min(self, dim=None, keepdim: bool = False):
         """Return the minimum of the tensor along the specified dimension(s)."""
         return self.min_(dim=dim, keepdim=keepdim)
@@ -405,6 +411,9 @@ class AbstractTensor:
 
     def sum_(self, dim=None, keepdim: bool = False):
         raise NotImplementedError(f"{self.__class__.__name__} must implement sum_() with keepdim.")
+
+    def cumsum_(self, dim: int = 0):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement cumsum_()")
 
     def min_(self, dim=None, keepdim: bool = False):
         raise NotImplementedError(f"{self.__class__.__name__} must implement min_() with keepdim.")

--- a/src/common/tensors/abstraction_functions.md
+++ b/src/common/tensors/abstraction_functions.md
@@ -98,6 +98,7 @@ This document groups available methods by theme for quick reference.
 - AbstractTensor.pow()
 - AbstractTensor.sqrt()
 - AbstractTensor.mean()
+- AbstractTensor.cumsum()
 - AbstractTensor.max()
 - AbstractTensor.log_softmax()
 

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -346,6 +346,10 @@ class JAXTensorOperations(AbstractTensor):
     def repeat_interleave_(self, tensor: Any, repeats: int, dim: Optional[int] = None) -> Any:
         return jnp.repeat(self._to_jnp(tensor), repeats, axis=dim).tolist()
 
+    def cumsum_(self, dim: int = 0) -> Any:
+        import jax.numpy as jnp
+        return jnp.cumsum(self.data, axis=dim)
+
     def repeat_(self, repeats: Any = None, dim: int = 0) -> Any:
         """Repeat tensor along ``dim`` ``repeats`` times (stub)."""
         raise NotImplementedError("repeat not implemented for JAX backend")

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -430,6 +430,10 @@ class NumPyTensorOperations(AbstractTensor):
             dim = 0
         return np.repeat(self.data, repeats, axis=dim)
 
+    def cumsum_(self, dim=0):
+        import numpy as np
+        return np.cumsum(self.data, axis=dim)
+
     def repeat_(self, repeats=None, dim: int = 0):
         """Repeat tensor along ``dim`` ``repeats`` times (stub)."""
         raise NotImplementedError("repeat not implemented for NumPy backend")

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -577,6 +577,20 @@ class PurePythonTensorOperations(AbstractTensor):
             return result
         raise NotImplementedError("repeat_interleave only implemented for dim 0 or None")
 
+    def cumsum_(self, dim: int = 0) -> Any:
+        try:
+            import numpy as np  # type: ignore
+            return np.cumsum(self.data, axis=dim).tolist()
+        except Exception:
+            if dim != 0:
+                raise NotImplementedError("pure backend cumsum_ only supports dim=0 without numpy")
+            out = []
+            total = 0.0
+            for v in self.data:
+                total += v
+                out.append(total)
+            return out
+
     def repeat_(self, repeats: Any = None, dim: int = 0) -> Any:
         """Repeat tensor along ``dim`` ``repeats`` times (stub)."""
         raise NotImplementedError("repeat not implemented for PurePython backend")

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -320,6 +320,10 @@ class PyTorchTensorOperations(AbstractTensor):
         if dim is None:
             dim = 0
         return self.data.repeat_interleave(repeats, dim=dim)
+
+    def cumsum_(self, dim=0):
+        import torch
+        return torch.cumsum(self.data, dim=dim)
         
 
     def view_flat_(self):


### PR DESCRIPTION
## Summary
- expose `cumsum` in `AbstractTensor` and implement `cumsum_` across torch, numpy, jax and pure-python backends
- document `cumsum` in abstraction functions
- track torch ops used in `laplace_nd.py` that lack abstraction with a new backlog file

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a6ac2d57ec832a86f56ac44036c7d6