### PR TITLE
Expose orphan nodes in gradient tape and Riemann layer

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional.py
@@ -8,6 +8,7 @@ Defines a RiemannConvolutional3D layer: a metric-aware 3D convolutional layer th
 from .laplace_nd import BuildLaplace3D, GridDomain
 from .ndpca3conv import NDPCA3Conv3d
 from ..abstraction import AbstractTensor
+from ..autograd import autograd
 
 class RiemannConvolutional3D:
 
@@ -93,3 +94,26 @@ class RiemannConvolutional3D:
         Returns: (B, out_channels, Nu, Nv, Nw)
         """
         return self.conv.forward(x, package=self.laplace_package)
+
+    def report_orphan_nodes(self, tape=None):
+        """Print information about nodes with no children on ``tape``.
+
+        Parameters
+        ----------
+        tape : GradTape, optional
+            Tape to inspect. Defaults to the global autograd tape.
+
+        Returns
+        -------
+        list of dict
+            Metadata describing orphan nodes.
+        """
+        tape = tape or autograd.tape
+        if tape is None:
+            return []
+        orphans = getattr(tape, "orphan_data", lambda: [])()
+        for info in orphans:
+            tid = info.get("id")
+            anns = info.get("annotations", {})
+            print(f"orphan node id={tid} annotations={anns}")
+        return orphans

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -511,6 +511,7 @@ class AbstractTensor:
 
         # 4. If all else fails, raise an error
         raise RuntimeError("No suitable tensor backend is available to create a tensor from list.")
+
     @classmethod
     def _tensor_from_list(
         cls,

--- a/src/common/tensors/abstraction_functions.md
+++ b/src/common/tensors/abstraction_functions.md
@@ -8,7 +8,6 @@ This document groups available methods by theme for quick reference.
 - AbstractTensor.full()
 - AbstractTensor.zeros()
 - AbstractTensor.arange()
-- AbstractTensor.tensor_from_list()
 - AbstractTensor.clone()
 
 ## Device & Dtype Management

--- a/tests/common/tensors/test_orphan_detection.py
+++ b/tests/common/tensors/test_orphan_detection.py
@@ -1,0 +1,18 @@
+from src.common.tensors.autograd import autograd, GradTape
+from src.common.tensors.abstraction import AbstractTensor
+
+
+def test_orphan_node_detection():
+    autograd.tape = GradTape()
+
+    a = AbstractTensor.get_tensor([1.0, 2.0], tape=autograd.tape).requires_grad_()
+    b = a * 2
+    c = b + 1  # <- will be orphaned
+    d = a * 3
+    loss = d.sum()
+
+    loss.backward(retain_graph=True)
+
+    orphans = autograd.tape.orphan_data()
+    ids = {info["id"] for info in orphans}
+    assert id(c) in ids


### PR DESCRIPTION
## Summary
- add `orphan_data` helper to `GradTape`
- allow `RiemannConvolutional3D` to report gradient orphans
- clarify autograd docs without calling the system small
- drop accidental public `tensor_from_list` wrapper
- test orphan node detection

## Testing
- `pytest tests/test_linear_bias_broadcast.py::test_expand_is_view_on_numpy -q` *(fails: AttributeError: type object 'NumPyTensorOperations' has no attribute 'tensor_from_list')*
- `pytest tests/common/tensors/test_orphan_detection.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_e_68afad270668832a84bec5abdde475b7