### PR TITLE
Introduce timing-aware autograd graph with profiling

### DIFF
--- a/src/common/tensors/accelerator_backends/opengl_backend.py
+++ b/src/common/tensors/accelerator_backends/opengl_backend.py
@@ -48,8 +48,8 @@ class GLBuffer:
 class OpenGLTensorOperations(AbstractTensor):
     """Stub OpenGL backend using buffers and compute shaders."""
 
-    def __init__(self, track_time: bool = False) -> None:
-        super().__init__(track_time=track_time)
+    def __init__(self, track_time: bool = False, tape=None) -> None:
+        super().__init__(track_time=track_time, tape=tape)
         if GL is None:
             raise RuntimeError("PyOpenGL is required for the OpenGL backend")
 

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -198,8 +198,8 @@ class JAXTensorOperations(AbstractTensor):
         return result
     """Tensor operations powered by `jax.numpy`."""
 
-    def __init__(self, default_device: Optional[Any] = None, track_time: bool = False) -> None:
-        super().__init__(track_time=track_time)
+    def __init__(self, default_device: Optional[Any] = None, track_time: bool = False, tape=None) -> None:
+        super().__init__(track_time=track_time, tape=tape)
         self.default_device = default_device
         self._validate_jax_setup()
 

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -233,8 +233,8 @@ class NumPyTensorOperations(AbstractTensor):
         if np.isscalar(self.data) or (isinstance(self.data, np.ndarray) and self.data.ndim == 0):
             return tuple(int(x) for x in result)
         return result
-    def __init__(self, track_time: bool = False):
-        super().__init__(track_time=track_time)
+    def __init__(self, track_time: bool = False, tape=None):
+        super().__init__(track_time=track_time, tape=tape)
 
     def _apply_operator__(self, op: str, left: Any, right: Any):
         """Apply arithmetic operators on NumPy arrays."""

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -201,8 +201,8 @@ class PurePythonTensorOperations(AbstractTensor):
         return tuple(reversed(coords))
     """Educational tensor ops using nested Python lists."""
 
-    def __init__(self, track_time: bool = False):
-        super().__init__(track_time=track_time)
+    def __init__(self, track_time: bool = False, tape=None):
+        super().__init__(track_time=track_time, tape=tape)
         # ########## STUB: PurePythonTensorOperations.__init__ ##########
         # PURPOSE: Placeholder for any future initialization logic needed for
         #          the pure Python backend.

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -186,8 +186,8 @@ class PyTorchTensorOperations(AbstractTensor):
         if self.data.dim() == 0:
             return tuple(int(x) for x in result)
         return result
-    def __init__(self, default_device = "cpu", track_time: bool = False):
-        super().__init__(track_time=track_time)
+    def __init__(self, default_device="cpu", track_time: bool = False, tape=None):
+        super().__init__(track_time=track_time, tape=tape)
         try:
             import torch
         except ImportError:

--- a/tests/test_autograd_homemade.py
+++ b/tests/test_autograd_homemade.py
@@ -79,7 +79,10 @@ def test_autograd_complex_sequence():
     grad_w = autograd.grad(w, [x, y, z])
 
     # PyTorch reference computation for parity validation
-    import torch
+    try:
+        import torch  # type: ignore
+    except Exception:
+        pytest.skip("torch not available")
     x_t = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
     y_t = torch.tensor([4.0, 5.0, 6.0], requires_grad=True)
     z_t = torch.tensor([7.0, 8.0, 9.0], requires_grad=True)

--- a/tests/test_laplace_nd.py
+++ b/tests/test_laplace_nd.py
@@ -39,6 +39,7 @@ def _laplace_power_section(backend_name, backend_cls, N=8):
         except NotImplementedError:
             pass
         x = backend_cls.linspace(0, 1, N)
+        x.track_time = True
         return (x - 0.5) ** 2
     finally:
         BACKEND_REGISTRY.clear()
@@ -46,11 +47,13 @@ def _laplace_power_section(backend_name, backend_cls, N=8):
 
 
 def test_power_operation_average_time_pure_vs_numpy():
-    pure_res = PurePythonTensorOperations.benchmark(
+    pure_prof = PurePythonTensorOperations.benchmark(
         lambda: _laplace_power_section("pure_python", PurePythonTensorOperations), repeat=3
     )
-    numpy_res = NumPyTensorOperations.benchmark(
+    numpy_prof = NumPyTensorOperations.benchmark(
         lambda: _laplace_power_section("numpy", NumPyTensorOperations), repeat=3
     )
-    assert pure_res.mean > 0 and numpy_res.mean > 0
-    assert pure_res.mean != numpy_res.mean
+    pure_mean = pure_prof.per_op()["pow"]["mean"]
+    numpy_mean = numpy_prof.per_op()["pow"]["mean"]
+    assert pure_mean > 0 and numpy_mean > 0
+    assert pure_mean != numpy_mean

--- a/tests/test_tensor_benchmark.py
+++ b/tests/test_tensor_benchmark.py
@@ -17,24 +17,17 @@ if NumPyTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_benchmark_records_timings(backend_name, Backend):
-    x = Backend.tensor_from_list([1, 2, 3])
-
     def workload():
+        x = Backend.tensor_from_list([1, 2, 3])
+        x.track_time = True
         _ = x + x
         time.sleep(0.001)
 
     result = Backend.benchmark(workload, repeat=3, warmup=1)
-    assert len(result.times) == 3
-    assert all(t >= 0 for t in result.times)
-    assert result.best > 0
+    stats = result.per_op()
+    assert stats["add"]["count"] == 3
+    assert stats["add"]["mean"] > 0
 
-    tape_times = [node.elapsed for _, node in result.tape.traverse()]
-    assert len(tape_times) == 3
-    for t1, t2 in zip(result.times, tape_times):
-        assert t1 == pytest.approx(t2)
-    nodes = list(result.tape.traverse())
-    for i, (_, node) in enumerate(nodes):
-        if i == 0:
-            assert node.parents == []
-        else:
-            assert node.parents == [(i - 1, 0)]
+    op_times = [data["elapsed"] for _, data in result.tape.graph.nodes(data=True) if data.get("kind") == "op"]
+    assert len(op_times) == 3
+    assert all(t >= 0 for t in op_times)


### PR DESCRIPTION
## Summary
- attach optional start/end timestamps to nodes on the global `GradTape`
- add `TapeProfiler` for per-op timing stats and quantile/outlier analysis
- route `benchmark` through the autograd tape and supply primitive backward rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a925dc0e34832aa7a8228ff1a37032