### PR TITLE
Handle nested and ragged tensor inputs

### DIFF
--- a/tests/test_tensor_from_nested.py
+++ b/tests/test_tensor_from_nested.py
@@ -13,3 +13,15 @@ def test_from_nested_with_existing_tensors():
     t = AbstractTensor.from_nested([a, b])
     assert t.shape == (2, 2)
     assert t.tolist() == [[1, 2], [3, 4]]
+
+
+def test_from_nested_ragged_padding():
+    t = AbstractTensor.from_nested([[1, 2], [3]])
+    assert t.shape == (2, 2)
+    assert t.tolist() == [[1, 2], [3, 0]]
+
+
+def test_get_tensor_dispatches_nested():
+    t = AbstractTensor.get_tensor([1, [2, 3]])
+    assert t.shape == (2, 2)
+    assert t.tolist() == [[1, 0], [2, 3]]


### PR DESCRIPTION
## Summary
- Detect nested sequences and ragged lists in `ensure_tensor` and dispatch to `from_nested`
- Pad inhomogeneous nested data to a common shape when packing tensors
- Test packing and dispatch of ragged inputs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a895947ac0832a80283733d2dc866a