### PR TITLE
Ensure float defaults and matmul dtype promotion

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1242,6 +1242,14 @@ class AbstractTensor:
             if isinstance(right, bool):
                 right = 1.0 if (op in div_ops or "float" in (lk,)) else 1
 
+        if op == "matmul":
+            lk, rk = kind(left), kind(right)
+            if "float" in (lk, rk) and "int" in (lk, rk):
+                if isinstance(left, AbstractTensor) and lk == "int":
+                    left = left.to_dtype("float")
+                if isinstance(right, AbstractTensor) and rk == "int":
+                    right = right.to_dtype("float")
+
         # unwrap AFTER promotion
         l = left._AbstractTensor__unwrap() if isinstance(left, AbstractTensor) else left
         r = right._AbstractTensor__unwrap() if isinstance(right, AbstractTensor) else right

--- a/src/common/tensors/abstraction_methods/creation.py
+++ b/src/common/tensors/abstraction_methods/creation.py
@@ -217,26 +217,26 @@ def _resolve_cls(cls):
             
     raise RuntimeError("No tensor backend available for tensor creation.")
 
-def zero(cls):
+def zero(cls, dtype: Any = None, device: Any = None):
     from ..abstraction import AbstractTensor  # Local import to avoid circular dependency
 
     cls = _resolve_cls(cls)
-    return AbstractTensor.get_tensor([0], cls=cls)
+    return AbstractTensor.get_tensor([0.0], dtype=dtype, device=device, cls=cls)
 
-def one(cls):
+def one(cls, dtype: Any = None, device: Any = None):
     """Create a tensor filled with ones using the requested backend."""
     from ..abstraction import AbstractTensor  # Local import to avoid circular dependency
 
     cls = _resolve_cls(cls)
-    inst = zero(cls) + 1
-    
+    inst = zero(cls, dtype=dtype, device=device) + 1
+
     return inst
 
 def zeros(size: Tuple[int, ...], dtype: Any = None, device: Any = None, *, cls=None):
     """Create a tensor filled with zeros using the requested backend."""
     from ..abstraction import AbstractTensor  # Local import to avoid circular dependency
 
-    return zero(cls).repeat(size)
+    return zero(cls, dtype=dtype, device=device).repeat(size)
 
 
 def randoms(size: Tuple[int, ...], device: Any = None, *, cls=None, **kwargs):
@@ -248,7 +248,7 @@ def ones(size: Tuple[int, ...], dtype: Any = None, device: Any = None, *, cls=No
     """Create a tensor filled with ones using the requested backend."""
     from ..abstraction import AbstractTensor  # Local import to avoid circular dependency
 
-    return one(cls).repeat(size)
+    return one(cls, dtype=dtype, device=device).repeat(size)
 
 
 def full(

--- a/tests/test_dtype_promotion.py
+++ b/tests/test_dtype_promotion.py
@@ -1,0 +1,49 @@
+import importlib.util
+import pytest
+
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # optional dependency
+    NumPyTensorOperations = None
+
+jax_spec = importlib.util.find_spec("jax")
+if jax_spec is not None:
+    try:
+        from src.common.tensors.jax_backend import JAXTensorOperations
+    except Exception:
+        JAXTensorOperations = None
+else:
+    JAXTensorOperations = None
+
+torch_spec = importlib.util.find_spec("torch")
+if torch_spec is not None:
+    try:
+        from src.common.tensors.torch_backend import PyTorchTensorOperations
+    except Exception:
+        PyTorchTensorOperations = None
+else:
+    PyTorchTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+if JAXTensorOperations is not None:
+    BACKENDS.append(("JAX", JAXTensorOperations))
+if PyTorchTensorOperations is not None:
+    BACKENDS.append(("PyTorch", PyTorchTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_zeros_default_float(backend_name, Backend):
+    t = Backend.zeros((2, 2))
+    assert "float" in str(t.get_dtype()).lower()
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_matmul_promotes_int_to_float(backend_name, Backend):
+    a = Backend.ones((2, 2))
+    b = Backend.ones((2, 2), dtype="int")
+    c = a @ b
+    assert "float" in str(c.get_dtype()).lower()


### PR DESCRIPTION
## Summary
- default tensor `zero`/`one` helpers to float and plumb dtype/device to `zeros`/`ones`
- upcast integer operands when performing mixed float/int `matmul`
- cover dtype behavior with regression tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa57418c98832a9c2be87dfe7441cb