### PR TITLE
Add comprehensive tensor annotations

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional.py
@@ -93,7 +93,9 @@ class RiemannConvolutional3D:
         x: (B, C, Nu, Nv, Nw)
         Returns: (B, out_channels, Nu, Nv, Nw)
         """
-        return self.conv.forward(x, package=self.laplace_package)
+        out = self.conv.forward(x, package=self.laplace_package)
+        autograd.tape.annotate(out, label="RiemannConvolutional3D.output")
+        return out
 
     def report_orphan_nodes(self, tape=None):
         """Print information about nodes with no children on ``tape``.

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -548,6 +548,32 @@ class AbstractTensor:
                 except Exception:
                     pass
         return inst
+
+    @classmethod
+    def tensor_from_list(
+        cls,
+        data,
+        dtype=None,
+        device=None,
+        tape: "GradTape" | None = None,
+        *,
+        like: "AbstractTensor" | None = None,
+        requires_grad: bool = False,
+    ):
+        """Public alias to :meth:`_tensor_from_list`.
+
+        This mirrors the historically exposed ``tensor_from_list`` constructor
+        so tests and callers can rely on a stable API. All arguments mirror
+        :meth:`_tensor_from_list` and are forwarded unchanged.
+        """
+        return cls._tensor_from_list(
+            data,
+            dtype=dtype,
+            device=device,
+            tape=tape,
+            like=like,
+            requires_grad=requires_grad,
+        )
     # --- Tensor creation and manipulation methods ---
 
     def full_(


### PR DESCRIPTION
## Summary
- annotate linear layer tensors and outputs
- instrument PCA and Riemann convolutional layers with detailed tape metadata
- expose tensor_from_list alias on AbstractTensor for compatibility

## Testing
- `pytest` *(fails: KeyError: 'source_map', AttributeError: 'Linear' object has no attribute 'backward', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68afb7bc12e8832aab9fbdab35e28f81