### PR TITLE
Replace prints with debug logging

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -487,9 +487,9 @@ class BuildLaplace3D:
             col_indices.extend(col_indices_map.flatten().tolist())
             values.extend(laplacian_contrib[self.index_map['masks'][label].cpu()].flatten().tolist())
 
-            print(f"row_indices_map shape {row_indices_map.shape}" )
-            print(f"col_indices_map shape {col_indices_map.shape}" )
-            print(f"laplacian_contrib flattened shape {laplacian_contrib.flatten().shape}" )
+            logger.debug("row_indices_map shape %s", row_indices_map.shape)
+            logger.debug("col_indices_map shape %s", col_indices_map.shape)
+            logger.debug("laplacian_contrib flattened shape %s", laplacian_contrib.flatten().shape)
 
         # 3. Add Diagonal Contributions
         flat_diag_indices = AbstractTensor.arange(total_size, device='cpu')
@@ -526,7 +526,7 @@ class BuildLaplace3D:
 
             # Validate perturbed dense Laplace tensor
             logger.debug("Validating dense Laplacian tensor.")
-            self.validate_laplace_tensor(laplacian_tensor)
+            self.validate_laplace_tensor(laplacian_tensor, verbose=False)
             logger.debug("Dense Laplacian tensor validated.")
         else:
             laplacian_tensor = None
@@ -549,7 +549,7 @@ class BuildLaplace3D:
 
         # Validate perturbed sparse Laplace tensor
         logger.debug("Validating sparse Laplacian matrix.")
-        self.validate_laplace_tensor(laplacian)
+        self.validate_laplace_tensor(laplacian, verbose=False)
         logger.debug("Sparse Laplacian matrix validated.")
 
         logger.debug("Completed build_general_laplace.")

--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -133,6 +133,18 @@ class GradTape:
             pass
 
     # ------------------------------------------------------------------
+    # annotation utilities
+    # ------------------------------------------------------------------
+    def annotate(self, tensor: Any, **metadata: Any) -> None:
+        """Attach ``metadata`` to ``tensor``'s graph node if present."""
+        tid = id(tensor)
+        if tid not in self.graph:
+            return
+        node = self.graph.nodes[tid]
+        annotations = node.setdefault("annotations", {})
+        annotations.update(metadata)
+
+    # ------------------------------------------------------------------
     # recording utilities
     # ------------------------------------------------------------------
     def record(


### PR DESCRIPTION
## Summary
- route Laplacian builder diagnostics through module logger
- add `GradTape.annotate` to support valuewise operation annotations

## Testing
- `pytest tests/test_laplace_nd.py::test_laplace_builds_with_numpy -q` *(fails: NameError: name 'AbstractTensor' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fddf5448832a9aff84891284a717