### PR TITLE
Introduce FusedProgram IR scaffolding and fix GraphTranslator

### DIFF
--- a/src/common/tensors/abstract_nn/__init__.py
+++ b/src/common/tensors/abstract_nn/__init__.py
@@ -4,3 +4,10 @@ from .losses import MSELoss, CrossEntropyLoss, BCEWithLogitsLoss
 from .optimizer import Adam
 from .train import train_step, train_loop
 from .utils import set_seed
+from .fused_program import (
+    Meta,
+    OpStep,
+    FusedProgram,
+    build_fused_program,
+    ProgramRunner,
+)

--- a/src/common/tensors/abstract_nn/fused_program.py
+++ b/src/common/tensors/abstract_nn/fused_program.py
@@ -1,0 +1,190 @@
+"""FusedProgram IR and runner.
+
+This module implements the initial scaffolding for the unified program
+intermediate representation described in ``docs/FUSED_PROGRAM_IR.md``.
+The IR captures a linear sequence of tensor operations detached from the
+Autograd tape and can be replayed deterministically with a ``training``
+flag to alter mode sensitive operators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Set
+
+import networkx as nx
+
+from ..abstraction import AbstractTensor as AT
+from ..graph_translator import GraphTranslator
+from ....transmogrifier.ilpscheduler import ILPScheduler
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses mirroring the design document
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Meta:
+    """Per-id snapshot of tensor metadata."""
+
+    shape: Iterable[int] | None = None
+    dtype: str | None = None
+    device: str | None = None
+
+
+@dataclass
+class OpStep:
+    """Single linearised tensor operation."""
+
+    step_id: int
+    op_name: str
+    input_ids: List[int]
+    attrs: Dict[str, Any] = field(default_factory=dict)
+    result_id: int = -1
+    mode_sensitive: bool = False
+
+
+@dataclass
+class FusedProgram:
+    """Unified program representation for AbstractTensor graphs."""
+
+    version: int
+    feeds: Set[int]
+    steps: List[OpStep]
+    outputs: Dict[str, int]
+    state_in: Set[int] | None = None
+    meta: Dict[int, Meta] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def build_fused_program(
+    graph: nx.DiGraph,
+    *,
+    outputs: Dict[str, int] | None = None,
+    version: int = 1,
+    scheduler_cls: type[ILPScheduler] = ILPScheduler,
+) -> FusedProgram:
+    """Construct a :class:`FusedProgram` from ``graph``.
+
+    The ``graph`` is expected to contain ``tensor`` and ``op`` nodes with the
+    following minimal attributes:
+
+    - tensor nodes: ``kind='tensor'``, optional ``shape``, ``dtype`` and
+      ``device``.
+    - op nodes: ``kind='op'``, ``op_name`` (method on ``AbstractTensor``),
+      optional ``attrs`` dict and ``mode_sensitive`` bool.
+
+    Feeds are inferred as tensor nodes with no producing op predecessors.
+    Steps are linearised according to ASAP levels from ``ILPScheduler``.
+    """
+
+    outputs = outputs or {}
+
+    translator = GraphTranslator(graph)
+    order = translator.schedule(scheduler_cls)
+
+    feeds: Set[int] = set()
+    steps: List[OpStep] = []
+    meta: Dict[int, Meta] = {}
+
+    for nid, data in graph.nodes(data=True):
+        if data.get("kind") == "tensor":
+            pred_ops = [p for p in graph.predecessors(nid) if graph.nodes[p].get("kind") == "op"]
+            if not pred_ops:
+                if isinstance(nid, int):
+                    feeds.add(nid)
+            m = Meta(
+                shape=tuple(data.get("shape", [])) or None,
+                dtype=data.get("dtype"),
+                device=data.get("device"),
+            )
+            if any(v is not None for v in (m.shape, m.dtype, m.device)):
+                if isinstance(nid, int):
+                    meta[nid] = m
+
+    for nid in order:
+        data = graph.nodes[nid]
+        if data.get("kind") != "op":
+            continue
+        if not isinstance(nid, int):
+            raise TypeError("Op node ids must be integers")
+        input_ids = [
+            int(tid)
+            for tid in graph.predecessors(nid)
+            if graph.nodes[tid].get("kind") == "tensor"
+        ]
+        result_candidates = [
+            int(tid)
+            for tid in graph.successors(nid)
+            if graph.nodes[tid].get("kind") == "tensor"
+        ]
+        result_id = result_candidates[0] if result_candidates else nid
+        step = OpStep(
+            step_id=nid,
+            op_name=str(data.get("op_name")),
+            input_ids=input_ids,
+            attrs=dict(data.get("attrs", {})),
+            result_id=result_id,
+            mode_sensitive=bool(data.get("mode_sensitive", False)),
+        )
+        steps.append(step)
+
+    return FusedProgram(
+        version=version,
+        feeds=feeds,
+        steps=steps,
+        outputs=outputs,
+        meta=meta or None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Program runner
+# ---------------------------------------------------------------------------
+
+
+class ProgramRunner:
+    """Execute a :class:`FusedProgram` using ``AbstractTensor`` ops."""
+
+    def __init__(self, program: FusedProgram) -> None:
+        self.program = program
+
+    def __call__(
+        self,
+        feeds: Dict[int, AT],
+        *,
+        training: bool = False,
+    ) -> Dict[str, AT]:
+        prog = self.program
+        store: Dict[int, AT] = {}
+
+        missing = prog.feeds - set(feeds)
+        if missing:
+            raise KeyError(f"Missing feeds: {sorted(missing)}")
+        store.update(feeds)
+
+        for step in prog.steps:
+            args = [store[i] for i in step.input_ids]
+            cls = args[0].__class__ if args else AT
+            fn = getattr(cls, step.op_name)
+            if step.mode_sensitive:
+                result = fn(*args, training=training, **step.attrs)
+            else:
+                result = fn(*args, **step.attrs)
+            store[step.result_id] = result
+
+        return {name: store[i] for name, i in prog.outputs.items() if i in store}
+
+
+__all__ = [
+    "Meta",
+    "OpStep",
+    "FusedProgram",
+    "build_fused_program",
+    "ProgramRunner",
+]

--- a/src/common/tensors/graph_translator.py
+++ b/src/common/tensors/graph_translator.py
@@ -61,8 +61,9 @@ class GraphTranslator:
     def schedule(self, scheduler_cls: Type[ILPScheduler] = ILPScheduler) -> List:
         """Compute and cache execution order using ``scheduler_cls``."""
         if self._order is None:
-            source_map: Dict[Any, Any] = unroll_all_cycles_once(self.graph)
-            proc = self._to_process_graph(self.graph)
+            g = self.graph.copy()
+            source_map: Dict[Any, Any] = unroll_all_cycles_once(g)
+            proc = self._to_process_graph(g)
             sched = scheduler_cls(proc)
             raw_levels = sched.compute_levels("asap", "dependency")
             


### PR DESCRIPTION
## Summary
- scaffold `FusedProgram` IR with dataclasses, builder, and `ProgramRunner`
- expose IR from abstract_nn package
- avoid mutating source graphs in `GraphTranslator.schedule` when unrolling cycles

## Testing
- `pytest` *(fails: ValueError in ascii render, gradient/broadcast issues, numpy backward errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b7b243b4832a86ea8b7e7adf6a3d