### PR TITLE
Add autograd training process diagram renderer

### DIFF
--- a/src/common/tensors/process_diagram.py
+++ b/src/common/tensors/process_diagram.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Render training loop diagrams for :mod:`autograd` tensors.
+
+This helper builds a layered graph from :class:`~src.common.tensors.autograd_process.AutogradProcess`
+instances and writes the result to a PNG image.  The diagram exposes the
+relationship between forward computations, cached values, the loss node and the
+backward pass.  Each operation is drawn in a box with its operator label so the
+entire optimisation step can be visually inspected.
+"""
+
+from pathlib import Path
+from typing import Iterable
+
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from .autograd_process import AutogradProcess
+
+
+def build_training_diagram(proc: AutogradProcess) -> nx.DiGraph:
+    """Return a graph describing the training loop captured by ``proc``.
+
+    Nodes are arranged into three layers:
+
+    * Forward operations.
+    * Intermediate nodes (``loss`` and cache markers).
+    * Backward operations.
+
+    Edges follow the data flow of the recorded computation while vertical
+    connections indicate cached values and the mapping between forward and
+    backward nodes.
+    """
+
+    if proc.forward_graph is None or proc.backward_graph is None:
+        raise RuntimeError("build() must be called before requesting a diagram")
+
+    g = nx.DiGraph()
+
+    # forward row -----------------------------------------------------------
+    for tid, data in proc.forward_graph.nodes(data=True):
+        fnode = f"f{tid}"
+        g.add_node(fnode, label=data.get("op"), layer=0)
+        for src in proc.forward_graph.predecessors(tid):
+            g.add_edge(f"f{src}", fnode)
+        if data.get("loss"):
+            g.add_node("loss", label="loss", layer=1)
+            g.add_edge(fnode, "loss")
+        if tid in proc.cache:
+            cache_node = f"cache_{tid}"
+            g.add_node(cache_node, label=f"cache[{tid}]", layer=1)
+            g.add_edge(fnode, cache_node)
+
+    # backward row ----------------------------------------------------------
+    for tid, data in proc.backward_graph.nodes(data=True):
+        bnode = f"b{tid}"
+        g.add_node(bnode, label=data.get("op"), layer=2)
+        for src in proc.backward_graph.predecessors(tid):
+            g.add_edge(f"b{src}", bnode)
+        # connect matching forward nodes to their backward counterparts
+        if proc.forward_graph.has_node(tid):
+            g.add_edge(f"f{tid}", bnode)
+
+    # route loss to the roots of the backward graph
+    roots: Iterable[int] = [
+        nid
+        for nid in proc.backward_graph.nodes
+        if proc.backward_graph.in_degree(nid) == 0
+    ]
+    for root in roots:
+        g.add_edge("loss", f"b{root}")
+
+    return g
+
+
+def render_training_diagram(proc: AutogradProcess, filename: str | Path, *, figsize: tuple[int, int] = (20, 12)) -> None:
+    """Render ``proc`` as a PNG file at ``filename``."""
+
+    diagram = build_training_diagram(proc)
+    pos = nx.multipartite_layout(diagram, subset_key="layer")
+    labels = {n: d.get("label", str(n)) for n, d in diagram.nodes(data=True)}
+
+    plt.figure(figsize=figsize)
+    nx.draw(
+        diagram,
+        pos,
+        with_labels=True,
+        labels=labels,
+        node_shape="s",
+        node_size=3000,
+        font_size=8,
+        arrows=True,
+        node_color="#e0e0ff",
+    )
+    plt.axis("off")
+    filename = Path(filename)
+    plt.savefig(filename, bbox_inches="tight")
+    plt.close()

--- a/tests/test_process_diagram.py
+++ b/tests/test_process_diagram.py
@@ -1,0 +1,33 @@
+from src.common.tensors import AbstractTensor
+from src.common.tensors.autograd_process import AutogradProcess
+from src.common.tensors.process_diagram import build_training_diagram, render_training_diagram
+
+
+def test_process_diagram_build_and_render(tmp_path):
+    autograd = AbstractTensor.autograd
+    tape = autograd.tape
+    tape._nodes.clear()
+    tape.graph.clear()
+
+    x = AbstractTensor.tensor([1.0, 2.0, 3.0])
+    y = AbstractTensor.tensor([2.0, 4.0, 6.0])
+    w = AbstractTensor.tensor([0.0])
+    w.requires_grad = True
+
+    def forward_fn():
+        pred = x * w
+        err = pred - y
+        sq = err * err
+        loss_val = sq.sum().item()
+        return sq, loss_val
+
+    proc = AutogradProcess(tape)
+    proc.training_loop(forward_fn, [w], steps=1, lr=0.1)
+
+    diagram = build_training_diagram(proc)
+    assert "loss" in diagram
+    assert any(n.startswith("cache_") for n in diagram.nodes)
+
+    out_file = tmp_path / "diagram.png"
+    render_training_diagram(proc, out_file)
+    assert out_file.exists() and out_file.stat().st_size > 0


### PR DESCRIPTION
## Summary
- Add `build_training_diagram` and `render_training_diagram` helpers to visualize full autograd training loops
- Test rendering and graph construction for process diagrams

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac7483e608832a9b80e69a7c0dbb0b