### PR TITLE
Ensure parameters require gradients in tensor layers

### DIFF
--- a/src/common/tensors/abstract_convolution/ndpca3conv.py
+++ b/src/common/tensors/abstract_convolution/ndpca3conv.py
@@ -110,6 +110,7 @@ class NDPCA3Conv3d:
         # shape: (k, 3) for [-1, 0, +1]
         init = np.array([[0.25, 0.50, 0.25] for _ in range(k)], dtype=np.float32)
         self.taps = like.ensure_tensor(init)
+        self.taps.requires_grad_(True)
         self.g_taps = AbstractTensor.zeros_like(self.taps)
 
         # optional 1x1 channel mix after spatial pass

--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -34,8 +34,11 @@ class Linear:
             f"Linear layer init: in_dim={in_dim}, out_dim={out_dim}, bias={bias}, init={init}, scale={scale}"
         )
         self.W = _randn_matrix(in_dim, out_dim, like=like, scale=scale)
+        self.W.requires_grad_(True)
         # Seed a small positive bias to avoid symmetric stall at init
         self.b = from_list_like([[0.01] * out_dim], like=like) if bias else None
+        if self.b is not None:
+            self.b.requires_grad_(True)
         logger.debug(
             f"Linear layer weights shape: {getattr(self.W, 'shape', None)}; bias shape: {getattr(self.b, 'shape', None) if self.b is not None else None}"
         )

--- a/tests/test_requires_grad.py
+++ b/tests/test_requires_grad.py
@@ -1,0 +1,16 @@
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
+from src.common.tensors.abstract_nn.core import Linear
+from src.common.tensors.abstract_convolution.ndpca3conv import NDPCA3Conv3d
+
+def test_linear_parameters_require_grad():
+    like = T.tensor_from_list([[0.0]])
+    layer = Linear(2, 3, like=like)
+    assert layer.W.requires_grad
+    assert layer.b is not None and layer.b.requires_grad
+
+def test_ndpca3conv_pointwise_linear_requires_grad():
+    like = T.tensor_from_list([[0.0]])
+    conv = NDPCA3Conv3d(1, 2, like=like, grid_shape=(1, 1, 1), pointwise=True)
+    assert conv.taps.requires_grad
+    assert conv.pointwise is not None
+    assert conv.pointwise.W.requires_grad


### PR DESCRIPTION
## Summary
- Call `requires_grad_(True)` on `Linear` weights and biases
- Mark `NDPCA3Conv3d` taps as requiring gradients
- Test that both layers, including nested `Linear` instances, have gradient-enabled parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e50b258832a9dec4d5db7915b50