### PR TITLE
Add geometry factory for Riemannian geometry packages

### DIFF
--- a/src/common/tensors/riemann/geometry_factory.py
+++ b/src/common/tensors/riemann/geometry_factory.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+"""Factories for common Riemannian geometry packages.
+
+Each builder constructs a :class:`Transform` and matching :class:`GridDomain`
+then wraps them in :class:`ManifoldPackage`.  The registry maps configuration
+keys to these builder functions so callers can obtain geometry packages from a
+simple config dictionary.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+from ..abstraction import AbstractTensor
+from ..abstract_convolution.laplace_nd import GridDomain
+from ..abstract_convolution.ndpca3transform import PCANDTransform
+from .manifold import ManifoldPackage
+
+# Type alias for builder functions
+GeometryBuilder = Callable[[Dict[str, Any]], Tuple[Any, GridDomain, Dict[str, Any]]]
+
+
+def _build_rect_euclidean(config: Dict[str, Any]):
+    grid_shape = config.get("grid_shape", (1, 1, 1))
+    boundary_conditions = config.get("boundary_conditions", (True,) * 6)
+    transform_args = dict(config.get("transform_args", {}))
+    laplace_kwargs = config.get("laplace_kwargs", {})
+    Nu, Nv, Nw = grid_shape
+
+    grid = GridDomain.generate_grid_domain(
+        "rectangular", N_u=Nu, N_v=Nv, N_w=Nw, **transform_args
+    )
+    transform = grid.transform
+    transform.grid_boundaries = boundary_conditions
+    grid.grid_boundaries = boundary_conditions
+
+    manifold = ManifoldPackage(transform, grid, laplace_kwargs=laplace_kwargs)
+    package = manifold.laplace_package()
+    return transform, grid, package
+
+
+def _build_pca_nd(config: Dict[str, Any]):
+    grid_shape = config.get("grid_shape", (1, 1, 1))
+    boundary_conditions = config.get("boundary_conditions", (True,) * 6)
+    transform_args = dict(config.get("transform_args", {}))
+    laplace_kwargs = config.get("laplace_kwargs", {})
+    Nu, Nv, Nw = grid_shape
+
+    transform = PCANDTransform(**transform_args)
+    AT = AbstractTensor
+    U = AT.linspace(-1.0, 1.0, Nu).reshape(Nu, 1, 1) * AT.ones((1, Nv, Nw))
+    V = AT.linspace(-1.0, 1.0, Nv).reshape(1, Nv, 1) * AT.ones((Nu, 1, Nw))
+    W = AT.linspace(-1.0, 1.0, Nw).reshape(1, 1, Nw) * AT.ones((Nu, Nv, 1))
+    grid = GridDomain(
+        U,
+        V,
+        W,
+        grid_boundaries=boundary_conditions,
+        transform=transform,
+        coordinate_system="rectangular",
+    )
+    manifold = ManifoldPackage(transform, grid, laplace_kwargs=laplace_kwargs)
+    package = manifold.laplace_package()
+    return transform, grid, package
+
+
+def _build_custom_metric(config: Dict[str, Any]):
+    grid_shape = config.get("grid_shape", (1, 1, 1))
+    boundary_conditions = config.get("boundary_conditions", (True,) * 6)
+    transform_args = dict(config.get("transform_args", {}))
+    laplace_kwargs = config.get("laplace_kwargs", {})
+    Nu, Nv, Nw = grid_shape
+
+    metric_fn = transform_args.pop("metric_tensor_func", None)
+    grid = GridDomain.generate_grid_domain(
+        "rectangular", N_u=Nu, N_v=Nv, N_w=Nw, **transform_args
+    )
+    transform = grid.transform
+    if metric_fn is not None:
+        transform.metric_tensor_func = metric_fn
+    transform.grid_boundaries = boundary_conditions
+    grid.grid_boundaries = boundary_conditions
+
+    manifold = ManifoldPackage(transform, grid, laplace_kwargs=laplace_kwargs)
+    package = manifold.laplace_package()
+    return transform, grid, package
+
+
+GEOMETRY_REGISTRY: Dict[str, GeometryBuilder] = {
+    "rect_euclidean": _build_rect_euclidean,
+    "pca_nd": _build_pca_nd,
+    "custom_metric": _build_custom_metric,
+}
+
+
+def build_geometry(config: Dict[str, Any]):
+    key = config.get("key")
+    if key not in GEOMETRY_REGISTRY:
+        raise ValueError(f"Unknown geometry key '{key}'")
+    return GEOMETRY_REGISTRY[key](config)

--- a/tests/test_geometry_factory.py
+++ b/tests/test_geometry_factory.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from src.common.tensors.abstraction import AbstractTensor
+from src.common.tensors.abstract_convolution.ndpca3transform import PCABasisND
+from src.common.tensors.riemann.geometry_factory import build_geometry
+
+
+def _identity_basis():
+    AT = AbstractTensor
+    mu = AT.zeros(3)
+    P = AT.eye(3)
+    return PCABasisND(mu=mu, P=P, n=3)
+
+
+def _phi(U, V, W):
+    AT = AbstractTensor
+    return AT.stack([U, V, W], dim=-1)
+
+
+def _metric(U, V, W, *_, **__):
+    AT = AbstractTensor
+    g = AT.eye(3).reshape(1, 1, 1, 3, 3).expand(U.shape + (3, 3))
+    g_inv = g
+    det_g = AT.ones(U.shape)
+    return g, g_inv, det_g
+
+
+def test_rect_euclidean_builds_package():
+    cfg = {
+        "key": "rect_euclidean",
+        "grid_shape": (2, 2, 2),
+        "boundary_conditions": (True,) * 6,
+        "transform_args": {"Lx": 1.0, "Ly": 1.0, "Lz": 1.0},
+        "laplace_kwargs": {},
+    }
+    transform, grid, package = build_geometry(cfg)
+    assert hasattr(transform, "metric_tensor_func")
+    assert grid.U.shape == (2, 2, 2)
+    assert isinstance(package, dict)
+
+
+def test_pca_nd_builds_package():
+    basis = _identity_basis()
+    cfg = {
+        "key": "pca_nd",
+        "grid_shape": (2, 2, 2),
+        "boundary_conditions": (True,) * 6,
+        "transform_args": {"pca_basis": basis, "phi_fn": _phi, "d_visible": 3},
+        "laplace_kwargs": {},
+    }
+    _, grid, package = build_geometry(cfg)
+    assert grid.U.shape == (2, 2, 2)
+    assert isinstance(package, dict)
+
+
+def test_custom_metric_builds_package():
+    cfg = {
+        "key": "custom_metric",
+        "grid_shape": (2, 2, 2),
+        "boundary_conditions": (True,) * 6,
+        "transform_args": {
+            "Lx": 1.0,
+            "Ly": 1.0,
+            "Lz": 1.0,
+            "metric_tensor_func": _metric,
+        },
+        "laplace_kwargs": {},
+    }
+    transform, grid, package = build_geometry(cfg)
+    assert transform.metric_tensor_func is _metric
+    assert grid.U.shape == (2, 2, 2)
+    assert isinstance(package, dict)
+
+
+def test_unknown_key_raises():
+    with pytest.raises(ValueError):
+        build_geometry({"key": "does_not_exist"})


### PR DESCRIPTION
## Summary
- provide `geometry_factory` with builders for rectangular, PCA-based, and custom metric geometries
- expose a registry and `build_geometry` dispatcher handling `grid_shape`, boundary conditions, and Laplace options
- add tests covering each geometry key and unknown-key error handling

## Testing
- `pytest tests/test_geometry_factory.py -q`
- `pytest -q` *(fails: `test_to_ascii_diff_preserves_color`, `test_linear_bias_broadcast_and_grad[PurePython-PurePythonTensorOperations]`, `test_linear_bias_broadcast_and_grad[NumPy-NumPyTensorOperations]`, `test_local_state_network_forward_backward_consistency`, `test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise`, `test_xor_learning.py::test_xor_learns[bce]`, `test_xor_learning.py::test_xor_learns[mse]`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1186a5240832a94fc91e2e3514423