### PR TITLE
docs: prefer numpy backend for abstract tensor

### DIFF
--- a/src/common/tensors/AGENTS.md
+++ b/src/common/tensors/AGENTS.md
@@ -4,7 +4,13 @@
 
 Refer to `../ENV_SETUP_OPTIONS.md` for setup instructions.
 
-This directory hosts the implementations of tensor operations for different numerical libraries (NumPy, PyTorch, JAX, etc.).
+This directory hosts the implementations of tensor operations for different numerical libraries.
+
+### Backend Policy
+
+- The **NumPy backend** is the default and canonical implementation.
+- **Do not import, install, or rely on PyTorch (`torch`)**. The dependency is too heavy for this project.
+- If an operation is missing, implement it in the NumPy backend rather than reaching for PyTorch or other large frameworks.
 
 **Important:** Each backend must implement `_apply_operator` from `AbstractTensor`. This single method handles all arithmetic primitives. Avoid creating additional bespoke operator helpers – Python's magic methods already route standard arithmetic through `_apply_operator`.
 
@@ -12,15 +18,15 @@ Follow the repository coding standards and remember to run the test suite after 
 
 ## Development Ethos
 
-`AbstractTensor` mirrors the PyTorch API while accommodating idioms from NumPy,
-JAX, and plain Python lists.  Operators are overloaded to hide backend
+`AbstractTensor` mirrors a subset of the PyTorch API while accommodating idioms
+from NumPy and plain Python lists.  Operators are overloaded to hide backend
 specifics, letting contributors work with whichever library they know best.
-When behaviours diverge between libraries, PyTorch is the authoritative
-reference.
+When behaviours diverge between libraries, **NumPy is the authoritative
+reference**.
 
 Implementation priority follows this order:
 1. Get the abstract interface fully specified.
-2. Maintain feature parity across Torch, NumPy, JAX, and pure Python backends.
-3. Address backend-specific gaps.
+2. Maintain feature parity across **NumPy** and pure Python backends.
+3. Address backend-specific gaps without introducing heavy dependencies.
 4. Expand the C backend only after the above are complete unless a simple stub
    can be filled quickly.


### PR DESCRIPTION
## Summary
- document backend policy for AbstractTensor
- forbid using PyTorch and designate NumPy as canonical backend

## Testing
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'Tensor')*


------
https://chatgpt.com/codex/tasks/task_e_68a8657a17c4832aa40f179a7218c91e