### PR TITLE
Add unravel_index abstraction and backend hooks

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1218,6 +1218,11 @@ class AbstractTensor:
     def squeeze_(self, dim: int | None = None):
         raise NotImplementedError(f"{self.__class__.__name__} must implement squeeze_()")
 
+    def unravel_index_(self, shape):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement unravel_index_()"
+        )
+
 
 class AbstractF:
     """
@@ -1377,6 +1382,9 @@ from .abstraction_methods.reduction import (
     max as reduction_max,
     argmax as reduction_argmax,
 )
+from .abstraction_methods.indexing import (
+    unravel_index as indexing_unravel_index,
+)
 from .abstraction_methods.type_ops import (
     to as type_to,
     astype as type_astype,
@@ -1469,6 +1477,8 @@ AbstractTensor.randint_like = randint_like
 
 AbstractTensor.max    = reduction_max
 AbstractTensor.argmax = reduction_argmax
+
+AbstractTensor.unravel_index = staticmethod(indexing_unravel_index)
 
 AbstractTensor.to        = type_to
 AbstractTensor.astype    = type_astype

--- a/src/common/tensors/abstraction_functions.md
+++ b/src/common/tensors/abstraction_functions.md
@@ -49,6 +49,7 @@ This document groups available methods by theme for quick reference.
 - AbstractTensor.increment_at_indices()
 - AbstractTensor.__getitem__()
 - AbstractTensor.__setitem__()
+- AbstractTensor.unravel_index()
 
 ## Reshaping & Manipulation
 - AbstractTensor.view_flat()

--- a/src/common/tensors/abstraction_methods/indexing.py
+++ b/src/common/tensors/abstraction_methods/indexing.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+
+def unravel_index(indices: Any, shape: Tuple[int, ...]):
+    """Map flat ``indices`` into coordinates for a tensor of ``shape``.
+
+    Delegates to the backend-specific implementation ``unravel_index_`` after
+    converting ``indices`` to an ``AbstractTensor`` instance.
+    """
+    from ..abstraction import AbstractTensor
+
+    tensor = AbstractTensor.get_tensor(indices)
+    return tensor.unravel_index_(shape)

--- a/src/common/tensors/accelerator_backends/c_backend.py
+++ b/src/common/tensors/accelerator_backends/c_backend.py
@@ -648,6 +648,11 @@ class CTensorOperations(AbstractTensor):
         # ############################################################
         raise NotImplementedError("cat not implemented for C backend")
 
+    def unravel_index_(self, shape):
+        raise NotImplementedError(
+            "unravel_index not implemented for C backend"
+        )
+
     def get_device_(self, tensor: CTensor) -> str:
         return "cpu_cffi"
 

--- a/src/common/tensors/accelerator_backends/opengl_backend.py
+++ b/src/common/tensors/accelerator_backends/opengl_backend.py
@@ -122,6 +122,11 @@ class OpenGLTensorOperations(AbstractTensor):
     def stack_(self, tensors: list[Any], dim: int = 0):
         raise NotImplementedError
 
+    def unravel_index_(self, shape):
+        raise NotImplementedError(
+            "unravel_index not implemented for OpenGL backend"
+        )
+
     def repeat_interleave_(self, repeats: int = 1, dim: int | None = None):
         raise NotImplementedError
 

--- a/src/common/tensors/accelerator_backends/rust_backend.py
+++ b/src/common/tensors/accelerator_backends/rust_backend.py
@@ -54,3 +54,8 @@ class RustTensorOperations:
     def full_(self, size: tuple[int, ...], fill_value: Any, dtype: Any, device: Any):
         raise NotImplementedError
 
+    def unravel_index_(self, shape):
+        raise NotImplementedError(
+            "unravel_index not implemented for Rust backend"
+        )
+

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -162,6 +162,13 @@ class JAXTensorOperations(AbstractTensor):
     def squeeze_(self, dim: int | None = None):
         import jax.numpy as jnp
         return jnp.squeeze(self.data, axis=dim) if dim is not None else jnp.squeeze(self.data)
+
+    def unravel_index_(self, shape):
+        import jax.numpy as jnp
+        result = jnp.unravel_index(self.data, shape)
+        if hasattr(self.data, "shape") and self.data.shape == ():
+            return tuple(int(x) for x in result)
+        return result
     """Tensor operations powered by `jax.numpy`."""
 
     def __init__(self, default_device: Optional[Any] = None, track_time: bool = False) -> None:

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -182,6 +182,13 @@ class NumPyTensorOperations(AbstractTensor):
     def squeeze_(self, dim: int | None = None):
         import numpy as np
         return np.squeeze(self.data, axis=dim) if dim is not None else np.squeeze(self.data)
+
+    def unravel_index_(self, shape):
+        import numpy as np
+        result = np.unravel_index(self.data, shape)
+        if np.isscalar(self.data) or (isinstance(self.data, np.ndarray) and self.data.ndim == 0):
+            return tuple(int(x) for x in result)
+        return result
     def __init__(self, track_time: bool = False):
         super().__init__(track_time=track_time)
 

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -102,6 +102,16 @@ class PurePythonTensorOperations(AbstractTensor):
                     idx = [idx]
             return idx
         return reduce_dim(data, dim)
+
+    def unravel_index_(self, shape: Tuple[int, ...]):
+        idx = self.data
+        if isinstance(idx, list):
+            idx = idx[0]
+        coords = []
+        for dim in reversed(shape):
+            coords.append(idx % dim)
+            idx //= dim
+        return tuple(reversed(coords))
     """Educational tensor ops using nested Python lists."""
 
     def __init__(self, track_time: bool = False):

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -155,6 +155,13 @@ class PyTorchTensorOperations(AbstractTensor):
 
     def squeeze_(self, dim: int | None = None):
         return self.data.squeeze() if dim is None else self.data.squeeze(dim)
+
+    def unravel_index_(self, shape):
+        import torch
+        result = torch.unravel_index(self.data, shape)
+        if self.data.dim() == 0:
+            return tuple(int(x) for x in result)
+        return result
     def __init__(self, default_device = "cpu", track_time: bool = False):
         super().__init__(track_time=track_time)
         try:


### PR DESCRIPTION
## Summary
- add `unravel_index` helper to abstraction and wire to backend hooks
- implement `unravel_index_` for torch, numpy, jax and pure-python backends
- document and stub missing implementations for accelerator backends

## Testing
- `pytest` *(fails: TypeError: AbstractTensor.get_tensor() got an unexpected keyword argument 'faculty')*

------
https://chatgpt.com/codex/tasks/task_e_68a7d87acf90832aa9e91e23f5d54b5a