### PR TITLE
feat: add unsqueeze support for numpy backend

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1592,6 +1592,7 @@ _bind_and_wrap({
     "reshape": _reshape_methods.reshape,
     "flatten": _reshape_methods.flatten,
     "transpose": _reshape_methods.transpose,
+    "unsqueeze": _reshape_methods.unsqueeze,
     "squeeze": _reshape_methods.squeeze,
     "repeat": _reshape_methods.repeat,
     "repeat_interleave": _reshape_methods.repeat_interleave,

--- a/src/common/tensors/abstraction_methods/reshape.py
+++ b/src/common/tensors/abstraction_methods/reshape.py
@@ -39,6 +39,26 @@ def transpose(self, dim0: int = 0, dim1: int = 1) -> "AbstractTensor":
     raise NotImplementedError("Transpose fallback not implemented for this backend.")
 
 
+def unsqueeze(self, dim: int) -> "AbstractTensor":
+    """Return a tensor with an inserted dimension of size 1 at ``dim``."""
+    if hasattr(self, "unsqueeze_"):
+        return _wrap_result(self, self.unsqueeze_(dim))
+    try:
+        from ..abstraction import BACKEND_REGISTRY
+        backend_cls = BACKEND_REGISTRY.get("numpy")
+        if backend_cls is not None:
+            numpy_tensor = backend_cls(track_time=getattr(self, "track_time", False))
+            numpy_tensor = numpy_tensor.ensure_tensor(self.data)
+            import numpy as np
+            expanded = np.expand_dims(numpy_tensor.data, axis=dim)
+            expanded_tensor = backend_cls(track_time=getattr(self, "track_time", False))
+            expanded_tensor.data = expanded
+            return expanded_tensor.to_backend(self)
+    except Exception:
+        pass
+    raise NotImplementedError("Unsqueeze fallback not implemented for this backend.")
+
+
 def squeeze(self, dim: int | None = None) -> "AbstractTensor":
     """Return a tensor with all (or one) dimensions of size 1 removed."""
     if hasattr(self, "squeeze_"):

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -209,6 +209,9 @@ class NumPyTensorOperations(AbstractTensor):
     def reshape_(self, shape):
         import numpy as np
         return np.reshape(self.data, shape)
+    def unsqueeze_(self, dim: int):
+        import numpy as np
+        return np.expand_dims(self.data, axis=dim)
     def squeeze_(self, dim: int | None = None):
         import numpy as np
         return np.squeeze(self.data, axis=dim) if dim is not None else np.squeeze(self.data)


### PR DESCRIPTION
## Summary
- implement `unsqueeze_` for NumPy backend
- expose `unsqueeze` in reshape helpers and bind into `AbstractTensor`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad39c238832aa58c6e113f92e5bd