### PR TITLE
Refine zero-normal diagnostics

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_legacy_for_reference.py
+++ b/src/common/tensors/abstract_convolution/laplace_legacy_for_reference.py
@@ -1082,7 +1082,9 @@ class TransformHub:
 
         if torch.any(zero_norm_mask):
             count_zero_normals = torch.sum(zero_norm_mask).item()  # Number of zero-magnitude normals
-            print(f"{count_zero_normals} out of {normals.numel()} zero-magnitude normals detected.")
+            grid_shape = normals.shape[:3]
+            total_points = grid_shape[0] * grid_shape[1] * grid_shape[2]
+            print(f"{count_zero_normals} out of {total_points} zero-magnitude normals detected.")
 
             if diagnostic_mode:
                 # Find the indices of the first zero-magnitude normal

--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -1110,7 +1110,9 @@ class TransformHub:
 
         if AbstractTensor.any(zero_norm_mask):
             count_zero_normals = AbstractTensor.sum(zero_norm_mask).item()  # Number of grid points with zero-magnitude normals
-            print(f"{count_zero_normals} out of {normals.numel()} zero-magnitude normals detected.")
+            grid_shape = normals.shape[:3]
+            total_points = grid_shape[0] * grid_shape[1] * grid_shape[2]
+            print(f"{count_zero_normals} out of {total_points} zero-magnitude normals detected.")
 
             if diagnostic_mode:
                 # Find the indices of the first zero-magnitude normal


### PR DESCRIPTION
## Summary
- compute grid dimension totals for normal arrays
- replace `normals.numel()` usage with total point counts in diagnostic logs

## Testing
- `pytest` (fails: tests/test_ascii_diff_double_buffer.py::test_ascii_diff_animation, tests/test_coo_tensor.py::test_coo_matrix_basic, tests/test_coo_tensor.py::test_on_graph_update_roundtrip, tests/test_laplace_nd.py::test_laplace_builds_with_numpy)

------
https://chatgpt.com/codex/tasks/task_e_68a86e38d558832ab6ad6d176c820a71