### PR TITLE
Fix forward graph to follow tensor dependencies

### DIFF
--- a/src/common/tensors/autograd_process.py
+++ b/src/common/tensors/autograd_process.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from .autograd import GradTape
 from .abstraction import AbstractTensor
+from .graph_translator import GraphTranslator
 
 
 @dataclass
@@ -47,19 +48,13 @@ class AutogradProcess:
 
         self.forward_graph = self.tape.export_forward_graph()
         self.backward_graph = self.tape.export_backward_graph(result)
-        self.forward_schedule = list(nx.topological_sort(self.forward_graph))
-        self.backward_schedule = list(nx.topological_sort(self.backward_graph))
 
-        # Annotate each graph node with its execution layer.  Many graphs
-        # produced by the autograd tape omit explicit dependency edges, which
-        # causes ``nx.topological_generations`` to collapse everything into a
-        # single layer.  By storing the order returned from
-        # :func:`nx.topological_sort` we provide a stable layering for
-        # visualisation utilities and downstream analysis.
-        for lvl, tid in enumerate(self.forward_schedule):
-            self.forward_graph.nodes[tid]["layer"] = lvl
-        for lvl, tid in enumerate(self.backward_schedule):
-            self.backward_graph.nodes[tid]["layer"] = lvl
+        # Use the project's ILP scheduler to determine execution order and
+        # layer assignments for both graphs.
+        f_sched = GraphTranslator(self.forward_graph)
+        self.forward_schedule = f_sched.schedule()
+        b_sched = GraphTranslator(self.backward_graph)
+        self.backward_schedule = b_sched.schedule()
 
         self.cache = self.tape.required_cache(result)
         self.stages["forward"] = self.forward_schedule

--- a/tests/test_forward_graph_dependencies.py
+++ b/tests/test_forward_graph_dependencies.py
@@ -1,0 +1,36 @@
+import numpy as np
+from src.common.tensors import AbstractTensor
+from src.common.tensors.autograd_process import AutogradProcess
+
+
+def test_forward_graph_tracks_dependencies():
+    autograd = AbstractTensor.autograd
+    autograd.tape._nodes.clear()
+
+    a = AbstractTensor.tensor([1.0])
+    b = AbstractTensor.tensor([2.0])
+    c = AbstractTensor.tensor([3.0])
+    d = AbstractTensor.tensor([4.0])
+
+    for t in (a, b, c, d):
+        t.requires_grad = True
+
+    x = a * b
+    y = c + d
+    loss = x + y
+
+    autograd.tape.mark_loss(loss)
+    proc = AutogradProcess(autograd.tape)
+    proc.build(loss)
+
+    edges = set(proc.forward_graph.edges())
+    assert (id(a), id(x)) in edges
+    assert (id(b), id(x)) in edges
+    assert (id(c), id(y)) in edges
+    assert (id(d), id(y)) in edges
+    assert (id(x), id(loss)) in edges
+    assert (id(y), id(loss)) in edges
+
+    lx = proc.forward_graph.nodes[id(x)]["layer"]
+    ly = proc.forward_graph.nodes[id(y)]["layer"]
+    assert lx == ly


### PR DESCRIPTION
## Summary
- derive forward graph edges from operation nodes so data dependencies drive layout
- add test ensuring parallel branches share the same layer in the forward graph
- remove topological sort usage in autograd and diagram generation in favour of the project's scheduler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad24b96a94832a8a0075841e4ae3fd