### PR TITLE
Log tensor index operations

### DIFF
--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -674,6 +674,22 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
         "notes": "Implements a simple scatter into the sliced region.",
         "tags": ["shape", "indexing"],
     },
+    "index_set": {
+        "arity": "binary",
+        "signature": "y = x; y[idx] = v",
+        "latex": r"y = x; y[\\text{idx}] = v",
+        "backward": {
+            "x": "gx = g.clone()",
+            "v": "gv = g[idx]"
+        },
+        "python": {
+            "parameters": ["g", "x", "v", "idx"],
+            "body": "gx=g.clone(); gv=g[idx]; return gx, gv"
+        },
+        "domain": "Any real; idx valid.",
+        "notes": "Scatter assignment; gradient flows from selected region to the value.",
+        "tags": ["indexing"],
+    },
     "concat": {
         "arity": "n-ary",
         "signature": "y = concat([x1, x2, ...], dim)",


### PR DESCRIPTION
## Summary
- log tensor getitem and setitem accesses to help debug tape recording
- record index assignments on the autograd tape via new `index_set` op and backward rule

## Testing
- `pytest tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise -q` *(fails: RecursionError: maximum recursion depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86240164832a934922bddcdb018b