### PR TITLE
Add gradient cache analysis and fix int conversion

### DIFF
--- a/tests/common/tensors/test_required_cache.py
+++ b/tests/common/tensors/test_required_cache.py
@@ -1,0 +1,31 @@
+import pytest
+from src.common.tensors.autograd import autograd, GradTape
+
+try:  # NumPy backend is optional
+    from src.common.tensors.numpy_backend import NumPyTensorOperations as Tensor
+except Exception:  # pragma: no cover - optional dependency
+    Tensor = None  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def _reset_tape():
+    autograd.tape = GradTape()
+    yield
+    autograd.tape = GradTape()
+
+
+def _tensor(data):
+    t = Tensor.tensor_from_list(data)
+    t.requires_grad_(True)
+    return t
+
+
+@pytest.mark.skipif(Tensor is None, reason="NumPy backend not available")
+def test_required_cache_simple_chain():
+    a = _tensor([1.0, 2.0])
+    b = _tensor([3.0, 4.0])
+    c = _tensor([5.0, 6.0])
+    inter = a * b
+    result = inter + c
+    required = autograd.tape.required_cache(result)
+    assert required == {id(a), id(b)}


### PR DESCRIPTION
## Summary
- add `GradTape.required_cache` to compute which tensor data must be kept for backward passes
- handle scalar `int` conversion and raise proper errors for non-scalar tensors
- add test covering `required_cache`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac63fe0c48832a955313a2cd9bff38