### PR TITLE
Handle custom layer gradients in Model

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -413,9 +413,14 @@ class Model:
     def grads(self) -> List[AbstractTensor]:
         gs: List[AbstractTensor] = []
         for l in self.layers:
-            gs.append(l.gW)
-            if l.b is not None:
-                gs.append(l.gb)
+            layer_grads = getattr(l, "grads", None)
+            if callable(layer_grads):
+                gs.extend(layer_grads())
+            else:
+                gs.append(l.gW)
+                if l.b is not None:
+                    gs.append(l.gb)
+        assert len(gs) == len(self.parameters()), "grads count must match parameters count"
         return gs
 
     def zero_grad(self) -> None:


### PR DESCRIPTION
## Summary
- Extend Model.grads to support layers exposing a `grads()` method
- Keep fallback to traditional `gW`/`gb` attributes and assert parity with parameters

## Testing
- `pytest` *(fails: ValueError: could not convert string to float: 'AbstractTensor')*

------
https://chatgpt.com/codex/tasks/task_e_68ab12165a5c832ab6d5c0baf9475b8d