### PR TITLE
Ensure reshape backward gets new shape info

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1951,6 +1951,13 @@ _bind_and_wrap({
     "ifft": fourier_ifft,
 })
 
+AbstractTensor.reshape = _reshape_methods.reshape
+AbstractTensor.flatten = _reshape_methods.flatten
+AbstractTensor.transpose = _reshape_methods.transpose
+AbstractTensor.unsqueeze = _reshape_methods.unsqueeze
+AbstractTensor.squeeze = _reshape_methods.squeeze
+AbstractTensor.swapaxes = _reshape_methods.swapaxes
+
 AbstractTensor.numel   = prop_numel
 AbstractTensor.item    = prop_item
 AbstractTensor.shape   = property(prop_shape)

--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -704,7 +704,14 @@ class Autograd:
                 if bw is None:
                     continue
                 go = grad_out
-                parent_grads = bw(go, *node.ctx["inputs"])
+                params = node.ctx.get("params", {})
+                if params:
+                    import inspect
+                    sig = inspect.signature(bw)
+                    allowed = {k: v for k, v in params.items() if k in sig.parameters}
+                else:
+                    allowed = {}
+                parent_grads = bw(go, *node.ctx["inputs"], **allowed)
                 if not isinstance(parent_grads, (list, tuple)):
                     parent_grads = (parent_grads,)
                 for (pid, _), g in zip(node.parents, parent_grads):

--- a/tests/test_autograd_reshape.py
+++ b/tests/test_autograd_reshape.py
@@ -1,0 +1,18 @@
+import pytest
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations as Tensor
+except Exception:  # pragma: no cover - optional dependency
+    Tensor = None  # type: ignore
+
+from src.common.tensors.autograd import autograd
+
+
+@pytest.mark.skipif(Tensor is None, reason="NumPy backend not available")
+def test_bw_reshape_handles_negative_one():
+    x = Tensor.arange(6).reshape(2, 3).astype("float32")
+    x.requires_grad_(True)
+    y = x.reshape(3, -1).sum()
+    autograd.grad(y, [x])
+    assert x._grad.shape == x.shape
+    assert x._grad.tolist() == [[1, 1, 1], [1, 1, 1]]


### PR DESCRIPTION
## Summary
- pass recorded op parameters to backward functions
- avoid double autograd recording for reshape family so new shapes are preserved
- test reshape backward with negative dimensions

## Testing
- `pytest tests/test_autograd_reshape.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae4c56b084832a8ed0813f543dd30d