### PR TITLE
Fix unary gradient aggregation and pow backward stability

### DIFF
--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -392,6 +392,8 @@ class Autograd:
                     continue
                 go = grad_out
                 parent_grads = bw(go, *node.ctx["inputs"])
+                if not isinstance(parent_grads, (list, tuple)):
+                    parent_grads = (parent_grads,)
                 for (pid, _), g in zip(node.parents, parent_grads):
                     if g is None:
                         continue

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -446,12 +446,12 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
             r"\frac{\partial z}{\partial p} = x^p \log x \quad (x>0)"
         ],
         "backward": {
-            "x": "gx = unbroadcast(g * p * (x + eps)**(p - 1), x.shape)",
-            "p": "gp = unbroadcast(g * (x + eps)**p * log(x + eps), p.shape)",
+            "x": "gx = unbroadcast(g * p * (x)**(p - 1), x.shape)",
+            "p": "gp = unbroadcast(g * (x)**p * log(abs(x) + eps), p.shape)",
         },
         "python": {
             "parameters": ["g", "x", "p"],
-            "body": "xs=x+eps(); ys=xs**p; gx=unbroadcast(g*p*(xs**(p-1)), x.shape); gp=unbroadcast(g*ys*AbstractTensor.log(xs), p.shape); return gx, gp"
+            "body": "absx=abs(x); xs=absx+eps(); ys=x**p; gx=unbroadcast(g*p*(x**(p-1)), x.shape); gp=unbroadcast(g*ys*AbstractTensor.log(xs), p.shape); return gx, gp"
         },
         "domain": "x>0 if p varies; if p is integer constant, extend by continuity.",
         "notes": "When p is constant, only x-branch is needed.",


### PR DESCRIPTION
## Summary
- ensure Autograd.grad wraps single parent gradients before zipping with parents
- refine pow backward rule to avoid log on negative bases and align analytic formula

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a95c3cc4a0832a8b0f83bfdb6c9006