### PR TITLE
Expand accepts varargs to match torch-style calling

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -905,8 +905,20 @@ class AbstractTensor:
 
 
     # --- Broadcasting helpers (abstract, backend-agnostic) ---
-    def expand(self, shape: tuple) -> "AbstractTensor":
-        """Backend-agnostic expand/broadcast_to (view when possible)."""
+    def expand(self, *shape) -> "AbstractTensor":
+        """Backend-agnostic expand/broadcast_to (view when possible).
+
+        Accepts either a single iterable ``shape`` or multiple integer
+        dimensions, mirroring ``torch.Tensor.expand``.  All provided values are
+        collapsed into a single ``tuple`` before delegating to
+        :meth:`expand_`.
+        """
+
+        if len(shape) == 1 and isinstance(shape[0], (tuple, list)):
+            shape = tuple(shape[0])
+        else:
+            shape = tuple(shape)
+
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.expand_(shape)
         return result

--- a/tests/test_linear_bias_broadcast.py
+++ b/tests/test_linear_bias_broadcast.py
@@ -47,3 +47,11 @@ def test_expand_is_view_on_numpy():
     t = NumPyTensorOperations.tensor_from_list([[1.0, 2.0]])
     expanded = t.expand((3, 2))
     assert np.shares_memory(expanded.data, t.data)
+
+
+def test_expand_accepts_varargs():
+    if NumPyTensorOperations is None:
+        pytest.skip("numpy backend not available")
+    t = NumPyTensorOperations.tensor_from_list([[1.0, 2.0]])
+    expanded = t.expand(3, 2)
+    assert expanded.shape == (3, 2)


### PR DESCRIPTION
## Summary
- Allow `AbstractTensor.expand` to accept either a shape tuple or multiple dimension arguments
- Add regression test ensuring varargs call works

## Testing
- `pytest` *(fails: KeyError 'source_map' and related errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af2259e508832a8a2b99adfd6feb51