### PR TITLE
Add optional NN-based ASCII kernel classifier

### DIFF
--- a/src/rendering/ascii_diff/draw.py
+++ b/src/rendering/ascii_diff/draw.py
@@ -59,7 +59,7 @@ def flexible_subunit_kernel(
 
 # Module-level cache for classifier and ramp
 _classifier_cache = {
-    "ramp_char_size": None, # Cache key will be a tuple (ramp, char_width, char_height)
+    "ramp_char_size_use_nn": None,  # Cache key will be a tuple (ramp, char_width, char_height, use_nn)
     "classifier": None,
 }
 
@@ -71,6 +71,10 @@ def default_subunit_batch_to_chars(
     ramp: str = DEFAULT_DRAW_ASCII_RAMP,
     char_width: int = 16, # Add parameters for desired char_size
     char_height: int = 16, # These will be the actual cell_w, cell_h from clock_demo
+    *,
+    use_nn: bool = False,
+    epsilon: float = 1e-4,
+    max_epochs: int = 200,
 ) -> list[str]:
     """Return characters for ``subunit_batch`` using a cached classifier."""
     # Removed: (subunit_height, subunit_width) = get_char_cell_dims(),
@@ -78,13 +82,17 @@ def default_subunit_batch_to_chars(
     # Removed: exit()
     # Now use the passed-in char_width and char_height
 
-    cache_key = (ramp, char_width, char_height)
-    if _classifier_cache["ramp_char_size"] != cache_key or _classifier_cache["classifier"] is None:
-        # AsciiKernelClassifier expects char_size as (width, height)
-        classifier = AsciiKernelClassifier(ramp, char_size=(char_width, char_height))
-        # font_size is for rendering reference characters, which are then scaled to char_size
+    cache_key = (ramp, char_width, char_height, use_nn)
+    if _classifier_cache["ramp_char_size_use_nn"] != cache_key or _classifier_cache["classifier"] is None:
+        classifier = AsciiKernelClassifier(
+            ramp,
+            char_size=(char_width, char_height),
+            use_nn=use_nn,
+            epsilon=epsilon,
+            max_epochs=max_epochs,
+        )
         classifier.set_font(font_path=str(DEFAULT_FONT_PATH), font_size=16, char_size=(char_width, char_height))
-        _classifier_cache["ramp_char_size"] = cache_key
+        _classifier_cache["ramp_char_size_use_nn"] = cache_key
         _classifier_cache["classifier"] = classifier
     else:
         classifier = _classifier_cache["classifier"]

--- a/tests/test_ascii_kernel_nn.py
+++ b/tests/test_ascii_kernel_nn.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from src.rendering.ascii_diff.ascii_kernel_classifier import AsciiKernelClassifier
+from src.common.tensors import AbstractTensor
+from src.common.tensors.numpy_backend import NumPyTensorOperations
+
+
+def test_nn_classifier_matches_reference_bitmasks():
+    ramp = " .:"
+    classifier = AsciiKernelClassifier(ramp, use_nn=True, epsilon=1e-3, max_epochs=50)
+    assert classifier.charBitmasks is not None
+    np_backend = AbstractTensor.get_tensor(cls=NumPyTensorOperations)
+    batch = np.stack([bm.to_backend(np_backend).numpy() for bm in classifier.charBitmasks], axis=0) * 255.0
+    result = classifier.classify_batch(batch)
+    assert result["chars"] == classifier.charset
+    assert classifier.nn_trained


### PR DESCRIPTION
## Summary
- expand AsciiKernelClassifier with optional neural-network path that trains on first use and caches the model
- allow draw helpers to enable the NN classifier via a new `use_nn` flag
- add a regression test exercising the NN classifier on reference bitmaps

## Testing
- `python -m pytest tests/test_ascii_kernel_nn.py -q`
- `python -m pytest -q` *(fails: ValueError: could not convert string to float: 'AbstractTensor (shape=(1,), dtype=float64, device=cpu)' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1df64b88832a9efa7352b4efd6cb