### PR TITLE
Replace torch precision with NumPy in Laplace test

### DIFF
--- a/tests/test_laplace_nd.py
+++ b/tests/test_laplace_nd.py
@@ -1,14 +1,10 @@
-import importlib.util
+import numpy as np
+from src.common.tensors.numpy_backend import NumPyTensorOperations  # noqa: F401
 import pytest
-
-if importlib.util.find_spec("torch") is None:  # pragma: no cover - torch optional
-    pytest.skip("torch not available", allow_module_level=True)
-
-import torch
 from src.common.tensors.abstract_convolution import laplace_nd as laplace
 
 
-def test_laplace_builds_with_torch():
+def test_laplace_builds_with_numpy():
     if not hasattr(laplace, "BuildLaplace3D"):
         pytest.skip("BuildLaplace3D not available")
     N = 4
@@ -16,9 +12,9 @@ def test_laplace_builds_with_torch():
     transform = laplace.RectangularTransform(Lx=Lx, Ly=Ly, Lz=Lz, device="cpu")
     grid_u, grid_v, grid_w = transform.create_grid_mesh(N, N, N)
     grid_domain = laplace.GridDomain.generate_grid_domain(
-        coordinate_system="rectangular", N_u=N, N_v=N, N_w=N, Lx=Lx, Ly=Ly, Lz=Lz, device="cpu"
+        coordinate_system="rectangular", N_u=N, N_v=N, N_w=N, Lx=Lx, Ly=Ly, Lz=Lz, device="cpu",
     )
-    BL = laplace.BuildLaplace3D(grid_domain=grid_domain, precision=torch.float64, resolution=N)
+    BL = laplace.BuildLaplace3D(grid_domain=grid_domain, precision=None, resolution=N)
     L_dense, L_scipy = BL.build_general_laplace(
         grid_u=grid_u,
         grid_v=grid_v,


### PR DESCRIPTION
## Summary
- switch `tests/test_laplace_nd.py` to use NumPy precision and backend import

## Testing
- `pytest tests/test_laplace_nd.py` *(fails: arange() received an invalid combination of arguments - got (int, int, int, dtype=str, device=str))*

------
https://chatgpt.com/codex/tasks/task_e_68a867434df8832a9d2be4c80815baba