### PR TITLE
Handle -1 inference in reshape autograd

### DIFF
--- a/src/common/tensors/abstraction_methods/reshape.py
+++ b/src/common/tensors/abstraction_methods/reshape.py
@@ -16,12 +16,12 @@ def reshape(self, *shape) -> "AbstractTensor":
     from ..abstraction import AbstractTensor, BACKEND_REGISTRY
 
     shape_tuple = AbstractTensor._normalize_shape_args(*shape)
-    finalize = AbstractTensor._pre_autograd(
-        "reshape", [self], params={"new_shape": shape_tuple}
-    )
 
     if hasattr(self, "reshape_"):
         out = _wrap_result(self, self.reshape_(shape_tuple))
+        finalize = AbstractTensor._pre_autograd(
+            "reshape", [self], params={"new_shape": out.shape}
+        )
         return finalize(out)
 
     # numpy fallback (kept intact, but now passes a tuple)
@@ -34,6 +34,9 @@ def reshape(self, *shape) -> "AbstractTensor":
                 reshaped_data = numpy_tensor.data.reshape(shape_tuple)
                 reshaped_tensor = backend_cls(track_time=getattr(self, "track_time", False))
                 reshaped_tensor.data = reshaped_data
+                finalize = AbstractTensor._pre_autograd(
+                    "reshape", [self], params={"new_shape": reshaped_tensor.shape}
+                )
                 return finalize(reshaped_tensor.to_backend(self))
     except Exception:
         pass

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -607,8 +607,8 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
             "x": "gx = reshape(g, x.shape)"
         },
         "python": {
-            "parameters": ["g", "x", "new_shape"],
-            "body": "return AbstractTensor.reshape(g, x.shape)"
+            "parameters": ["g", "x", "new_shape=None"],
+            "body": "return AbstractTensor.reshape(g, getattr(x, 'shape', new_shape))"
         },
         "domain": "Same number of elements.",
         "notes": "Gradient reshapes back.",


### PR DESCRIPTION
## Summary
- record resolved output shape in reshape so autograd knows inferred dimensions
- allow bw_reshape to accept optional `new_shape` for handling inputs with inferred dimensions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c56b084832a8ed0813f543dd30d