### PR TITLE
Handle non-contiguous tensors in torch view_flat

### DIFF
--- a/src/common/tensors/torch_backend.py
+++ b/src/common/tensors/torch_backend.py
@@ -488,7 +488,7 @@ class PyTorchTensorOperations(AbstractTensor):
         
 
     def view_flat_(self):
-        return self.data.view(-1)
+        return self.data.reshape(-1)
 
     def flatten_(self):
         return self.data.flatten()

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -63,3 +63,11 @@ def test_prod(backend_name, Backend):
     assert to_list(a.prod(dim=0)) == [3, 8]
     assert to_list(a.prod(dim=1, keepdim=True)) == [[2], [12]]
     assert to_list(a.prod(dim=-1)) == [2, 12]
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_view_flat_handles_non_contiguous(backend_name, Backend):
+    # swapaxes produces a non-contiguous view for some backends (e.g., PyTorch)
+    t = Backend.tensor_from_list([[1, 2], [3, 4]]).swapaxes(0, 1)
+    flat = t.view_flat()
+    assert flat.tolist() == [1, 3, 2, 4]


### PR DESCRIPTION
## Summary
- Fix torch backend `view_flat_` to use `reshape` so non-contiguous tensors flatten correctly
- Add regression test covering `view_flat` on swapped axes across backends

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aba6a5f9b4832a8ab11968798e663a