### PR TITLE
Add diag and cbrt utilities

### DIFF
--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -599,6 +599,10 @@ class NumPyTensorOperations(AbstractTensor):
     def argmin_(self, dim=None, keepdim=False):
         return np.argmin(self.data, axis=dim, keepdims=keepdim)
 
+    def diag_(self, offset: int = 0):
+        import numpy as np
+        return np.diag(self.data, k=offset)
+
     def interpolate_(self, size):
         arr = np.array(self.data)
         if len(size) != arr.ndim:

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -965,6 +965,30 @@ class PurePythonTensorOperations(AbstractTensor):
             return idx
         return reduce_dim(data, dim)
 
+    def diag_(self, offset: int = 0):
+        data = self.data
+        # If input is 2D, extract diagonal with offset
+        if data and isinstance(data[0], list):
+            rows = len(data)
+            cols = len(data[0])
+            diag = []
+            for i in range(rows):
+                j = i + offset
+                if 0 <= j < cols:
+                    diag.append(data[i][j])
+            return diag
+        # Otherwise assume 1D vector and construct diagonal matrix
+        n = len(data)
+        size = n + abs(offset)
+        mat = [[0 for _ in range(size)] for _ in range(size)]
+        for idx, val in enumerate(data):
+            if offset >= 0:
+                i, j = idx, idx + offset
+            else:
+                i, j = idx - offset, idx
+            mat[i][j] = val
+        return mat
+
     def interpolate_(self, tensor: Any, size: Tuple[int, ...]) -> Any:
         tensor = self._AbstractTensor__unwrap(tensor)
         shape = _get_shape(tensor)


### PR DESCRIPTION
## Summary
- implement `AbstractTensor.diag` plus backend support for numpy and pure python
- add `copy` alias and `cbrt` helper to `AbstractTensor`
- enable laplace heat simulation to run without GUI and expose numeric output

## Testing
- `pytest tests/test_tensor_basic_ops.py tests/test_laplace_nd.py -q`
- `python - <<'PY'
from src.common.tensors.abstract_convolution.laplace_nd import RectangularTransform, GridDomain, BuildLaplace3D, HeatEngine
from src.common.tensors import AbstractTensor

N=5
L=1.0
transform = RectangularTransform(Lx=L, Ly=L, Lz=L, device='cpu')
grid_u, grid_v, grid_w = transform.create_grid_mesh(N,N,N)

grid_domain = GridDomain.generate_grid_domain(
    coordinate_system='rectangular',
    N_u=N, N_v=N, N_w=N,
    Lx=L, Ly=L, Lz=L,
    device='cpu'
)

boundary_conditions = ('dirichlet','dirichlet','dirichlet','dirichlet','dirichlet','dirichlet')

build_laplace = BuildLaplace3D(
    grid_domain=grid_domain,
    wave_speed=343,
    precision=AbstractTensor.float_dtype_,
    resolution=N,
    metric_tensor_func=None,
    density_func=None,
    tension_func=None,
    singularity_conditions=None,
    boundary_conditions=boundary_conditions,
    artificial_stability=1e-10
)

laplacian_tensor, _ = build_laplace.build_general_laplace(
    grid_u=grid_u,
    grid_v=grid_v,
    grid_w=grid_w,
    boundary_conditions=boundary_conditions,
    grid_boundaries=(True,True,True,True,True,True),
    device='cpu',
    dense=True,
    f=0.0
)

x = AbstractTensor.linspace(0, 1, N)
y = AbstractTensor.linspace(0, 1, N)
z = AbstractTensor.linspace(0, 1, N)
X, Y, Z = AbstractTensor.meshgrid(x, y, z, indexing='ij')
initial_temp = AbstractTensor.exp(-50 * ((X-0.5)**2 + (Y-0.5)**2 + (Z-0.5)**2))
engine = HeatEngine(laplacian_tensor, initial_temp.flatten(), alpha=0.01)

for step in range(3):
    ok, metrics, new_state = engine.step(0.01)
    print(f"step {step} ok={ok} max_vel={metrics.max_vel}")

center_slice = engine.temperature.reshape((N,N,N))[...,N//2]
print("center slice:\n", center_slice)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8d8da27e0832a9676db22e1d96cbe