### PR TITLE
Skip strict connectivity checks when allow_unused

### DIFF
--- a/src/common/tensors/README.md
+++ b/src/common/tensors/README.md
@@ -19,3 +19,12 @@ Development priorities follow a strict order:
 3. Fill gaps in individual backends.
 4. Only after the above are complete do we expand the optional C backend, except for trivial
    stub replacements when time permits.
+
+## Autograd strict mode
+
+The autograd engine can operate in a strict validation mode that checks for
+missing backward implementations and verifies that all input parameters are
+connected to the loss. When `allow_unused=True` is passed to
+`autograd.grad`, those connectivity checks are skipped for the corresponding
+inputs, allowing gradients to be requested for tensors unrelated to the loss
+without triggering a `RuntimeError`.

--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -859,12 +859,17 @@ class Autograd:
                 ]
                 detail = "\n".join(lines)
                 raise RuntimeError("Strict autograd: missing backward implementations for reachable ops:\n" + detail)
-            # Also validate parameter connectivity: any input not present in the backward graph
+            # Also validate parameter connectivity: any input not present in the
+            # backward graph, unless unused params are explicitly allowed.
             try:
                 bwd_graph = tape_v.export_backward_graph(output)
             except Exception:
                 bwd_graph = None
-            if bwd_graph is not None and inputs is not None:
+            if (
+                not allow_unused
+                and bwd_graph is not None
+                and inputs is not None
+            ):
                 broken: list[str] = []
                 import networkx as nx
                 # Helper: whitelist check via per-tensor annotations or label allowlist

--- a/tests/test_autograd_allow_unused.py
+++ b/tests/test_autograd_allow_unused.py
@@ -1,0 +1,22 @@
+import pytest
+from src.common.tensors import AbstractTensor
+
+
+def test_grad_allow_unused_skips_strict_connectivity():
+    autograd = AbstractTensor.autograd
+    prev_strict = autograd.strict
+    autograd.strict = True
+    autograd.tape._nodes.clear()
+
+    try:
+        a = AbstractTensor.tensor([1.0])
+        b = AbstractTensor.tensor([2.0])
+        a.requires_grad = True
+        b.requires_grad = True
+
+        y = a * 3.0
+        grads = autograd.grad(y, [a, b], allow_unused=True)
+        assert grads[0] is not None
+        assert grads[1] is None
+    finally:
+        autograd.strict = prev_strict


### PR DESCRIPTION
## Summary
- Skip strict-mode connectivity checks in `autograd.grad` when `allow_unused=True`
- Document strict mode behavior for optional unused parameters
- Add test ensuring gradients can be queried for unused tensors without errors

## Testing
- `pytest tests/test_autograd_allow_unused.py tests/test_autograd_missing_grad_message.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b127f291e4832aa7dae8a824827951