### PR TITLE
Add training replay validation and implement autograd.train

### DIFF
--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -750,20 +750,24 @@ class Autograd:
         lr: float = 1e-2,
         params: Optional[List[Any]] = None,
     ) -> None:
-        """Stub for graph-based training using recorded tape metadata.
+        """Train ``params`` by repeatedly evaluating ``loss_fn``.
 
-        The intended design is to translate the metadata captured on the
-        ``GradTape`` into a standalone forward/backward execution graph and
-        perform parameter updates by walking that graph directly.  No tape
-        playback should occur once the graphs are materialised.
-
-        This function currently serves as a placeholder and does not execute
-        any training loop.
+        This thin wrapper delegates to :meth:`AutogradProcess.training_loop`
+        so callers can quickly execute self-contained optimisation runs using
+        the existing :class:`GradTape`.  The returned
+        :class:`~src.common.tensors.autograd_process.AutogradProcess` carries
+        the full forward/backward graphs and execution schedules for the final
+        iteration which can be used for further analysis or replay.
         """
 
-        raise NotImplementedError(
-            "Graph-based training is not yet implemented"
-        )
+        if params is None:
+            params = []
+
+        from .autograd_process import AutogradProcess
+
+        proc = AutogradProcess(self.tape)
+        proc.training_loop(loss_fn, params, steps=epochs, lr=lr)
+        return proc
 
 
 autograd = Autograd()

--- a/tests/common/tensors/test_training_state_and_train.py
+++ b/tests/common/tensors/test_training_state_and_train.py
@@ -46,7 +46,7 @@ def test_export_training_state():
 
 
 @pytest.mark.skipif(Tensor is None, reason="NumPy backend not available")
-def test_train_is_stubbed():
+def test_train_updates_parameter():
     w = _param(0.0)
     x = Tensor.tensor_from_list([1.0])
     y = Tensor.tensor_from_list([2.0])
@@ -56,5 +56,6 @@ def test_train_is_stubbed():
         loss = (pred - y) * (pred - y)
         return loss
 
-    with pytest.raises(NotImplementedError):
-        autograd.train(loss_fn, epochs=1, lr=0.1, params=[w])
+    proc = autograd.train(loss_fn, epochs=1, lr=0.1, params=[w])
+    assert isinstance(proc.forward_graph, nx.DiGraph)
+    assert abs(w.data[0] - 0.4) < 1e-6


### PR DESCRIPTION
## Summary
- implement `autograd.train` to run optimisation loops via `AutogradProcess`
- extend NDPCA3Conv3d demo with replay-based validation covering weight updates and new inputs
- update tests for new training helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae017187f8832abc61d819cbfd39a3