### PR TITLE
Add image rendering support to RenderChooser ASCII mode

### DIFF
--- a/src/rendering/ascii_diff/roll_demo.py
+++ b/src/rendering/ascii_diff/roll_demo.py
@@ -1,0 +1,39 @@
+"""Demo: roll a tensor image along both axes and display via RenderChooser."""
+
+from __future__ import annotations
+
+import time
+import numpy as np
+from src.rendering.render_chooser import RenderChooser
+
+
+def roll_image(img: np.ndarray, t: int, period_y: int, period_x: int) -> np.ndarray:
+    """Return ``img`` rolled along Y and X using sinusoidal shifts.
+
+    ``period_y`` and ``period_x`` control the oscillation period for the
+    respective axes.  The shifts are quarter amplitude of the image size.
+    """
+
+    shift_y = int(np.sin(2 * np.pi * t / period_y) * img.shape[0] / 4)
+    shift_x = int(np.sin(2 * np.pi * t / period_x) * img.shape[1] / 4)
+    return np.roll(np.roll(img, shift_y, axis=0), shift_x, axis=1)
+
+
+def main() -> None:
+    width, height = 64, 32
+    base = np.indices((height, width)).sum(axis=0) % 2 * 255
+
+    chooser = RenderChooser(width, height, mode="ascii")
+    period_y = height
+    period_x = width * 2
+    try:
+        for t in range(max(period_y, period_x)):
+            frame = roll_image(base, t, period_y, period_x)
+            chooser.render({"image": frame})
+            time.sleep(0.05)
+    finally:
+        chooser.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rendering/render_chooser/__init__.py
+++ b/src/rendering/render_chooser/__init__.py
@@ -16,6 +16,7 @@ import sys
 import threading
 import time
 from typing import Any, Dict, Iterable, Tuple, List, Set
+import numpy as np
 from src.common.double_buffer import DoubleBuffer
 from src.rendering.ascii_diff import (
     ThreadedAsciiDiffPrinter,
@@ -209,6 +210,12 @@ class RenderChooser:
     def _render_ascii(self, state: Dict[str, Any]) -> None:
         r = self.renderer
         r.clear()
+        image = state.get("image")
+        if image is not None:
+            arr = np.asarray(image)
+            if arr.ndim == 2:
+                arr = arr[..., None]
+            r.paint(arr)
         for x, y in state.get("points", []):
             r.point(int(x), int(y))
         for (x0, y0), (x1, y1) in state.get("edges", []):

--- a/tests/test_render_chooser_image.py
+++ b/tests/test_render_chooser_image.py
@@ -1,0 +1,16 @@
+import numpy as np
+from src.rendering.render_chooser import RenderChooser
+
+
+def test_render_chooser_accepts_image():
+    chooser = RenderChooser(8, 4, mode="ascii")
+    try:
+        frame = np.zeros((4, 8), dtype=np.uint8)
+        frame[1, 1] = 255
+        chooser._render_ascii({"image": frame})
+        q = chooser._ascii_queue
+        assert q is not None
+        out = q.get(timeout=1)
+        assert out.strip() != ""
+    finally:
+        chooser.close()


### PR DESCRIPTION
## Summary
- allow `RenderChooser` to blit 2D image tensors in ASCII mode
- add rolling image demo showcasing different x/y periods
- cover image support with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d451bf0832a8302cbcdbe8930b1