### PR TITLE
Enable vector output for process diagrams

### DIFF
--- a/src/common/tensors/abstract_convolution/demo_ndpca3conv3d_process_diagram.py
+++ b/src/common/tensors/abstract_convolution/demo_ndpca3conv3d_process_diagram.py
@@ -2,14 +2,16 @@
 
 This demo builds a tiny classifier using the metric-driven
 :class:`~src.common.tensors.abstract_convolution.ndpca3conv.NDPCA3Conv3d`
-layer and renders the recorded autograd process to a PNG image.  The
+layer and renders the recorded autograd process to an image. The
 network is the same Riemannian convolution used by ``AsciiKernelClassifier``
 so the resulting diagram reflects the data flow through that classifier.
+The output format can be selected at runtime (PNG, SVG, or PDF).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+import argparse
 import numpy as np
 
 from src.common.tensors.abstraction import AbstractTensor
@@ -60,6 +62,10 @@ class DemoModel(Model):
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Render training diagram for NDPCA3Conv3d demo")
+    parser.add_argument("--format", choices=["png", "svg", "pdf"], default="png", help="Output image format")
+    args = parser.parse_args()
+
     np.random.seed(0)
     img_np = np.random.rand(BATCH_SIZE, IN_CHANNELS, IMG_D, IMG_H, IMG_W).astype(np.float32)
     img = AbstractTensor.get_tensor(img_np)
@@ -113,8 +119,8 @@ def main() -> None:
     proc = AutogradProcess(autograd.tape)
     proc.build(loss)
 
-    out_file = Path(__file__).with_name("ndpca3conv3d_training.png")
-    render_training_diagram(proc, out_file)
+    out_file = Path(__file__).with_name(f"ndpca3conv3d_training.{args.format}")
+    render_training_diagram(proc, out_file, format=args.format)
     print(f"Process diagram written to {out_file}")
 
 

--- a/src/common/tensors/process_diagram.py
+++ b/src/common/tensors/process_diagram.py
@@ -167,21 +167,28 @@ def render_training_diagram(
     proc: AutogradProcess,
     filename: str | Path | None = None,
     *,
+    format: str | None = None,
     figsize: tuple[int, int] | None = None,
 ) -> nx.DiGraph:
     """Return a combined process diagram for ``proc``.
 
     The diagram is drawn using :mod:`matplotlib`. If ``filename`` is provided
     the image is written to that path. Otherwise a window will be shown so the
-    caller can visually inspect the graph.
+    caller can visually inspect the graph. The output format is inferred from
+    the filename extension but can be explicitly set via ``format`` to force
+    vector formats like SVG or PDF.
 
     Parameters
     ----------
     proc:
         The :class:`AutogradProcess` whose computation will be represented.
     filename:
-        Optional output location for a PNG snapshot of the diagram. When
-        omitted a GUI window is opened instead.
+        Optional output location for a snapshot of the diagram. When omitted a
+        GUI window is opened instead.
+    format:
+        Optional file format passed to :func:`matplotlib.pyplot.savefig`.
+        When ``None`` the format is inferred from ``filename``. Use ``"svg"``
+        or ``"pdf"`` for vector output.
     figsize:
         Optional figure size passed through to
         :func:`matplotlib.pyplot.figure`. When omitted the size is determined
@@ -210,7 +217,8 @@ def render_training_diagram(
         artist.set_zorder(3)
 
     if filename is not None:
-        plt.savefig(Path(filename))
+        save_kwargs = {"format": format} if format else {}
+        plt.savefig(Path(filename), **save_kwargs)
         plt.close()
     else:
         plt.show()


### PR DESCRIPTION
## Summary
- allow `render_training_diagram` to save using a specified format (e.g. SVG or PDF)
- add `--format` option to NDPCA3Conv3d demo to choose PNG, SVG, or PDF output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ade9a74908832a942f128edcc05d19