### PR TITLE
Use logging instead of print in ASCII rendering modules

### DIFF
--- a/src/rendering/ascii_diff/draw.py
+++ b/src/rendering/ascii_diff/draw.py
@@ -5,10 +5,23 @@ import sys
 import numpy as AbstractTensor
 from colorama import Style, Fore, Back
 from pathlib import Path
+import logging
+import os
 from .ascii_kernel_classifier import AsciiKernelClassifier
 from src.common.tensors.abstraction import AbstractTensor
 test_tensor = AbstractTensor.get_tensor([0])
 integer_type = test_tensor.long_dtype_
+
+
+logger = logging.getLogger(__name__)
+if os.getenv("TURING_DEBUG"):
+    if not logger.handlers:
+        _h = logging.StreamHandler()
+        _h.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s"))
+        logger.addHandler(_h)
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.addHandler(logging.NullHandler())
 
 # Default ASCII ramp used if no specific ramp is provided to drawing functions.
 DEFAULT_DRAW_ASCII_RAMP = " .:░▒▓█"
@@ -140,12 +153,12 @@ def draw_diff(
     if char_cell_pixel_height <= 0: char_cell_pixel_height = 1
     if char_cell_pixel_width <= 0: char_cell_pixel_width = 1
     if not changed_subunits:
-        print("No changed subunits to draw")
+        logger.debug("No changed subunits to draw")
         return
     subunit_batch = AbstractTensor.stack([data for _, _, data in changed_subunits], dim=0)
     # Pass the actual char_cell_pixel_width and char_cell_pixel_height to the kernel
     chars = subunit_to_char_kernel(subunit_batch, active_ascii_ramp, char_cell_pixel_width, char_cell_pixel_height)
-    print(f"Drawing {len(changed_subunits)} changed subunits")
+    logger.debug("Drawing %d changed subunits", len(changed_subunits))
     for (y_pixel, x_pixel, subunit_data), char_to_draw in zip(changed_subunits, chars):
         char_y = y_pixel // char_cell_pixel_height
         char_x = x_pixel // char_cell_pixel_width

--- a/src/rendering/ascii_diff/threaded_printer.py
+++ b/src/rendering/ascii_diff/threaded_printer.py
@@ -61,23 +61,23 @@ class ThreadedAsciiDiffPrinter:
 
     def _render_loop(self) -> None:
         agent_writer, agent_reader = 0, 1
-        print("Starting render loop")
+        logger.debug("Starting render loop")
         while not self._stop.is_set():
             try:
                 item = self._queue.get(timeout=0.1)
-                print("Retrieved frame from queue")
+                logger.debug("Retrieved frame from queue")
             except queue.Empty:
                 import time
                 time.sleep(0.01)
                 continue
             if item is None:
-                print("Stop sentinel received")
+                logger.debug("Stop sentinel received")
                 self._queue.task_done()
                 break
             self._db.write_frame(item, agent_idx=agent_writer)
             frame = self._db.read_frame(agent_idx=agent_reader)
             if frame is not None:
-                print("Sending frame to cffiPrinter: %d chars", len(frame))
+                logger.debug("Sending frame to cffiPrinter: %d chars", len(frame))
                 self._printer.print(frame)
             self._queue.task_done()
         self._printer.flush()

--- a/src/rendering/ascii_render/__init__.py
+++ b/src/rendering/ascii_render/__init__.py
@@ -13,6 +13,7 @@ from io import StringIO
 from contextlib import redirect_stdout
 import os
 import time
+import logging
 
 import numpy as np
 
@@ -26,6 +27,15 @@ from src.rendering.ascii_diff import (
 
 __all__ = ["AsciiRenderer"]
 
+logger = logging.getLogger(__name__)
+if os.getenv("TURING_DEBUG"):
+    if not logger.handlers:
+        _h = logging.StreamHandler()
+        _h.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s"))
+        logger.addHandler(_h)
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.addHandler(logging.NullHandler())
 
 class AsciiRenderer:
     """Draw simple shapes onto a numpy canvas and render ASCII art.
@@ -220,7 +230,7 @@ class AsciiRenderer:
         fg = enable_fg_color if enable_fg_color is not None else self.enable_fg_color
         bg = enable_bg_color if enable_bg_color is not None else self.enable_bg_color
         #with redirect_stdout(buffer):
-        print("draw diff starting")
+        logger.debug("draw diff starting")
         draw_diff(
                 changed_subunits,
                 char_cell_pixel_height=c_h,
@@ -230,7 +240,7 @@ class AsciiRenderer:
                 enable_fg_color=fg,
                 enable_bg_color=bg,
             )
-        print("draw diff over")
+        logger.debug("draw diff over")
         ascii_out = buffer.getvalue()
         if self.profile and start is not None:
             elapsed = (time.perf_counter() - start) * 1000.0


### PR DESCRIPTION
## Summary
- replace debug prints in ASCII diff renderer with logger calls
- hook ASCII render helpers into logging based on `TURING_DEBUG`
- clean up threaded printer output formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac6e4f0660832a87c522cc66786c9f