### PR TITLE
Improve missing gradient error reporting

### DIFF
--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -716,13 +716,15 @@ class Autograd:
                         grad_map[pid] = g
 
         results: List[Any] = []
-        for inp in inputs:
+        for idx, inp in enumerate(inputs):
             g = grad_map.get(id(inp))
             if g is None:
                 if allow_unused:
                     results.append(None)
                 else:
-                    raise ValueError("No gradient found for one of the inputs")
+                    raise ValueError(
+                        f"No gradient found for input at index {idx} with id={id(inp)}"
+                    )
             else:
                 if hasattr(inp, "data") and isinstance(inp.data, list):
                     g = g.tolist()

--- a/tests/test_autograd_missing_grad_message.py
+++ b/tests/test_autograd_missing_grad_message.py
@@ -1,0 +1,20 @@
+import pytest
+from src.common.tensors import AbstractTensor
+
+
+def test_grad_error_identifies_missing_input():
+    autograd = AbstractTensor.autograd
+    autograd.tape._nodes.clear()
+
+    a = AbstractTensor.tensor([1.0])
+    b = AbstractTensor.tensor([2.0])
+    a.requires_grad = True
+    b.requires_grad = True
+
+    y = a * 3.0
+
+    with pytest.raises(ValueError) as excinfo:
+        autograd.grad(y, [a, b], allow_unused=False)
+    msg = str(excinfo.value)
+    assert "index 1" in msg
+    assert str(id(b)) in msg


### PR DESCRIPTION
## Summary
- include offending input index and id in missing gradient error message
- add test ensuring grad error message identifies problematic input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0d43191c832aa0eb5f35d78b17ee