### PR TITLE
Whitelist mesh-grid tensors in Laplace autograd and add strict-mode test

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -1103,6 +1103,16 @@ class TransformHub:
         if hasattr(W, "requires_grad_"):
             W.requires_grad_(True)
 
+        # Mark mesh-grid tensors as intentionally unused for strict autograd
+        # connectivity checks and label them for clarity in traces.
+        AbstractTensor.autograd.whitelist(U, V, W)
+        try:  # pragma: no cover - annotation helper
+            autograd.tape.annotate(U, label="laplace_nd.grid.U", strict_allow_unused=True)
+            autograd.tape.annotate(V, label="laplace_nd.grid.V", strict_allow_unused=True)
+            autograd.tape.annotate(W, label="laplace_nd.grid.W", strict_allow_unused=True)
+        except Exception:
+            pass
+
         # Forward pass: get transformed coordinates
         X, Y, Z = self.transform_spatial(U, V, W)
         # Label transformed coordinates for provenance


### PR DESCRIPTION
## Summary
- mark Laplace mesh-grid tensors as intentionally unused and annotate them for autograd tracing
- add regression test running the Laplace builder under autograd strict mode

## Testing
- `pytest tests/test_laplace_nd.py::test_compute_partials_and_normals_strict -q`
- `pytest -q` *(fails: tests/test_ascii_render.py::test_to_ascii_diff_preserves_color, tests/test_linear_bias_broadcast.py::test_linear_bias_broadcast_and_grad[PurePython-PurePythonTensorOperations], tests/test_linear_bias_broadcast.py::test_linear_bias_broadcast_and_grad[NumPy-NumPyTensorOperations], tests/test_local_state_network.py::test_local_state_network_forward_backward_consistency, tests/test_xor_learning.py::test_xor_learns[bce], tests/test_xor_learning.py::test_xor_learns[mse])*

------
https://chatgpt.com/codex/tasks/task_e_68b129e2125c832a94e23971a71635c9