### PR TITLE
Enable optional PNG output for process diagrams

### DIFF
--- a/src/common/tensors/process_diagram.py
+++ b/src/common/tensors/process_diagram.py
@@ -13,6 +13,7 @@ omitted to keep the module light-weight.
 from pathlib import Path
 from typing import Dict, Iterable, List
 
+import matplotlib.pyplot as plt
 import networkx as nx
 
 from .autograd_process import AutogradProcess
@@ -84,6 +85,54 @@ def build_training_diagram(proc: AutogradProcess) -> nx.DiGraph:
     return g
 
 
+def _layered_grid_layout(
+    g: nx.DiGraph,
+    *,
+    max_nodes_per_col: int = 8,
+    layer_gap: float = 3.0,
+    col_gap: float = 0.5,
+    row_gap: float = 1.0,
+) -> Dict[str, tuple[float, float]]:
+    """Return coordinates for ``g`` arranging each ``layer`` in a grid.
+
+    ``nx.multipartite_layout`` tends to stack all nodes for a layer along a
+    single line which can make dense graphs unreadable.  This helper spreads
+    nodes within the same layer vertically and wraps to new columns once the
+    number of nodes exceeds ``max_nodes_per_col``.
+
+    Parameters
+    ----------
+    g:
+        Graph with ``layer`` metadata on each node.
+    max_nodes_per_col:
+        Number of nodes to place in a single column for a layer before
+        wrapping to a new column.
+    layer_gap:
+        Horizontal distance between successive layers.
+    col_gap:
+        Additional horizontal offset applied when wrapping to a new column
+        inside a layer.
+    row_gap:
+        Vertical distance between nodes within the same column.
+    """
+
+    layers: Dict[int, List[str]] = {}
+    for node, data in g.nodes(data=True):
+        layer = int(data.get("layer", 0))
+        layers.setdefault(layer, []).append(node)
+
+    pos: Dict[str, tuple[float, float]] = {}
+    for layer, nodes in layers.items():
+        for idx, node in enumerate(nodes):
+            col = idx // max_nodes_per_col
+            row = idx % max_nodes_per_col
+            x = layer * layer_gap + col * col_gap
+            y = -row * row_gap
+            pos[node] = (x, y)
+
+    return pos
+
+
 def render_training_diagram(
     proc: AutogradProcess,
     filename: str | Path | None = None,
@@ -92,18 +141,38 @@ def render_training_diagram(
 ) -> nx.DiGraph:
     """Return a combined process diagram for ``proc``.
 
-    Image generation has been stubbed out; this function now simply returns the
-    :class:`networkx.DiGraph` produced by :func:`build_training_diagram` that
-    combines forward, cached values, the loss node and the backward pass.
+    The diagram is drawn using :mod:`matplotlib`. If ``filename`` is provided
+    the image is written to that path. Otherwise a window will be shown so the
+    caller can visually inspect the graph.
 
     Parameters
     ----------
     proc:
         The :class:`AutogradProcess` whose computation will be represented.
     filename:
-        Ignored placeholder for the previous PNG output path.
+        Optional output location for a PNG snapshot of the diagram. When
+        omitted a GUI window is opened instead.
     figsize:
-        Retained for backwards compatibility and unused.
+        Figure size passed through to :func:`matplotlib.pyplot.figure`.
     """
 
-    return build_training_diagram(proc)
+    g = build_training_diagram(proc)
+
+    pos = _layered_grid_layout(g)
+    plt.figure(figsize=figsize)
+    node_artists = nx.draw_networkx_nodes(g, pos)
+    node_artists.set_zorder(1)
+    edge_artists = nx.draw_networkx_edges(g, pos)
+    for artist in edge_artists:
+        artist.set_zorder(2)
+    label_artists = nx.draw_networkx_labels(g, pos)
+    for artist in label_artists.values():
+        artist.set_zorder(3)
+
+    if filename is not None:
+        plt.savefig(Path(filename))
+        plt.close()
+    else:
+        plt.show()
+
+    return g

--- a/tests/test_process_diagram.py
+++ b/tests/test_process_diagram.py
@@ -30,6 +30,8 @@ def test_process_diagram_build_and_render(tmp_path):
     assert "loss" in diagram
     assert any(n.startswith("cache_") for n in diagram.nodes)
 
-    rendered = render_training_diagram(proc, tmp_path / "diagram.png")
+    out_file = tmp_path / "diagram.png"
+    rendered = render_training_diagram(proc, out_file)
     assert isinstance(rendered, nx.DiGraph)
     assert "loss" in rendered
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- render training diagrams with matplotlib, saving to PNG when a filename is provided or showing an interactive window otherwise
- adjust process diagram test to verify PNG output
- spread diagram nodes across grid layers and raise edges above nodes for clarity

## Testing
- `python3 -m pytest tests/test_process_diagram.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac845b3214832a8dcf888d2f99d684