### PR TITLE
Handle reserved graph attrs in translator

### DIFF
--- a/src/common/tensors/graph_translator.py
+++ b/src/common/tensors/graph_translator.py
@@ -41,8 +41,14 @@ class GraphTranslator:
         G = nx.DiGraph()
         for nid, data in src.nodes(data=True):
             # copy all attrs except the executable op
-            attrs = {k: v for k, v in data.items() if k != "op"}
-            G.add_node(nid, label=str(nid), parents=[], children=[], **attrs)
+            attrs = {
+                k: v
+                for k, v in data.items()
+                if k not in {"op", "parents", "children", "label"}
+            }
+            attrs.setdefault("parents", [])
+            attrs.setdefault("children", [])
+            G.add_node(nid, label=str(nid), **attrs)
         for u, v in src.edges():
             G.add_edge(u, v)
             G.nodes[u]["children"].append((v, "dep"))

--- a/tests/test_graph_translator.py
+++ b/tests/test_graph_translator.py
@@ -1,0 +1,16 @@
+import networkx as nx
+
+from src.common.tensors.graph_translator import GraphTranslator
+
+
+def test_schedule_handles_existing_parent_child_attrs() -> None:
+    g = nx.DiGraph()
+    g.add_node("a", op=lambda: None, parents=[("p", "dep")], children=[("c", "dep")])
+    g.add_node(
+        "b", op=lambda: None, parents=[("q", "dep")], children=[("d", "dep")], label="x"
+    )
+    g.add_edge("a", "b")
+
+    translator = GraphTranslator(g)
+    order = translator.schedule()
+    assert order == ["a", "b"]


### PR DESCRIPTION
## Summary
- avoid collisions with pre-existing node attributes by filtering out `parents`, `children`, and `label`
- ensure default `parents` and `children` lists exist when translating graphs
- add regression test covering nodes with existing relationship attributes

## Testing
- `pytest tests/test_graph_translator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af073ba200832a85513424eaeb5d45