### PR TITLE
Fix laplace_nd edge index dtype

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -834,7 +834,9 @@ class HodgeStarBuilder:
         else:
             # No faces were detected; fall back to an empty tensor so downstream
             # operations become no-ops instead of crashing with a stack error.
-            face_tensor = AbstractTensor.empty((0, 3), dtype=AbstractTensor.long, device=self.device)
+            face_tensor = AbstractTensor.empty(
+                (0, 3), dtype=AbstractTensor.long_dtype_, device=self.device
+            )
         for i, edge in enumerate(edges):
             # Find faces containing this edge
             mask = (face_tensor == edge[0]).any(dim=1) & (face_tensor == edge[1]).any(dim=1)
@@ -1313,8 +1315,8 @@ def validate_transform_hub():
     # Simple edge index: connect each vertex to next in a line for demonstration
     edges = []
     for i in range(num_vertices-1):
-        edges.append([i, i+1])
-    edge_index = AbstractTensor.tensor(edges, dtype=AbstractTensor.long)
+        edges.append([i, i + 1])
+    edge_index = AbstractTensor.tensor(edges, dtype=AbstractTensor.long_dtype_)
 
     hub = IdentityTransform(1.0, 1.0, (True, True, True, True))
     geometry = hub.calculate_geometry(U, V, W, edge_index=edge_index, detect_faces=True)

--- a/tests/test_laplace_nd.py
+++ b/tests/test_laplace_nd.py
@@ -1,6 +1,7 @@
 import numpy as np
 from src.common.tensors.numpy_backend import NumPyTensorOperations  # noqa: F401
 from src.common.tensors.pure_backend import PurePythonTensorOperations  # noqa: F401
+from src.common.tensors.abstraction import AbstractTensor
 import pytest
 from src.common.tensors.abstract_convolution import laplace_nd as laplace
 
@@ -25,6 +26,19 @@ def test_laplace_builds_with_numpy():
         f=0.0,
     )
     assert L_dense is not None or L_scipy is not None
+
+
+def test_edge_index_dtype_long():
+    if not hasattr(laplace, "TransformHub"):
+        pytest.skip("TransformHub not available")
+
+    edges = [[0, 1], [1, 2]]
+    edge_index = AbstractTensor.tensor(edges, dtype=AbstractTensor.long_dtype_)
+
+    data = AbstractTensor.arange(3, dtype=AbstractTensor.long_dtype_)
+    _ = data[edge_index]
+
+    assert edge_index.dtype == AbstractTensor.long_dtype_
 
 
 def _laplace_power_section(backend_name, backend_cls, N=8):


### PR DESCRIPTION
## Summary
- ensure laplace_nd uses `AbstractTensor.long_dtype_` when constructing edge indices and fallback face tensor
- add regression test confirming edge indices retain integer dtype

## Testing
- `pytest tests/test_laplace_nd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96327da20832aa7170384cc8de931