### PR TITLE
feat: integrate cycle unroller into graph scheduling

### DIFF
--- a/tests/common/tensors/test_graph_translator_unroll.py
+++ b/tests/common/tensors/test_graph_translator_unroll.py
@@ -1,0 +1,22 @@
+import networkx as nx
+
+from src.common.tensors.graph_translator import GraphTranslator
+
+
+def test_graph_translator_handles_self_loops():
+    trace: list[str] = []
+    g = nx.DiGraph()
+    g.add_node("A", op=lambda: trace.append("A"))
+    g.add_node("B", op=lambda: trace.append("B"))
+    g.add_edge("A", "A")
+    g.add_edge("A", "B")
+
+    trans = GraphTranslator(g)
+    order = trans.schedule()
+    trans.execute()
+
+    assert trace == ["A", "B"]
+    assert order == ["A", "B"]
+    assert g.nodes["A"]["level"] < g.nodes["B"]["level"]
+    assert {g.nodes[n]["level"] for n in g} == {0, 1}
+


### PR DESCRIPTION
## Summary
- unroll self-loop edges before ILP scheduling to avoid cycles
- test that GraphTranslator processes self-loop graphs correctly

## Testing
- `pytest -q` *(fails: RecursionError in tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise)*

------
https://chatgpt.com/codex/tasks/task_e_68aeee465d9c832a9115b1e9b3b5247e