### PR TITLE
Implement flatten operation for torch tensors

### DIFF
--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -351,6 +351,9 @@ class PyTorchTensorOperations(AbstractTensor):
     def view_flat_(self):
         return self.data.view(-1)
 
+    def flatten_(self):
+        return self.data.flatten()
+
     def assign_at_indices_(self, indices_dim0, indices_dim1, values_to_assign):
         self.data[indices_dim0, indices_dim1] = values_to_assign
         return self.data

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -37,3 +37,10 @@ def test_basic_add_and_zeros(backend_name, Backend):
     assert result.tolist() == [[6, 8], [10, 12]]
     zeros = Backend.zeros((2, 2))
     assert zeros.tolist() == [[0, 0], [0, 0]]
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_flatten(backend_name, Backend):
+    a = Backend.tensor_from_list([[1, 2], [3, 4]])
+    flat = a.flatten()
+    assert flat.tolist() == [1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- add `flatten_` method to PyTorch tensor backend
- test tensor flattening across available backends

## Testing
- `pytest tests/test_tensor_basic_ops.py::test_flatten -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d3c2938c832a96d66b4ef981c7e7