### PR TITLE
feat: add casting reshape strategies

### DIFF
--- a/src/common/tensors/abstract_nn/activations.py
+++ b/src/common/tensors/abstract_nn/activations.py
@@ -15,8 +15,7 @@ def _sigmoid_stable(x: AbstractTensor) -> AbstractTensor:
     return pos * y_pos + neg * y_neg
 
 def _tanh_stable(x: AbstractTensor) -> AbstractTensor:
-    # tanh(x) = 2*sigmoid(2x) - 1 (stable if sigmoid is stable)
-    return 2.0 * _sigmoid_stable(2.0 * x) - 1.0
+    return x.tanh()
 
 # -------- base --------
 

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -124,8 +124,7 @@ class NumPyTensorOperations(AbstractTensor):
         return np.maximum(self.data, min_val)
 
     def clamp_min(self, min_val):
-        import numpy as np
-        return np.maximum(self.data, min_val)
+        return super().clamp_min(min_val)
 
     def clamp_max_(self, max_val):
         import numpy as np


### PR DESCRIPTION
## Summary
- support `1to1`, `row_major`, and `normalized_span` reshape strategies in casting stage
- default to `row_major` mapping and document available options
- test deterministic row-major mapping and coverage for 1to1 strategy
- fix tensor creation and broadcasting bugs uncovered by new tests

## Testing
- `pytest tests/test_ascii_render.py::test_to_ascii_diff_preserves_color`
- `pytest tests/test_linear_bias_broadcast.py::test_linear_bias_broadcast_and_grad[PurePython-PurePythonTensorOperations]`
- `pytest tests/test_linear_bias_broadcast.py::test_linear_bias_broadcast_and_grad[NumPy-NumPyTensorOperations]`
- `pytest tests/test_local_state_network.py::test_local_state_network_forward_backward_consistency`
- `pytest tests/test_riemann_grid_block.py::test_casting_row_major_deterministic tests/test_riemann_grid_block.py::test_casting_1to1_mapping`
- `pytest tests/test_xor_learning.py::test_xor_learns[bce]` *(fails: unsupported operand type(s) for *: 'NoneType' and 'NoneType')*
- `pytest tests/test_xor_learning.py::test_xor_learns[mse]` *(fails: unsupported operand type(s) for *: 'NoneType' and 'NoneType')*

------
https://chatgpt.com/codex/tasks/task_e_68b134b9a030832a83222f8db2486598