### PR TITLE
Fix gradient tracking in training loop

### DIFF
--- a/src/common/tensors/abstract_convolution/demo_ndpca3conv3d_process_diagram.py
+++ b/src/common/tensors/abstract_convolution/demo_ndpca3conv3d_process_diagram.py
@@ -85,13 +85,14 @@ def main() -> None:
         model.backward(grad_pred)
         params = model.parameters()
         grads = model.grads()
-        new_params = optimizer.step(params, grads)
-        i = 0
-        for layer in model.layers:
-            layer_params = layer.parameters()
-            for j in range(len(layer_params)):
-                layer_params[j].data[...] = new_params[i].data
-                i += 1
+        with autograd.no_grad():
+            new_params = optimizer.step(params, grads)
+            i = 0
+            for layer in model.layers:
+                layer_params = layer.parameters()
+                for j in range(len(layer_params)):
+                    AbstractTensor.copyto(layer_params[j], new_params[i])
+                    i += 1
         model.zero_grad()
 
     # --- capture autograd process on a fresh tape ---

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -392,9 +392,10 @@ class AbstractTensor:
 
     def sum(self, dim=None, keepdim: bool = False):
         """Return the sum of the tensor along the specified dimension(s)."""
+        finalize = AbstractTensor._pre_autograd("sum", [self])
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.sum_(dim=dim, keepdim=keepdim)
-        return result
+        return finalize(result)
 
     def cumsum(self, dim: int = 0) -> "AbstractTensor":
         """Return the cumulative sum of the tensor along a dimension."""

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -509,7 +509,7 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
             "x": "gx = expand_to(g, x.shape)"
         },
         "python": {
-            "parameters": ["g", "x", "axis", "keepdim"],
+            "parameters": ["g", "x"],
             "body": "return expand_to(g, x.shape)"
         },
         "domain": "x: any real",

--- a/tests/test_process_diagram.py
+++ b/tests/test_process_diagram.py
@@ -20,8 +20,8 @@ def test_process_diagram_build_and_render(tmp_path):
         pred = x * w
         err = pred - y
         sq = err * err
-        loss_val = sq.sum().item()
-        return sq, loss_val
+        loss_val = sq.sum()
+        return loss_val, loss_val.detach()
 
     proc = AutogradProcess(tape)
     proc.training_loop(forward_fn, [w], steps=1, lr=0.1)


### PR DESCRIPTION
## Summary
- Preserve tensor form in `AutogradProcess.training_loop` and update parameters via `AbstractTensor.copyto`
- Record reduction ops on the autograd tape and simplify the `sum` backward rule
- Update demo and tests to avoid `.item()` and respect the new gradient-safe workflow

## Testing
- `pytest tests/test_process_diagram.py::test_process_diagram_build_and_render -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade041be10832aac3c6e0406be5052