### PR TITLE
Ensure ASCII frames finish rendering before prompts

### DIFF
--- a/src/rendering/ascii_diff/image_viewer.py
+++ b/src/rendering/ascii_diff/image_viewer.py
@@ -148,6 +148,9 @@ def menu():
                             time.sleep(1.0 / fps)
 
                     rc.render({"image": frame})
+                    # Ensure all pending frames have been printed before prompting the user.
+                    if rc.mode == "ascii" and getattr(rc, "_ascii_queue", None) is not None:
+                        rc._ascii_queue.join()
                     user_input = (
                         input("\nPress Enter to continue, or type 'repeat' to play again: ")
                         .strip()

--- a/tests/test_ascii_printer_flush.py
+++ b/tests/test_ascii_printer_flush.py
@@ -1,0 +1,15 @@
+import sys
+from src.rendering.ascii_diff import ThreadedAsciiDiffPrinter
+
+
+def test_queue_join_prints_before_prompt(capfd):
+    printer = ThreadedAsciiDiffPrinter()
+    try:
+        q = printer.get_queue()
+        q.put("FRAME\n")
+        q.join()
+        print("PROMPT")
+    finally:
+        printer.stop()
+    out = capfd.readouterr().out
+    assert out == "FRAME\nPROMPT\n"


### PR DESCRIPTION
## Summary
- Ensure image viewer waits for all ASCII frames to print before showing a prompt by joining the printer queue
- Add regression test verifying ThreadedAsciiDiffPrinter's queue join flushes output before prompts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab447381b0832ab8adad83fda4bc59