### PR TITLE
Warn when fast console unavailable in ASCII diff printer

### DIFF
--- a/src/rendering/ascii_diff/threaded_printer.py
+++ b/src/rendering/ascii_diff/threaded_printer.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import threading
 import queue
 from typing import Optional
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:  # Windows-only fast console; fallback to normal print if unavailable
     from src.common.fast_console import cffiPrinter
-except Exception:  # pragma: no cover - non-Windows or missing deps
+except Exception as e:  # pragma: no cover - non-Windows or missing deps
+    logger.warning("fast console unavailable; fallback mode active: %s", e)
     cffiPrinter = None  # type: ignore
 
 from src.common.double_buffer import DoubleBuffer


### PR DESCRIPTION
## Summary
- log a warning when fast console import fails and fallback mode is used

## Testing
- `pytest -o log_cli=true -o log_cli_level=WARNING tests/test_render_chooser_image.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab4c62bb00832aa1d1fb14ab873756