### PR TITLE
Fix flatten fallback to listify tensors

### DIFF
--- a/src/common/tensors/abstraction_methods/reshape.py
+++ b/src/common/tensors/abstraction_methods/reshape.py
@@ -77,7 +77,7 @@ def flatten(self):
         if not isinstance(data, list):
             return [data]
         return [item for sublist in data for item in _flatten(sublist)]
-    flat_data = _flatten(self.data)
+    flat_data = _flatten(self.tolist())
     out = type(self)(track_time=getattr(self, 'track_time', False))
     out.data = flat_data
     return out


### PR DESCRIPTION
## Summary
- ensure reshape.flatten fallback converts tensors to lists using tolist

## Testing
- `pytest` (fails: AbstractTensor.get_tensor() got an unexpected keyword argument 'faculty')

------
https://chatgpt.com/codex/tasks/task_e_68a7d3c41a6c832aac51b64e4f02c192