### PR TITLE
Implement __trunc__ for tensor backends

### DIFF
--- a/src/common/tensors/accelerator_backends/c_backend.py
+++ b/src/common/tensors/accelerator_backends/c_backend.py
@@ -341,6 +341,13 @@ class CTensorOperations(AbstractTensor):
     def numel_(self, tensor: CTensor) -> int:
         return tensor.size
 
+    def __trunc__(self):
+        import math
+        tensor = self.data
+        if tensor.size != 1:
+            raise TypeError("Only scalar tensors can be converted to int")
+        return int(math.trunc(tensor.buffer[0]))
+
     def mean_(self, tensor: Any, dim: Optional[int] = None) -> Any:
         if not isinstance(tensor, CTensor):
             tensor = CTensor.from_list(tensor, _get_shape(tensor))

--- a/src/common/tensors/accelerator_backends/opengl_backend.py
+++ b/src/common/tensors/accelerator_backends/opengl_backend.py
@@ -127,6 +127,9 @@ class OpenGLTensorOperations(AbstractTensor):
             "unravel_index not implemented for OpenGL backend"
         )
 
+    def __trunc__(self):
+        raise NotImplementedError("trunc not implemented for OpenGL backend")
+
     def repeat_interleave_(self, repeats: int = 1, dim: int | None = None):
         raise NotImplementedError
 

--- a/src/common/tensors/accelerator_backends/rust_backend.py
+++ b/src/common/tensors/accelerator_backends/rust_backend.py
@@ -59,3 +59,6 @@ class RustTensorOperations:
             "unravel_index not implemented for Rust backend"
         )
 
+    def __trunc__(self):
+        raise NotImplementedError("trunc not implemented for Rust backend")
+

--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -172,6 +172,12 @@ class JAXTensorOperations(AbstractTensor):
         import jax.numpy as jnp
         return jnp.ceil(self.data)
 
+    def __trunc__(self):
+        import jax.numpy as jnp
+        if self.data.size != 1:
+            raise TypeError("Only scalar tensors can be converted to int")
+        return int(jnp.trunc(self.data).item())
+
     def softmax_(self, dim):
         import jax.numpy as jnp
         x = self.data

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -189,6 +189,12 @@ class NumPyTensorOperations(AbstractTensor):
         import numpy as np
         return np.ceil(self.data)
 
+    def __trunc__(self):
+        import numpy as np
+        if self.data.size != 1:
+            raise TypeError("Only scalar tensors can be converted to int")
+        return int(np.trunc(self.data).item())
+
     def softmax_(self, dim):
         import numpy as np
         x = self.data

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -1433,6 +1433,13 @@ class PurePythonTensorOperations(AbstractTensor):
         import math
         return self._map_unary(math.ceil, self.data)
 
+    def __trunc__(self):
+        import math
+        if self.numel_() != 1:
+            raise TypeError("Only scalar tensors can be converted to int")
+        value = self.item_(self.data)
+        return int(math.trunc(value))
+
     def exp_(self):
         import math
         return self._map_unary(math.exp, self.data)

--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -173,6 +173,12 @@ class PyTorchTensorOperations(AbstractTensor):
         import torch
         return torch.ceil(self.data)
 
+    def __trunc__(self):
+        import torch
+        if self.data.numel() != 1:
+            raise TypeError("Only scalar tensors can be converted to int")
+        return int(torch.trunc(self.data).item())
+
     def softmax_(self, dim):
         import torch
         return torch.softmax(self.data, dim=dim)

--- a/tests/test_tensor_int_cast.py
+++ b/tests/test_tensor_int_cast.py
@@ -1,0 +1,49 @@
+import importlib.util
+import pytest
+
+from src.common.tensors import AbstractTensor
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    NumPyTensorOperations = None
+
+jax_spec = importlib.util.find_spec("jax")
+if jax_spec is not None:
+    try:
+        from src.common.tensors.jax_backend import JAXTensorOperations
+    except Exception:  # pragma: no cover - optional dependency
+        JAXTensorOperations = None
+else:  # jax not available
+    JAXTensorOperations = None
+
+torch_spec = importlib.util.find_spec("torch")
+if torch_spec is not None:
+    try:
+        from src.common.tensors.torch_backend import PyTorchTensorOperations
+    except Exception:  # pragma: no cover - optional dependency
+        PyTorchTensorOperations = None
+else:  # torch not available
+    PyTorchTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+if JAXTensorOperations is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+if PyTorchTensorOperations is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_int_conversion(backend_name, Backend):
+    t = AbstractTensor.get_tensor(3.9, cls=Backend)
+    assert int(t) == 3
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_int_conversion_requires_scalar(backend_name, Backend):
+    t = AbstractTensor.get_tensor([1.0, 2.0], cls=Backend)
+    with pytest.raises(TypeError, match="Only scalar tensors can be converted to int"):
+        int(t)


### PR DESCRIPTION
## Summary
- add scalar-aware `__trunc__` implementations for NumPy, PyTorch, JAX, Pure Python, and C tensor backends
- stub `__trunc__` in OpenGL and Rust tensor backends
- test integer casting via `int(AbstractTensor.get_tensor(...))`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa39714da4832a9cd4efd947817e6a