### PR TITLE
Register tensors with autograd

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -4,6 +4,7 @@ import threading
 
 from ..abstraction import AbstractTensor
 from ..abstract_nn import Linear, RectConv3d
+from ..autograd import autograd
 
 # ``LocalStateNetwork`` intentionally avoids heavyweight frameworks like
 # PyTorch.  Convolutional support will be wired in once an abstract 3D
@@ -151,6 +152,9 @@ class LocalStateNetwork:
         num_parameters = 27
         # NN Integration Manager
         self.weight_layer = AbstractTensor.get_tensor(np.ones((3, 3, 3), dtype=np.float32))
+        self.weight_layer.requires_grad_(True)
+        self.weight_layer._tape = autograd.tape
+        autograd.tape.create_tensor_node(self.weight_layer)
         self.weight_layer._label = f"{_label_prefix+'.' if _label_prefix else ''}LocalStateNetwork.weight_layer"
         self.g_weight_layer = AbstractTensor.get_tensor(np.zeros((3, 3, 3), dtype=np.float32))
         self._cached_padded_raw = None

--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -7,6 +7,7 @@ import random, math
 from .utils import from_list_like, zeros_like, transpose2d
 from .activations import Identity
 from ..logger import get_tensors_logger
+from ..autograd import autograd
 
 logger = get_tensors_logger()
 
@@ -36,10 +37,14 @@ class Linear:
         )
         self.W = _randn_matrix(in_dim, out_dim, like=like, scale=scale)
         self.W.requires_grad_(True)
+        self.W._tape = autograd.tape
+        autograd.tape.create_tensor_node(self.W)
         self.W._label = f"{_label_prefix+'.' if _label_prefix else ''}Linear.W"
         self.b = from_list_like([[0.01] * out_dim], like=like) if bias else None
         if self.b is not None:
             self.b.requires_grad_(True)
+            self.b._tape = autograd.tape
+            autograd.tape.create_tensor_node(self.b)
             self.b._label = f"{_label_prefix+'.' if _label_prefix else ''}Linear.b"
         logger.debug(
             f"Linear layer weights shape: {getattr(self.W, 'shape', None)}; bias shape: {getattr(self.b, 'shape', None) if self.b is not None else None}"
@@ -137,7 +142,14 @@ class RectConv2d:
             for _ in range(out_channels)
         ]
         self.W = from_list_like(w_data, like=like)
+        self.W.requires_grad_(True)
+        self.W._tape = autograd.tape
+        autograd.tape.create_tensor_node(self.W)
         self.b = from_list_like([0.0] * out_channels, like=like) if bias else None
+        if self.b is not None:
+            self.b.requires_grad_(True)
+            self.b._tape = autograd.tape
+            autograd.tape.create_tensor_node(self.b)
         self.gW = zeros_like(self.W)
         self.gb = zeros_like(self.b) if self.b is not None else None
         self._x = None
@@ -243,7 +255,14 @@ class RectConv3d:
             for _ in range(out_channels)
         ]
         self.W = from_list_like(w_data, like=like)
+        self.W.requires_grad_(True)
+        self.W._tape = autograd.tape
+        autograd.tape.create_tensor_node(self.W)
         self.b = from_list_like([0.0] * out_channels, like=like) if bias else None
+        if self.b is not None:
+            self.b.requires_grad_(True)
+            self.b._tape = autograd.tape
+            autograd.tape.create_tensor_node(self.b)
         self.gW = zeros_like(self.W)
         self.gb = zeros_like(self.b) if self.b is not None else None
         self._x = None


### PR DESCRIPTION
## Summary
- ensure NDPCA3Conv3d taps register with autograd tape
- register parameters in Linear, RectConv2d/3d, and LocalStateNetwork with autograd for gradient tracking

## Testing
- `pytest tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise -q`
- `PYTHONPATH=src pytest` *(fails: KeyError: 'source_map', 20 failed, 256 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68af5f7c1f84832a8ea3e253300f1c99