### PR TITLE
Reduce tensor index logging verbosity

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1458,7 +1458,7 @@ class AbstractTensor:
         if DEBUG:
             print(f"Unwrapped index: {index}")
             print(f"Data type: {type(data)}")
-        logger.info("getitem idx=%s tensor_id=%s", index, id(self))
+        logger.debug("getitem idx=%s tensor_id=%s", index, id(self))
 
         # ---- prefer backend-specific get_item_ if available ----
         # Try to locate the ops/backend object (name may vary in your codebase)
@@ -1511,7 +1511,7 @@ class AbstractTensor:
         if getattr(AbstractTensor.autograd, "_no_grad_depth", 0) > 0:
             raw_value = value.data if isinstance(value, AbstractTensor) else value
             data[index] = raw_value
-            logger.info("setitem idx=%s tensor_id=%s", index, id(self))
+            logger.debug("setitem idx=%s tensor_id=%s", index, id(self))
             return
 
         finalize = AbstractTensor._pre_autograd("index_set", [self, value], params={"idx": index})
@@ -1519,7 +1519,7 @@ class AbstractTensor:
         raw_value = value.data if isinstance(value, AbstractTensor) else value
         data[index] = raw_value
         finalize(self)
-        logger.info("setitem idx=%s tensor_id=%s", index, id(self))
+        logger.debug("setitem idx=%s tensor_id=%s", index, id(self))
 
     def __bool__(self):
         try:

--- a/src/common/tensors/logger.py
+++ b/src/common/tensors/logger.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 def get_tensors_logger():
     logger = logging.getLogger("tensors")
@@ -7,5 +8,7 @@ def get_tensors_logger():
         formatter = logging.Formatter('[%(asctime)s][%(levelname)s][%(name)s] %(message)s')
         handler.setFormatter(formatter)
         logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+    level_name = os.getenv("TENSORS_LOG_LEVEL", "WARNING").upper()
+    level = getattr(logging, level_name, logging.WARNING)
+    logger.setLevel(level)
     return logger


### PR DESCRIPTION
## Summary
- make tensor logger level configurable via `TENSORS_LOG_LEVEL` and default to WARNING
- drop noisy `info` logs for tensor `__getitem__`/`__setitem__` to `debug`

## Testing
- `pytest` *(fails: KeyError: 'source_map')*


------
https://chatgpt.com/codex/tasks/task_e_68af227964c8832ab1d87e6b275dbc77