### PR TITLE
Annotate graph nodes with ILP levels

### DIFF
--- a/tests/common/tensors/test_ilps_scheduler_interop.py
+++ b/tests/common/tensors/test_ilps_scheduler_interop.py
@@ -42,6 +42,7 @@ def test_ilps_scheduler_interop():
     f_trans.execute(CountingScheduler)
     assert f_trace == ["a", "b", "a", "b"]
     assert CountingScheduler.calls == 1
+    assert {f_graph.nodes[n]["layer"] for n in f_graph} == {0, 1}
 
     # Backward graph scheduling and execution
     b_trace: list[str] = []
@@ -54,3 +55,4 @@ def test_ilps_scheduler_interop():
     b_trans.execute(CountingScheduler)
     assert b_trace == ["b", "a", "b", "a"]
     assert CountingScheduler.calls == 1
+    assert {b_graph.nodes[n]["layer"] for n in b_graph} == {0, 1}

--- a/tests/test_process_diagram.py
+++ b/tests/test_process_diagram.py
@@ -29,6 +29,12 @@ def test_process_diagram_build_and_render(tmp_path):
     diagram = build_training_diagram(proc)
     assert "loss" in diagram
     assert any(n.startswith("cache_") for n in diagram.nodes)
+    # Forward graph nodes should carry layered execution metadata so that the
+    # diagram arranges operations sequentially.
+    f_layers = {data.get("layer") for _, data in proc.forward_graph.nodes(data=True)}
+    assert len(f_layers) > 1
+    d_layers = {data.get("layer") for _, data in diagram.nodes(data=True)}
+    assert min(d_layers) == 0 and max(d_layers) > 0
 
     out_file = tmp_path / "diagram.png"
     rendered = render_training_diagram(proc, out_file)


### PR DESCRIPTION
## Summary
- Persist execution order as `layer` attributes on autograd forward/backward graphs
- Build process diagrams using existing layer metadata and color nodes by layer for clarity
- Verify layer propagation in process diagram tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad1b944e24832aa1d39150c0bf2c84