### PR TITLE
Add full trigonometric suite to tensor backends

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -342,6 +342,65 @@ class AbstractTensor:
     def log_(self):
         raise NotImplementedError(f"{self.__class__.__name__} must implement log_()")
 
+    # --- Trigonometric and hyperbolic functions ---
+    def sin(self) -> "AbstractTensor":
+        return self._apply_operator("sin", self, None)
+
+    def cos(self) -> "AbstractTensor":
+        return self._apply_operator("cos", self, None)
+
+    def tan(self) -> "AbstractTensor":
+        return self._apply_operator("tan", self, None)
+
+    def asin(self) -> "AbstractTensor":
+        return self._apply_operator("asin", self, None)
+
+    def acos(self) -> "AbstractTensor":
+        return self._apply_operator("acos", self, None)
+
+    def atan(self) -> "AbstractTensor":
+        return self._apply_operator("atan", self, None)
+
+    def sinh(self) -> "AbstractTensor":
+        return self._apply_operator("sinh", self, None)
+
+    def cosh(self) -> "AbstractTensor":
+        return self._apply_operator("cosh", self, None)
+
+    def tanh(self) -> "AbstractTensor":
+        return self._apply_operator("tanh", self, None)
+
+    def asinh(self) -> "AbstractTensor":
+        return self._apply_operator("asinh", self, None)
+
+    def acosh(self) -> "AbstractTensor":
+        return self._apply_operator("acosh", self, None)
+
+    def atanh(self) -> "AbstractTensor":
+        return self._apply_operator("atanh", self, None)
+
+    # Derived via identities
+    def sec(self) -> "AbstractTensor":
+        return self.cos() ** -1
+
+    def csc(self) -> "AbstractTensor":
+        return self.sin() ** -1
+
+    def cot(self) -> "AbstractTensor":
+        return self.cos() / self.sin()
+
+    def sech(self) -> "AbstractTensor":
+        return self.cosh() ** -1
+
+    def csch(self) -> "AbstractTensor":
+        return self.sinh() ** -1
+
+    def coth(self) -> "AbstractTensor":
+        return self.cosh() / self.sinh()
+
+    def sinc(self) -> "AbstractTensor":
+        return self.sin() / self
+
     # --- Softmax utilities ---
     def softmax(self, dim: int = -1) -> "AbstractTensor":
         result = type(self)(track_time=self.track_time)

--- a/src/common/tensors/abstraction_functions.md
+++ b/src/common/tensors/abstraction_functions.md
@@ -102,6 +102,27 @@ This document groups available methods by theme for quick reference.
 - AbstractTensor.max()
 - AbstractTensor.log_softmax()
 
+## Trigonometric & Hyperbolic
+- AbstractTensor.sin()
+- AbstractTensor.cos()
+- AbstractTensor.tan()
+- AbstractTensor.asin()
+- AbstractTensor.acos()
+- AbstractTensor.atan()
+- AbstractTensor.sinh()
+- AbstractTensor.cosh()
+- AbstractTensor.tanh()
+- AbstractTensor.asinh()
+- AbstractTensor.acosh()
+- AbstractTensor.atanh()
+- AbstractTensor.sec()
+- AbstractTensor.csc()
+- AbstractTensor.cot()
+- AbstractTensor.sech()
+- AbstractTensor.csch()
+- AbstractTensor.coth()
+- AbstractTensor.sinc()
+
 ## Persistence
 - AbstractTensor.save()
 - AbstractTensor.load()

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -212,6 +212,30 @@ class JAXTensorOperations(AbstractTensor):
             return jnp.abs(a)
         if op == "invert":
             return jnp.invert(a)
+        if op == "sin":
+            return jnp.sin(a)
+        if op == "cos":
+            return jnp.cos(a)
+        if op == "tan":
+            return jnp.tan(a)
+        if op == "asin":
+            return jnp.arcsin(a)
+        if op == "acos":
+            return jnp.arccos(a)
+        if op == "atan":
+            return jnp.arctan(a)
+        if op == "sinh":
+            return jnp.sinh(a)
+        if op == "cosh":
+            return jnp.cosh(a)
+        if op == "tanh":
+            return jnp.tanh(a)
+        if op == "asinh":
+            return jnp.arcsinh(a)
+        if op == "acosh":
+            return jnp.arccosh(a)
+        if op == "atanh":
+            return jnp.arctanh(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -196,6 +196,30 @@ class NumPyTensorOperations(AbstractTensor):
             return np.abs(a)
         if op == "invert":
             return np.invert(a)
+        if op == "sin":
+            return np.sin(a)
+        if op == "cos":
+            return np.cos(a)
+        if op == "tan":
+            return np.tan(a)
+        if op == "asin":
+            return np.arcsin(a)
+        if op == "acos":
+            return np.arccos(a)
+        if op == "atan":
+            return np.arctan(a)
+        if op == "sinh":
+            return np.sinh(a)
+        if op == "cosh":
+            return np.cosh(a)
+        if op == "tanh":
+            return np.tanh(a)
+        if op == "asinh":
+            return np.arcsinh(a)
+        if op == "acosh":
+            return np.arccosh(a)
+        if op == "atanh":
+            return np.arctanh(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -156,6 +156,30 @@ class PurePythonTensorOperations(AbstractTensor):
             return abs(x)
         if op == "invert":
             return ~x
+        if op == "sin":
+            return math.sin(x)
+        if op == "cos":
+            return math.cos(x)
+        if op == "tan":
+            return math.tan(x)
+        if op == "asin":
+            return math.asin(x)
+        if op == "acos":
+            return math.acos(x)
+        if op == "atan":
+            return math.atan(x)
+        if op == "sinh":
+            return math.sinh(x)
+        if op == "cosh":
+            return math.cosh(x)
+        if op == "tanh":
+            return math.tanh(x)
+        if op == "asinh":
+            return math.asinh(x)
+        if op == "acosh":
+            return math.acosh(x)
+        if op == "atanh":
+            return math.atanh(x)
         raise NotImplementedError(f"Operator {op} not implemented for pure Python backend.")
 
     def _elementwise_op(self, op: str, a, b):

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -175,6 +175,30 @@ class PyTorchTensorOperations(AbstractTensor):
             return torch.abs(a)
         if op == "invert":
             return torch.bitwise_not(a)
+        if op == "sin":
+            return torch.sin(a)
+        if op == "cos":
+            return torch.cos(a)
+        if op == "tan":
+            return torch.tan(a)
+        if op == "asin":
+            return torch.asin(a)
+        if op == "acos":
+            return torch.acos(a)
+        if op == "atan":
+            return torch.atan(a)
+        if op == "sinh":
+            return torch.sinh(a)
+        if op == "cosh":
+            return torch.cosh(a)
+        if op == "tanh":
+            return torch.tanh(a)
+        if op == "asinh":
+            return torch.asinh(a)
+        if op == "acosh":
+            return torch.acosh(a)
+        if op == "atanh":
+            return torch.atanh(a)
         if op in ("add", "iadd"):
             return a + b
         if op == "radd":

--- a/tests/test_trig_functions.py
+++ b/tests/test_trig_functions.py
@@ -1,0 +1,66 @@
+import importlib.util
+import numpy as np
+import pytest
+
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.common.tensors.torch_backend import PyTorchTensorOperations
+except Exception:
+    PyTorchTensorOperations = None
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:
+    NumPyTensorOperations = None
+
+try:
+    from src.common.tensors.jax_backend import JAXTensorOperations
+except Exception:
+    JAXTensorOperations = None
+
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+
+torch_spec = importlib.util.find_spec("torch")
+if PyTorchTensorOperations is not None and torch_spec is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+
+jax_spec = importlib.util.find_spec("jax")
+if JAXTensorOperations is not None and jax_spec is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,BackendCls", BACKENDS)
+def test_trigonometric_suite(backend_name, BackendCls):
+    vals = [0.5, 0.8]
+    t = BackendCls.tensor_from_list(vals, dtype=None, device=None)
+    arr = np.array(vals)
+
+    np.testing.assert_allclose(t.sin().tolist(), np.sin(arr))
+    np.testing.assert_allclose(t.cos().tolist(), np.cos(arr))
+    np.testing.assert_allclose(t.tan().tolist(), np.tan(arr))
+    np.testing.assert_allclose(t.asin().tolist(), np.arcsin(arr))
+    np.testing.assert_allclose(t.acos().tolist(), np.arccos(arr))
+    np.testing.assert_allclose(t.atan().tolist(), np.arctan(arr))
+
+    np.testing.assert_allclose(t.sinh().tolist(), np.sinh(arr))
+    np.testing.assert_allclose(t.cosh().tolist(), np.cosh(arr))
+    np.testing.assert_allclose(t.tanh().tolist(), np.tanh(arr))
+    np.testing.assert_allclose(t.asinh().tolist(), np.arcsinh(arr))
+    np.testing.assert_allclose(t.atanh().tolist(), np.arctanh(arr))
+
+    acosh_vals = [1.0, 2.0]
+    t_acosh = BackendCls.tensor_from_list(acosh_vals, dtype=None, device=None)
+    np.testing.assert_allclose(t_acosh.acosh().tolist(), np.arccosh(np.array(acosh_vals)))
+
+    np.testing.assert_allclose(t.sec().tolist(), 1 / np.cos(arr))
+    np.testing.assert_allclose(t.csc().tolist(), 1 / np.sin(arr))
+    np.testing.assert_allclose(t.cot().tolist(), np.cos(arr) / np.sin(arr))
+    np.testing.assert_allclose(t.sech().tolist(), 1 / np.cosh(arr))
+    np.testing.assert_allclose(t.csch().tolist(), 1 / np.sinh(arr))
+    np.testing.assert_allclose(t.coth().tolist(), np.cosh(arr) / np.sinh(arr))
+    np.testing.assert_allclose(t.sinc().tolist(), np.sin(arr) / arr)


### PR DESCRIPTION
## Summary
- implement comprehensive trigonometric and hyperbolic functions on AbstractTensor
- wire new ops through torch, numpy, jax, and pure backends
- cover extended trig identities via sec/csc/cot and related helpers
- document and test the new trigonometric API

## Testing
- `pytest` *(fails: RuntimeError: Numpy is not available in laplace tests)*
- `pytest tests/test_trig_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6aefb13b0832a8f6604d8c4fc3b69