### PR TITLE
Ensure ASCII frames finish rendering before prompts

### DIFF
--- a/src/rendering/ascii_diff/image_viewer.py
+++ b/src/rendering/ascii_diff/image_viewer.py
@@ -148,6 +148,9 @@ def menu():
                             time.sleep(1.0 / fps)
 
                     rc.render({"image": frame})
+                    # Ensure all pending frames have been printed before prompting the user.
+                    if rc.mode == "ascii":
+                        rc.sync()
                     user_input = (
                         input("\nPress Enter to continue, or type 'repeat' to play again: ")
                         .strip()

--- a/src/rendering/render_chooser/__init__.py
+++ b/src/rendering/render_chooser/__init__.py
@@ -37,6 +37,7 @@ class RenderChooser:
         self.screen = None
         self._ascii_printer: ThreadedAsciiDiffPrinter | None = None
         self._ascii_queue = None
+        self._sync_event = threading.Event()
 
         preferred = (mode or os.environ.get("TURING_RENDERER", "ascii")).lower()
 
@@ -159,6 +160,18 @@ class RenderChooser:
                 pass
 
     # ------------------------------------------------------------------
+    def sync(self) -> None:
+        """Block until pending frames have been rendered and printed."""
+        if self.mode != "ascii" or self._ascii_queue is None:
+            return
+        self._sync_event.clear()
+        # Send a sentinel frame that causes the worker thread to signal when
+        # all previous frames have been processed.
+        self.render({"__sync__": True})
+        self._sync_event.wait()
+        self._ascii_queue.join()
+
+    # ------------------------------------------------------------------
     def _loop(self) -> None:
         """Worker thread body: poll input and process render requests."""
 
@@ -167,6 +180,9 @@ class RenderChooser:
             state = self._buffer.read_frame(agent_idx=1)
             if state is None:
                 time.sleep(0.05)
+                continue
+            if state.get("__sync__"):
+                self._sync_event.set()
                 continue
             if self.mode == "opengl":  # pragma: no cover - requires GL context
                 self._render_opengl(state)

--- a/tests/test_ascii_printer_flush.py
+++ b/tests/test_ascii_printer_flush.py
@@ -1,0 +1,15 @@
+import sys
+from src.rendering.ascii_diff import ThreadedAsciiDiffPrinter
+
+
+def test_queue_join_prints_before_prompt(capfd):
+    printer = ThreadedAsciiDiffPrinter()
+    try:
+        q = printer.get_queue()
+        q.put("FRAME\n")
+        q.join()
+        print("PROMPT")
+    finally:
+        printer.stop()
+    out = capfd.readouterr().out
+    assert out == "FRAME\nPROMPT\n"

--- a/tests/test_render_chooser_sync.py
+++ b/tests/test_render_chooser_sync.py
@@ -1,0 +1,15 @@
+import numpy as np
+from src.rendering.render_chooser import RenderChooser
+
+
+def test_render_chooser_sync_drains_buffers(capfd):
+    rc = RenderChooser(2, 2, mode="ascii")
+    try:
+        frame = np.zeros((2, 2, 1), dtype=np.uint8)
+        rc.render({"image": frame})
+        rc.sync()
+        print("PROMPT")
+    finally:
+        rc.close()
+    out = capfd.readouterr().out
+    assert out.endswith("PROMPT\n")


### PR DESCRIPTION
## Summary
- Ensure image viewer waits for all ASCII frames to render by adding a sentinel-based `sync` method in `RenderChooser`
- Use `sync` in the ASCII image viewer so prompts only show after final frame
- Add regression test confirming `RenderChooser.sync` drains buffers before further output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab447381b0832ab8adad83fda4bc59