### PR TITLE
Implement clamp deferral and clip alias in abstract tensor

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -216,8 +216,49 @@ class AbstractTensor:
     def argmax_(self, dim=None, keepdim: bool = False):
         raise NotImplementedError(f"{self.__class__.__name__} must implement argmax_() with keepdim.")
 
-    def clamp_max_(self, max):
+    # --- Clamping ---
+    def clamp(self, min: float | None = None, max: float | None = None) -> "AbstractTensor":
+        """Return ``self`` clamped between ``min`` and ``max``."""
+        result = type(self)(track_time=self.track_time)
+        result.data = self.clamp_(min_val=min, max_val=max)
+        return result
+
+    def clamp_(self, min_val: float | None = None, max_val: float | None = None):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement clamp_()")
+
+    def clamp_min(self, min_val: float) -> "AbstractTensor":
+        """Clamp values below ``min_val`` up to ``min_val``."""
+        result = type(self)(track_time=self.track_time)
+        result.data = self.clamp_min_(min_val)
+        return result
+
+    def clamp_min_(self, min_val: float):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement clamp_min_()")
+
+    def clamp_max(self, max_val: float) -> "AbstractTensor":
+        """Clamp values above ``max_val`` down to ``max_val``."""
+        result = type(self)(track_time=self.track_time)
+        result.data = self.clamp_max_(max_val)
+        return result
+
+    def clamp_max_(self, max_val: float):
         raise NotImplementedError(f"{self.__class__.__name__} must implement clamp_max_()")
+
+    # --- API compatibility ---
+    def clip(
+        self,
+        min: float | None = None,
+        max: float | None = None,
+        *,
+        a_min: float | None = None,
+        a_max: float | None = None,
+    ) -> "AbstractTensor":
+        """Alias for :meth:`clamp` accepting NumPy-style parameters."""
+        if (min is not None or max is not None) and (a_min is not None or a_max is not None):
+            raise TypeError("Specify either min/max or a_min/a_max, not both")
+        if min is None and max is None:
+            min, max = a_min, a_max
+        return self.clamp(min=min, max=max)
 
     def greater_(self, value):
         raise NotImplementedError(f"{self.__class__.__name__} must implement greater_()")

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -763,6 +763,20 @@ class PurePythonTensorOperations(AbstractTensor):
             return val
         return _clamp(self.data)
 
+    def clamp_min_(self, min_val: float) -> Any:
+        def _clamp_min(val):
+            if isinstance(val, list):
+                return [_clamp_min(v) for v in val]
+            return val if val >= min_val else min_val
+        return _clamp_min(self.data)
+
+    def clamp_max_(self, max_val: float) -> Any:
+        def _clamp_max(val):
+            if isinstance(val, list):
+                return [_clamp_max(v) for v in val]
+            return val if val <= max_val else max_val
+        return _clamp_max(self.data)
+
     def shape_(self) -> Tuple[int, ...]:
         return _get_shape(self.data)
 

--- a/tests/test_tensor_clip.py
+++ b/tests/test_tensor_clip.py
@@ -1,0 +1,13 @@
+from src.common.tensors.abstraction import AbstractTensor
+
+
+def test_clip_alias_min_max():
+    t = AbstractTensor.tensor([-1.0, 0.0, 1.0])
+    clipped = t.clip(min=-0.5, max=0.5)
+    assert clipped.tolist() == [-0.5, 0.0, 0.5]
+
+
+def test_clip_alias_numpy_names():
+    t = AbstractTensor.tensor([-1.0, 0.0, 1.0])
+    clipped = t.clip(a_min=-0.5, a_max=0.5)
+    assert clipped.tolist() == [-0.5, 0.0, 0.5]


### PR DESCRIPTION
## Summary
- add clip() to translate a_min/a_max into clamp
- exercise clip alias with dedicated unit tests

## Testing
- `python -m src.common.tensors.abstract_convolution.laplace_nd` (fails: IndexError)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7678864832aab78a0d45d4abf56