### PR TITLE
Ensure ASCII fallback output flushes

### DIFF
--- a/src/rendering/ascii_diff/threaded_printer.py
+++ b/src/rendering/ascii_diff/threaded_printer.py
@@ -53,7 +53,7 @@ class ThreadedAsciiDiffPrinter:
                 if self._printer is not None:
                     self._printer.print(frame)
                 else:  # pragma: no cover - fallback path
-                    print(frame, end="")
+                    print(frame, end="", flush=True)
             self._queue.task_done()
         if self._printer is not None:
             self._printer.flush()


### PR DESCRIPTION
## Summary
- flush stdout when ThreadedAsciiDiffPrinter falls back to Python's print

## Testing
- `pytest tests/test_render_chooser_sync.py tests/test_render_chooser_image.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c6f876c832a92d94824bfc18fa0