### PR TITLE
Default to NN kernel and support model state IO

### DIFF
--- a/src/rendering/ascii_diff/ascii_kernel_classifier.py
+++ b/src/rendering/ascii_diff/ascii_kernel_classifier.py
@@ -46,7 +46,7 @@ class AsciiKernelClassifier:
         char_size: tuple[int, int] = (16, 16),
         loss_mode: str = "sad",
         *,
-        use_nn: bool = False,
+        use_nn: bool = True,
         epsilon: float = 1e-4,
         max_epochs: int = 200,
     ) -> None:

--- a/src/rendering/ascii_diff/draw.py
+++ b/src/rendering/ascii_diff/draw.py
@@ -72,7 +72,7 @@ def default_subunit_batch_to_chars(
     char_width: int = 16, # Add parameters for desired char_size
     char_height: int = 16, # These will be the actual cell_w, cell_h from clock_demo
     *,
-    use_nn: bool = False,
+    use_nn: bool = True,
     epsilon: float = 1e-4,
     max_epochs: int = 200,
 ) -> list[str]:

--- a/tests/test_ascii_kernel_nn.py
+++ b/tests/test_ascii_kernel_nn.py
@@ -7,7 +7,8 @@ from src.common.tensors.numpy_backend import NumPyTensorOperations
 
 def test_nn_classifier_matches_reference_bitmasks():
     ramp = " .:"
-    classifier = AsciiKernelClassifier(ramp, use_nn=True, epsilon=1e-3, max_epochs=50)
+    # Default behaviour should use the NN kernel
+    classifier = AsciiKernelClassifier(ramp, epsilon=1e-3, max_epochs=50)
     assert classifier.charBitmasks is not None
     np_backend = AbstractTensor.get_tensor(cls=NumPyTensorOperations)
     batch = np.stack([bm.to_backend(np_backend).numpy() for bm in classifier.charBitmasks], axis=0) * 255.0

--- a/tests/test_model_state_io.py
+++ b/tests/test_model_state_io.py
@@ -1,0 +1,43 @@
+import numpy as np
+from pathlib import Path
+
+from src.common.tensors import AbstractTensor
+from src.common.tensors.numpy_backend import NumPyTensorOperations
+from src.common.tensors.abstract_nn.core import Model, Linear
+from src.common.tensors.abstract_nn.activations import Identity
+
+def _to_numpy(t):
+    np_backend = AbstractTensor.get_tensor(cls=NumPyTensorOperations)
+    return t.to_backend(np_backend).numpy()
+
+
+def test_model_state_roundtrip(tmp_path: Path):
+    like = AbstractTensor.get_tensor(cls=NumPyTensorOperations)
+    layer = Linear(2, 2, like=like)
+    model = Model([layer], activations=[Identity()])
+
+    inp = AbstractTensor.get_tensor(np.array([[1.0, 2.0]], dtype=np.float32))
+    out_initial = model.forward(inp)
+
+    state = model.state_dict()
+
+    # Zero the parameters and ensure output changes
+    for p in model.parameters():
+        p.data[...] = 0
+    out_zero = model.forward(inp)
+    assert not np.allclose(_to_numpy(out_initial), _to_numpy(out_zero))
+
+    # Restore from the in-memory state
+    model.load_state_dict(state)
+    out_restored = model.forward(inp)
+    assert np.allclose(_to_numpy(out_initial), _to_numpy(out_restored))
+
+    # Persist to disk and load again
+    file_path = tmp_path / "model_state.json"
+    model.save_state(file_path)
+
+    for p in model.parameters():
+        p.data[...] = 0
+    model.load_state(file_path)
+    out_file_restored = model.forward(inp)
+    assert np.allclose(_to_numpy(out_initial), _to_numpy(out_file_restored))


### PR DESCRIPTION
## Summary
- Prefer neural-network kernel in ascii_diff utilities
- Allow abstract_nn Model to save and load parameter states
- Cover model state round-trip with new tests

## Testing
- `pytest` *(fails: tests/dt_system/test_dt_scale_response.py::test_dt_scaler_step_response, tests/dt_system/test_dt_scheduler_monte_carlo.py::test_dt_scheduler_monte_carlo, tests/dt_system/test_dt_superstep.py::test_superstep_exact_landing_and_monotone, tests/dt_system/test_dt_superstep.py::test_superstep_allows_increase_when_enabled, tests/dt_system/test_dt_superstep.py::test_halving_on_failure_and_clamped_flag, tests/dt_system/test_dt_superstep.py::test_superstep_returns_unclamped_proposal, tests/dt_system/test_dt_superstep.py::test_nested_supersteps_compose, tests/test_ascii_kernel_nn.py::test_nn_classifier_matches_reference_bitmasks, tests/test_bath_adapter.py::test_sph_adapter_deposit_and_sample, tests/test_bath_adapter.py::test_mac_adapter_deposit_salinity, tests/test_bath_adapter.py::test_adapter_visualization_state_api, tests/test_bath_run_hooks.py::test_run_opengl_draw_modes, tests/test_dt_scale_response.py::test_dt_scaler_step_response, tests/test_dt_scheduler_monte_carlo.py::test_dt_scheduler_monte_carlo, tests/test_dt_superstep.py::test_superstep_exact_landing_and_monotone, tests/test_dt_superstep.py::test_superstep_allows_increase_when_enabled, tests/test_dt_superstep.py::test_halving_on_failure_and_clamped_flag, tests/test_dt_superstep.py::test_superstep_returns_unclamped_proposal, tests/test_dt_superstep.py::test_nested_supersteps_compose, tests/test_opengl_menu_debug.py::test_menu_runs_in_debug[1], tests/test_opengl_menu_debug.py::test_menu_runs_in_debug[2], tests/test_opengl_menu_debug.py::test_menu_runs_in_debug[3], tests/test_run_fluid_demo_step.py::test_run_fluid_demo_uses_step)*

------
https://chatgpt.com/codex/tasks/task_e_68ab207b4dd4832a8d06fc252dbb2981