### PR TITLE
Defer autograd recording when no grads

### DIFF
--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,28 +1,46 @@
-from src.common.tensors.abstraction import AbstractTensor, Faculty
-
-# 1) Pure list → target backends
-L = [[0,1,1],[1,0,1]]
-x_list = AbstractTensor.get_tensor(L)                 # PurePythonListTensor
-x_np   = x_list.to_backend(AbstractTensor.get_tensor(faculty=Faculty.NUMPY))
-try:  # Optional torch backend
-    x_th   = x_list.to_backend(AbstractTensor.get_tensor(faculty=Faculty.TORCH))
-except Exception:
-    x_th = None
-
-# 2) Native arrays to backends (ensure_tensor fast-paths)
+from src.common.tensors.abstraction import AbstractTensor
+from src.common.tensors.numpy_backend import NumPyTensorOperations
+try:  # optional torch backend
+    from src.common.tensors.torch_backend import PyTorchTensorOperations
+except Exception:  # pragma: no cover - torch is optional
+    PyTorchTensorOperations = None
 import numpy as np
-arr = np.array(L)
-np_ops = AbstractTensor.get_tensor(faculty=Faculty.NUMPY)
-wrapped_np = np_ops.ensure_tensor(arr)
-try:
-    torch_ops = AbstractTensor.get_tensor(faculty=Faculty.TORCH)
-    wrapped_np_to_torch = wrapped_np.to_backend(torch_ops)
-except Exception:
-    pass
 
-# 3) The ascii path uses interpolate; exercise it on a tiny mask
-bm = [[0,1],[1,1]]
-t = AbstractTensor.get_tensor(bm)
-resized = AbstractTensor.F.interpolate(t, size=(8,8))  # should pick a real backend and return
 
-print("Smoke test completed successfully!")
+def main() -> None:
+    # 1) Pure list → target backends
+    L = [[0, 1, 1], [1, 0, 1]]
+    x_list = AbstractTensor.get_tensor(L)
+    x_np = x_list.to_backend(AbstractTensor.get_tensor(cls=NumPyTensorOperations))
+    try:
+        if PyTorchTensorOperations is not None:
+            x_th = x_list.to_backend(
+                AbstractTensor.get_tensor(cls=PyTorchTensorOperations)
+            )
+        else:
+            x_th = None
+    except Exception:
+        x_th = None
+
+    # 2) Native arrays to backends (ensure_tensor fast-paths)
+    arr = np.array(L)
+    np_ops = AbstractTensor.get_tensor(cls=NumPyTensorOperations)
+    wrapped_np = np_ops.ensure_tensor(arr)
+    try:
+        if PyTorchTensorOperations is not None:
+            torch_ops = AbstractTensor.get_tensor(cls=PyTorchTensorOperations)
+            wrapped_np_to_torch = wrapped_np.to_backend(torch_ops)
+    except Exception:
+        pass
+
+    # 3) The ascii path uses interpolate; exercise it on a tiny mask
+    bm = [[0, 1], [1, 1]]
+    t = AbstractTensor.get_tensor(bm)
+    resized = AbstractTensor.F.interpolate(t, size=(8, 8))
+
+    print("Smoke test completed successfully!")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_xor_learning.py
+++ b/tests/test_xor_learning.py
@@ -6,7 +6,7 @@ from src.common.tensors.abstraction import AbstractTensor
 
 @pytest.mark.parametrize("loss_type", ["bce", "mse"])
 def test_xor_learns(loss_type):
-    ops = AbstractTensor.get_tensor(faculty=None)
+    ops = AbstractTensor.get_tensor()
     set_seed(0)
     X = from_list_like([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]], like=ops)
     X = X * 2.0 - 1.0


### PR DESCRIPTION
## Summary
- avoid recording autograd ops when neither operand requires gradients
- update autograd tests and xor demo for new API
- make ASCII classifier tolerate missing torch backend

## Testing
- `pytest` *(fails: tests/test_ascii_diff_double_buffer.py::test_ascii_diff_animation - NameError: name 'AbstractTensor' is not defined, tests/test_coo_tensor.py::test_coo_matrix_basic - AssertionError, tests/test_coo_tensor.py::test_on_graph_update_roundtrip - AttributeError)*
- `pytest tests/test_autograd_homemade.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a86ae31b94832ab831fb96337c1984