### PR TITLE
Fix autograd input handling and validate Laplace normals

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -1021,19 +1021,37 @@ class TransformHub:
             print("Z:", Z)
 
         # Calculate partial derivatives with respect to U
-        dXdu = AbstractTensor.autograd.grad(X, U, grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True)[0]
-        dYdu = AbstractTensor.autograd.grad(Y, U, grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True)[0]
-        dZdu = AbstractTensor.autograd.grad(Z, U, grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True)[0]
+        dXdu = AbstractTensor.autograd.grad(
+            X, [U], grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True
+        )[0]
+        dYdu = AbstractTensor.autograd.grad(
+            Y, [U], grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True
+        )[0]
+        dZdu = AbstractTensor.autograd.grad(
+            Z, [U], grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True
+        )[0]
 
         # Calculate partial derivatives with respect to V
-        dXdv = AbstractTensor.autograd.grad(X, V, grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True)[0]
-        dYdv = AbstractTensor.autograd.grad(Y, V, grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True)[0]
-        dZdv = AbstractTensor.autograd.grad(Z, V, grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True)[0]
+        dXdv = AbstractTensor.autograd.grad(
+            X, [V], grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True
+        )[0]
+        dYdv = AbstractTensor.autograd.grad(
+            Y, [V], grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True
+        )[0]
+        dZdv = AbstractTensor.autograd.grad(
+            Z, [V], grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True
+        )[0]
 
         # Calculate partial derivatives with respect to W
-        dXdw = AbstractTensor.autograd.grad(X, W, grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True)[0]
-        dYdw = AbstractTensor.autograd.grad(Y, W, grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True)[0]
-        dZdw = AbstractTensor.autograd.grad(Z, W, grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True)[0]
+        dXdw = AbstractTensor.autograd.grad(
+            X, [W], grad_outputs=AbstractTensor.ones_like(X), retain_graph=True, allow_unused=True
+        )[0]
+        dYdw = AbstractTensor.autograd.grad(
+            Y, [W], grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True, allow_unused=True
+        )[0]
+        dZdw = AbstractTensor.autograd.grad(
+            Z, [W], grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True, allow_unused=True
+        )[0]
 
         target_shape = U.shape  # (N_u, N_v, N_w)
 

--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -125,7 +125,11 @@ class GradTape:
     ) -> Any:
         """Append a new node representing ``op`` to the tape."""
 
-        inputs = list(inputs)
+        # Ensure a sequence of inputs; a single tensor should not be iterated elementwise.
+        if isinstance(inputs, (list, tuple, set)):
+            inputs = list(inputs)
+        else:
+            inputs = [inputs]
         parent_ids = [(id(t), pos) for pos, t in enumerate(inputs)]
         ctx = {
             "inputs": [x.data if hasattr(x, "data") else x for x in inputs],
@@ -288,7 +292,10 @@ class Autograd:
         if np is None:
             raise RuntimeError("NumPy is required for autograd operations")
 
-        inputs = list(inputs)
+        if isinstance(inputs, (list, tuple, set)):
+            inputs = list(inputs)
+        else:
+            inputs = [inputs]
         out_grad = grad_outputs
         if out_grad is None:
             out_grad = np.ones_like(output.data if hasattr(output, "data") else output)

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -82,8 +82,6 @@ class NumPyTensorOperations(AbstractTensor):
     def any_(self, dim=None):
         import numpy as np
         return np.any(self.data, axis=dim)
-    def max_(self, dim=None, keepdim=False):
-        return np.max(self.data, axis=dim, keepdims=keepdim)
 
     def argmax_(self, dim=None, keepdim=False):
         arr = self.data
@@ -348,8 +346,9 @@ class NumPyTensorOperations(AbstractTensor):
     def item_(self):
         return self.data.item()
 
-    def max_(self, tensor):
-        return np.max(self._AbstractTensor__unwrap(tensor))
+    def max_(self, tensor=None, dim=None, keepdim=False):
+        data = self._AbstractTensor__unwrap(tensor if tensor is not None else self.data)
+        return np.max(data, axis=dim, keepdims=keepdim)
 
     def long_cast_(self, tensor):
         return self._AbstractTensor__unwrap(tensor).astype(np.int64)

--- a/tests/test_autograd_homemade.py
+++ b/tests/test_autograd_homemade.py
@@ -50,3 +50,15 @@ def test_autograd_records_only_for_grad_inputs():
     node = autograd.tape.node(z)
     assert node is not None
     assert {pid for pid, _ in node.parents} == {id(a), id(b)}
+
+
+def test_autograd_single_tensor_input():
+    autograd = AbstractTensor.autograd
+    autograd.tape._nodes.clear()
+
+    x = AbstractTensor.tensor([1.0, 2.0, 3.0])
+    x.requires_grad = True
+    y = x * 2.0
+
+    grad_x = autograd.grad(y, x)[0]
+    assert np.allclose(grad_x, np.array([2.0, 2.0, 2.0]))

--- a/tests/test_laplace_normals.py
+++ b/tests/test_laplace_normals.py
@@ -1,0 +1,27 @@
+import numpy as np
+from src.common.tensors.numpy_backend import NumPyTensorOperations  # noqa: F401
+from src.common.tensors import AbstractTensor
+
+
+def test_autograd_identity_normals():
+    u = AbstractTensor.linspace(0, 1, 3)
+    v = AbstractTensor.linspace(0, 1, 3)
+    w = AbstractTensor.linspace(0, 1, 3)
+    U, V, W = AbstractTensor.meshgrid(u, v, w, indexing='ij')
+
+    U.requires_grad = True
+    V.requires_grad = True
+    W.requires_grad = True
+
+    X, Y, Z = U, V, W
+
+    dXdu = AbstractTensor.autograd.grad(X, [U], grad_outputs=AbstractTensor.ones_like(X), retain_graph=True)[0]
+    dYdv = AbstractTensor.autograd.grad(Y, [V], grad_outputs=AbstractTensor.ones_like(Y), retain_graph=True)[0]
+    dZdw = AbstractTensor.autograd.grad(Z, [W], grad_outputs=AbstractTensor.ones_like(Z), retain_graph=True)[0]
+
+    e_u = AbstractTensor.stack([dXdu, AbstractTensor.zeros_like(dXdu), AbstractTensor.zeros_like(dXdu)], dim=-1)
+    e_v = AbstractTensor.stack([AbstractTensor.zeros_like(dYdv), dYdv, AbstractTensor.zeros_like(dYdv)], dim=-1)
+    normals = AbstractTensor.linalg.cross(e_u, e_v, dim=-1)
+
+    norms = np.linalg.norm(normals, axis=-1)
+    assert np.allclose(norms, np.ones_like(norms))


### PR DESCRIPTION
## Summary
- avoid zero normals in Laplace builder by supplying tensor lists to `autograd.grad`
- harden autograd to wrap single-tensor inputs and fix numpy backend `max_`
- add tests covering single-input gradients and identity normal computation

## Testing
- `pytest tests/test_autograd_homemade.py tests/test_autograd_independent_backward.py tests/test_laplace_normals.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8a347925c832aaffa98840d1b74dc