### PR TITLE
Fix weighted covariance in metric PCA

### DIFF
--- a/src/common/tensors/abstract_convolution/ndpca3transform.py
+++ b/src/common/tensors/abstract_convolution/ndpca3transform.py
@@ -115,8 +115,9 @@ def fit_metric_pca(
     # centered
     Xc = X - mu  # (B, n)
 
-    # weighted covariance: Sigma = Xc^T diag(w) Xc
-    Sigma = (Xc.swapaxes(-1, -2) * w.reshape(B, 1, 1)) @ Xc  # (n, n)
+    # weighted covariance: Sigma = (w * Xc)^T Xc
+    # ensure weights apply along the sample axis only
+    Sigma = (w.reshape(B, 1) * Xc).swapaxes(-1, -2) @ Xc  # (n, n)
 
     if metric_M is None:
         # Euclidean PCA: eig(Sigma)

--- a/tests/test_metric_pca.py
+++ b/tests/test_metric_pca.py
@@ -1,0 +1,22 @@
+from src.common.tensors.abstraction import AbstractTensor
+from src.common.tensors.abstract_convolution.ndpca3transform import fit_metric_pca
+
+
+def test_fit_metric_pca_returns_expected_shapes():
+    AT = AbstractTensor
+    B, n = 10, 3
+
+    t = AT.linspace(0.0, 1.0, B)
+    samples = AT.stack([t, t**2, t**3], dim=-1)
+    weights = AT.linspace(1.0, 2.0, B)
+
+    M = AT.eye(n)
+    diag = AT.get_tensor([1.0, 0.5, 2.0])
+    M = M * diag.reshape(1, -1)
+    M = M.swapaxes(-1, -2) * diag.reshape(1, -1)
+
+    basis = fit_metric_pca(samples, weights=weights, metric_M=M)
+
+    assert basis.mu.shape == (n,)
+    assert basis.P.shape == (n, n)
+    assert basis.n == n


### PR DESCRIPTION
## Summary
- correct weight application when computing covariance in `fit_metric_pca`
- add regression test for metric PCA shape outputs

## Testing
- `pytest` *(fails: TypeError float() argument must be a string or a real number)*
- `pytest tests/test_metric_pca.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa8845e2e8832a9dac9a4cde90c778