### PR TITLE
feat: add c backend matmul and graph validation

### DIFF
--- a/src/common/tensors/abstract_nn_graph_core.py
+++ b/src/common/tensors/abstract_nn_graph_core.py
@@ -109,3 +109,9 @@ class AbstractNNGraphCore(ABC):
             if hasattr(nn, 'in_nodes') and hasattr(nn, 'out_nodes'):
                 self.in_nodes = nn.in_nodes
                 self.out_nodes = nn.out_nodes
+        if not self.is_graph_complete():
+            raise ValueError("NN graph is incomplete or disconnected.")
+
+    def is_graph_complete(self) -> bool:
+        """Return True if the internal graph is weakly connected."""
+        return self.backing.number_of_nodes() > 0 and nx.is_weakly_connected(self.backing)

--- a/src/common/tensors/accelerator_backends/c_backend/ctensor_ops.c
+++ b/src/common/tensors/accelerator_backends/c_backend/ctensor_ops.c
@@ -139,6 +139,17 @@
     void floordiv_double(const double* a, const double* b, double* out, int n) {
         for (int i = 0; i < n; ++i) out[i] = floor(a[i] / b[i]);
     }
+    void matmul_double(const double* a, const double* b, double* out, int m, int n, int p) {
+        for (int i = 0; i < m; ++i) {
+            for (int j = 0; j < p; ++j) {
+                double sum = 0.0;
+                for (int k = 0; k < n; ++k) {
+                    sum += a[i * n + k] * b[k * p + j];
+                }
+                out[i * p + j] = sum;
+            }
+        }
+    }
     // Scalar ops
     void add_scalar(const double* a, double b, double* out, int n) {
         for (int i = 0; i < n; ++i) out[i] = a[i] + b;

--- a/tests/test_cffi_matmul.py
+++ b/tests/test_cffi_matmul.py
@@ -1,0 +1,23 @@
+import numpy as np
+from src.common.tensors.abstract_nn_graph_core import AbstractNNGraphCore
+from src.common.tensors.accelerator_backends.c_backend import CTensorOperations
+
+def test_nn_graph_complete_and_cffi_forward_pass():
+    segments = [
+        {"label": "input", "nodes": ["i1", "i2"]},
+        {"label": "hidden", "num_nodes": 2},
+    ]
+    segmap = AbstractNNGraphCore.create_segment_map(segments)
+    graph = AbstractNNGraphCore()
+    dummy = type("NN", (), {"segments": segmap, "in_nodes": ["i1", "i2"], "out_nodes": ["hidden_0", "hidden_1"]})
+    graph._register_NN(dummy)
+    assert graph.is_graph_complete()
+
+    ops = CTensorOperations()
+    A = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=float)
+    B = np.array([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]], dtype=float)
+    expected = A @ B
+    A_tensor = ops.tensor_from_list_(A.tolist(), ops.float_dtype_, None)
+    B_tensor = ops.tensor_from_list_(B.tolist(), ops.float_dtype_, None)
+    result = ops.matmul_(A_tensor, B_tensor)
+    assert np.allclose(result.tolist(), expected.tolist())


### PR DESCRIPTION
## Summary
- validate neural network graphs for connectivity
- implement C backend matmul via CFFI and expose python API
- add test covering graph assembly and CFFI matmul

## Testing
- `pytest tests/test_cffi_matmul.py -q`
- `pytest tests/test_tensor_basic_ops.py::test_basic_add_and_zeros -q`

------
https://chatgpt.com/codex/tasks/task_e_68abe04228fc832aa5554af916041708