### PR TITLE
Add graph-to-ILPScheduler adapter and interop tests

### DIFF
--- a/src/common/tensors/graph_translator.py
+++ b/src/common/tensors/graph_translator.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+"""Translate simple networkx graphs to ILPScheduler process graphs.
+
+This module provides a minimal adapter that converts a ``networkx`` graph
+into the structure expected by :class:`ILPScheduler`.  Nodes may carry an
+``op`` attribute representing the callable to execute.  The translator
+computes a stable execution order via ILP scheduling and caches it for
+subsequent executions.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, List, Type
+
+import networkx as nx
+
+from ...transmogrifier.ilpscheduler import ILPScheduler
+
+
+@dataclass
+class MinimalProcessGraph:
+    """Lightweight shim that satisfies ``ILPScheduler(process_graph)``."""
+
+    G: nx.DiGraph
+    role_schemas: Dict | None = None
+
+
+class GraphTranslator:
+    """Adapt a ``networkx`` graph for ILP scheduling and execution."""
+
+    def __init__(self, graph: nx.DiGraph) -> None:
+        self.graph = graph
+        self._order: List = None
+
+    # ------------------------------------------------------------------
+    # Graph -> ProcessGraph adapter
+    # ------------------------------------------------------------------
+    def _to_process_graph(self) -> MinimalProcessGraph:
+        G = nx.DiGraph()
+        for nid, data in self.graph.nodes(data=True):
+            # copy all attrs except the executable op
+            attrs = {k: v for k, v in data.items() if k != "op"}
+            G.add_node(nid, label=str(nid), parents=[], children=[], **attrs)
+        for u, v in self.graph.edges():
+            G.add_edge(u, v)
+            G.nodes[u]["children"].append((v, "dep"))
+            G.nodes[v]["parents"].append((u, "dep"))
+        return MinimalProcessGraph(G=G, role_schemas={})
+
+    # ------------------------------------------------------------------
+    # Scheduling / execution helpers
+    # ------------------------------------------------------------------
+    def schedule(self, scheduler_cls: Type[ILPScheduler] = ILPScheduler) -> List:
+        """Compute and cache execution order using ``scheduler_cls``."""
+        if self._order is None:
+            proc = self._to_process_graph()
+            sched = scheduler_cls(proc)
+            levels = sched.compute_levels("asap", "dependency")
+            # Order nodes by level (stable for repeated runs)
+            self._order = [nid for nid, _ in sorted(levels.items(), key=lambda x: x[1])]
+        return self._order
+
+    def execute(self, scheduler_cls: Type[ILPScheduler] = ILPScheduler) -> None:
+        """Execute callables attached to nodes in scheduled order."""
+        order = self.schedule(scheduler_cls)
+        for nid in order:
+            op = self.graph.nodes[nid].get("op")
+            if callable(op):
+                op()
+
+
+__all__ = ["GraphTranslator", "MinimalProcessGraph"]

--- a/tests/common/tensors/test_ilps_scheduler_interop.py
+++ b/tests/common/tensors/test_ilps_scheduler_interop.py
@@ -1,0 +1,56 @@
+import networkx as nx
+
+from src.common.tensors.graph_translator import GraphTranslator
+from src.transmogrifier.ilpscheduler import ILPScheduler
+
+
+class CountingScheduler(ILPScheduler):
+    """ILPScheduler subclass that counts compute_levels invocations."""
+
+    calls = 0
+
+    def compute_levels(self, method, order):  # type: ignore[override]
+        type(self).calls += 1
+        return super().compute_levels(method, order)
+
+
+def make_forward(trace):
+    g = nx.DiGraph()
+    g.add_node("a", op=lambda: trace.append("a"))
+    g.add_node("b", op=lambda: trace.append("b"))
+    g.add_edge("a", "b")
+    return g
+
+
+def make_backward(trace):
+    g = nx.DiGraph()
+    g.add_node("b", op=lambda: trace.append("b"))
+    g.add_node("a", op=lambda: trace.append("a"))
+    g.add_edge("b", "a")
+    return g
+
+
+def test_ilps_scheduler_interop():
+    # Forward graph scheduling and execution
+    f_trace: list[str] = []
+    f_graph = make_forward(f_trace)
+    f_trans = GraphTranslator(f_graph)
+
+    CountingScheduler.calls = 0
+    f_trans.schedule(CountingScheduler)
+    f_trans.execute(CountingScheduler)
+    f_trans.execute(CountingScheduler)
+    assert f_trace == ["a", "b", "a", "b"]
+    assert CountingScheduler.calls == 1
+
+    # Backward graph scheduling and execution
+    b_trace: list[str] = []
+    b_graph = make_backward(b_trace)
+    b_trans = GraphTranslator(b_graph)
+
+    CountingScheduler.calls = 0
+    b_trans.schedule(CountingScheduler)
+    b_trans.execute(CountingScheduler)
+    b_trans.execute(CountingScheduler)
+    assert b_trace == ["b", "a", "b", "a"]
+    assert CountingScheduler.calls == 1


### PR DESCRIPTION
## Summary
- add GraphTranslator adapter to convert simple networkx graphs to ILPScheduler process graphs
- execute graph operations using cached ILP schedule
- test forward/backward graph scheduling without repeated ILPScheduler invocations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac70aaf154832abebccc9b6852545a