### PR TITLE
docs: document autograd strict mode and whitelist examples

### DIFF
--- a/src/common/tensors/README.md
+++ b/src/common/tensors/README.md
@@ -19,3 +19,26 @@ Development priorities follow a strict order:
 3. Fill gaps in individual backends.
 4. Only after the above are complete do we expand the optional C backend, except for trivial
    stub replacements when time permits.
+
+## Autograd strict mode and whitelisting
+
+The autograd engine can enforce that every tensor contributing to a loss has
+registered backward rules and is connected to the loss graph.  Enable this
+behaviour by setting the environment variable `AUTOGRAD_STRICT=1`.  When active,
+any missing backward implementation or disconnected input raises an error.
+
+Tensors carrying a `label` annotation can be ignored by providing a comma or
+pipe separated list of regular expressions via
+`AUTOGRAD_STRICT_ALLOW_LABELS`.
+
+Strict mode may be tuned or disabled at runtime:
+
+```python
+from src.common.tensors.autograd import autograd
+
+autograd.strict = False                  # disable strict checks
+autograd.whitelist(tensor_a, tensor_b)   # ignore specific tensors
+autograd.whitelist_labels(r"demo.*")    # allow labels matching the pattern
+```
+
+Labels can be attached using `autograd.tape.annotate(tensor, label="name")`.

--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -117,6 +117,11 @@ def main(config=None):
     x = AT.randn((B, C, *grid_shape), requires_grad=True)
     autograd.tape.annotate(x, label="riemann_demo.input")
     autograd.tape.auto_annotate_eval(x)
+    # When AUTOGRAD_STRICT=1, unused tensors trigger connectivity errors.
+    # Uncomment one of the lines below to relax those checks:
+    # autograd.strict = False                   # disable strict mode globally
+    # autograd.whitelist(x, target)             # or whitelist specific tensors
+    # autograd.whitelist_labels(r"riemann_demo.*")  # whitelist by label pattern
     # --- Parameter and gradient collection helpers ---
     from ..logger import get_tensors_logger
     logger = get_tensors_logger()


### PR DESCRIPTION
## Summary
- document AUTOGRAD_STRICT environment variables and whitelist APIs
- show how to disable strict mode or whitelist tensors in Riemann convolution demo

## Testing
- `pytest` *(fails: ValueError/AttributeError/KeyboardInterrupt in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b127fc904c832a91e8bef319e7fb9e