### PR TITLE
Ensure ASCII image viewer clears screen between menu frames

### DIFF
--- a/src/rendering/ascii_diff/image_viewer.py
+++ b/src/rendering/ascii_diff/image_viewer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 from PIL import Image
 
-from .console import reset_cursor_to_top
+from .console import full_clear_and_reset_cursor
 from .theme_manager import ThemeManager
 from ..render_chooser import RenderChooser
 
@@ -70,6 +70,7 @@ def menu():
         print("9. Exit")
 
     while True:
+        full_clear_and_reset_cursor()
         print_menu()
         choice = input("Select option (1-9,10): ").strip()
         if choice == "1":
@@ -155,7 +156,7 @@ def menu():
                     )
                     if user_input == "repeat":
                         continue
-                    reset_cursor_to_top()
+                    full_clear_and_reset_cursor()
                     break
             except Exception as e:
                 print(f"Error rendering image: {e}")

--- a/tests/test_image_viewer_menu_clear.py
+++ b/tests/test_image_viewer_menu_clear.py
@@ -1,0 +1,19 @@
+"""Tests for the ASCII image viewer menu screen clearing."""
+
+from unittest import mock
+
+from src.rendering.ascii_diff import image_viewer
+
+
+def test_menu_clears_screen_once(monkeypatch):
+    """Ensure the menu clears the screen before displaying options."""
+
+    # Simulate user immediately exiting the menu.
+    monkeypatch.setattr("builtins.input", lambda *_: "9")
+
+    with mock.patch.object(image_viewer, "full_clear_and_reset_cursor") as clear:
+        image_viewer.menu()
+
+    # The clear function should be invoked at least once per menu iteration.
+    assert clear.call_count >= 1
+


### PR DESCRIPTION
## Summary
- Use `full_clear_and_reset_cursor` for clearing the terminal in the ASCII image viewer
- Clear the screen before each menu iteration and after viewing to prevent frame leftovers
- Add regression test ensuring menu loop invokes the clear function

## Testing
- `pytest tests/test_image_viewer_menu_clear.py tests/test_render_chooser_image.py tests/test_ascii_diff_double_buffer.py tests/test_ascii_render.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab444cfc6c832a92e1bc30c157b036