### PR TITLE
Fix repeat cloning across backends and add tests

### DIFF
--- a/src/common/tensors/jax_backend.py
+++ b/src/common/tensors/jax_backend.py
@@ -416,16 +416,26 @@ class JAXTensorOperations(AbstractTensor):
         tensors = [self._to_jnp(t) for t in tensors]
         return jnp.stack(tensors, axis=dim).tolist()
 
-    def repeat_interleave_(self, tensor: Any, repeats: int, dim: Optional[int] = None) -> Any:
-        return jnp.repeat(self._to_jnp(tensor), repeats, axis=dim).tolist()
+    def repeat_interleave_(self, repeats: int = 1, dim: Optional[int] = None) -> Any:
+        return jnp.repeat(self._to_jnp(self.data), repeats, axis=dim).tolist()
 
     def cumsum_(self, dim: int = 0) -> Any:
         import jax.numpy as jnp
         return jnp.cumsum(self.data, axis=dim)
 
     def repeat_(self, repeats: Any = None, dim: int = 0) -> Any:
-        """Repeat tensor along ``dim`` ``repeats`` times (stub)."""
-        raise NotImplementedError("repeat not implemented for JAX backend")
+        """Repeat tensor along ``dim`` ``repeats`` times using JAX."""
+        if repeats is None:
+            raise ValueError("repeats must be specified for JAX backend")
+        arr = self._to_jnp(self.data)
+        if isinstance(repeats, int):
+            reps = [1] * arr.ndim
+            reps[dim] = repeats
+            return jnp.tile(arr, reps).tolist()
+        elif isinstance(repeats, (tuple, list)):
+            return jnp.tile(arr, repeats).tolist()
+        else:
+            raise TypeError("repeats must be int or tuple for JAX backend")
 
     def view_flat_(self, tensor: Any) -> Any:
         return jnp.ravel(self._to_jnp(tensor)).tolist()

--- a/tests/test_repeat_behavior.py
+++ b/tests/test_repeat_behavior.py
@@ -1,0 +1,53 @@
+import pytest
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+from src.common.tensors.numpy_backend import NumPyTensorOperations
+
+try:
+    from src.common.tensors.jax_backend import JAXTensorOperations  # type: ignore
+    _has_jax = True
+except Exception:  # pragma: no cover - optional dependency
+    JAXTensorOperations = None  # type: ignore
+    _has_jax = False
+
+
+def _has_zero_column(data):
+    if not isinstance(data, list):
+        data = data.tolist()
+    return any(all(col == 0 for col in column) for column in zip(*data))
+
+
+@pytest.mark.parametrize("backend_cls", [PurePythonTensorOperations, NumPyTensorOperations])
+def test_repeat_no_alias_or_zero_column(backend_cls):
+    t = backend_cls.tensor_from_list([[1, 2], [3, 4]])
+    r = t.repeat(repeats=2, dim=0)
+    assert not _has_zero_column(r.data)
+    r.data[0][0] = 99
+    assert r.data[2][0] == 1
+    assert t.data[0][0] == 1
+
+
+@pytest.mark.parametrize("backend_cls", [PurePythonTensorOperations, NumPyTensorOperations])
+def test_repeat_interleave_no_alias(backend_cls):
+    t = backend_cls.tensor_from_list([[1, 2], [3, 4]])
+    r = t.repeat_interleave(repeats=2, dim=0)
+    assert not _has_zero_column(r.data)
+    r.data[0][0] = 99
+    assert r.data[1][0] == 1
+
+
+def test_pure_repeat_tuple_no_alias():
+    t = PurePythonTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    r = t.repeat(repeats=(2, 1))
+    assert not _has_zero_column(r.data)
+    r.data[0][0] = 99
+    assert r.data[2][0] == 1
+
+
+@pytest.mark.skipif(not _has_jax, reason="jax not available")
+def test_jax_repeat_no_alias_or_zero_column():
+    t = JAXTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    r = t.repeat(repeats=2, dim=0)
+    assert not _has_zero_column(r.data)
+    r.data[0][0] = 99
+    assert r.data[2][0] == 1
+


### PR DESCRIPTION
## Summary
- prevent PurePythonTensorOperations repeat functions from returning shared references
- implement repeat for JAX backend and fix repeat_interleave signature
- add tests checking repeat and repeat_interleave avoid aliasing and zero columns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa4a249df0832aa5a443875b066dd6