### PR TITLE
Add Riemann regularization helpers and integrate into grid block

### DIFF
--- a/src/common/tensors/riemann/__init__.py
+++ b/src/common/tensors/riemann/__init__.py
@@ -18,4 +18,5 @@ from .geodesic import GeodesicConv3D
 from .transport import ParallelTransport
 from .heat import HeatKernel3D
 from .grid_block import RiemannGridBlock
+from .regularization import smooth_bins, weight_decay
 

--- a/src/common/tensors/riemann/regularization.py
+++ b/src/common/tensors/riemann/regularization.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Regularization helpers for Riemann grid modules."""
+
+from typing import Optional, Dict
+
+from ..abstraction import AbstractTensor
+
+
+def smooth_bins(bins: AbstractTensor, lam: float) -> AbstractTensor:
+    """Penalise non‑smooth bin assignments via finite differences.
+
+    Parameters
+    ----------
+    bins : AbstractTensor
+        Tensor of shape ``(Cin, D, H, W)`` representing per‑voxel bin weights.
+    lam : float
+        Scaling coefficient. ``0`` disables the penalty.
+
+    Returns
+    -------
+    AbstractTensor
+        Scalar tensor containing the Laplacian penalty.
+    """
+    if lam == 0.0:
+        return AbstractTensor.get_tensor([0.0]).sum()
+
+    diffs = []
+    if bins.shape[1] > 1:
+        diffs.append(bins[:, 1:, :, :] - bins[:, :-1, :, :])
+    if bins.shape[2] > 1:
+        diffs.append(bins[:, :, 1:, :] - bins[:, :, :-1, :])
+    if bins.shape[3] > 1:
+        diffs.append(bins[:, :, :, 1:] - bins[:, :, :, :-1])
+
+    penalty = AbstractTensor.get_tensor([0.0]).sum()
+    for d in diffs:
+        penalty = penalty + (d * d).sum()
+    return penalty * lam
+
+
+def weight_decay(
+    casting: Optional[object],
+    conv: Optional[object],
+    post: Optional[object],
+    coeffs: Dict[str, float],
+) -> AbstractTensor:
+    """Apply L2 penalties to parameter groups with separate coefficients.
+
+    Parameters
+    ----------
+    casting, conv, post : modules or ``None``
+        Components whose parameters will be regularised.
+    coeffs : dict
+        Mapping with optional ``"pre"``, ``"conv"`` and ``"post"`` entries
+        specifying the decay strength for each group.
+    """
+    penalty = AbstractTensor.get_tensor([0.0]).sum()
+
+    pre_coef = coeffs.get("pre", 0.0)
+    if casting is not None and pre_coef != 0.0 and getattr(casting, "pre_linear", None) is not None:
+        for p in casting.pre_linear.parameters():
+            penalty = penalty + pre_coef * (p * p).sum()
+
+    conv_coef = coeffs.get("conv", 0.0)
+    if conv is not None and conv_coef != 0.0:
+        for p in conv.parameters():
+            penalty = penalty + conv_coef * (p * p).sum()
+
+    post_coef = coeffs.get("post", 0.0)
+    if post is not None and post_coef != 0.0:
+        for p in post.parameters():
+            penalty = penalty + post_coef * (p * p).sum()
+
+    return penalty

--- a/tests/test_riemann_regularization.py
+++ b/tests/test_riemann_regularization.py
@@ -1,0 +1,35 @@
+from src.common.tensors.abstraction import AbstractTensor
+from src.common.tensors.abstract_convolution.ndpca3conv import NDPCA3Conv3d
+from src.common.tensors.riemann.grid_block import RiemannGridBlock
+
+
+def _basic_block(**reg):
+    like = AbstractTensor.get_tensor([0.0])
+    conv = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2, 2, 2))
+    return RiemannGridBlock(conv=conv, package={}, bin_map=None, post_linear=None, regularization=reg)
+
+
+def test_smooth_bins_penalty_changes():
+    like = AbstractTensor.get_tensor([0.0])
+    conv = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2, 2, 2))
+    bin_map = AbstractTensor.zeros((1, 2, 2, 2))
+    block = RiemannGridBlock(
+        conv=conv,
+        package={},
+        bin_map=bin_map,
+        post_linear=None,
+        regularization={"smooth_bins": 0.5},
+    )
+    loss0 = float(block.regularization_loss().data)
+    block.bin_map.data[0, 0, 0, 0] = 1.0
+    loss1 = float(block.regularization_loss().data)
+    assert loss1 > loss0
+
+
+def test_weight_decay_penalty_changes():
+    block = _basic_block(weight_decay={"conv": 0.1})
+    block.conv.taps.data[:] = 0.0
+    loss0 = float(block.regularization_loss().data)
+    block.conv.taps.data[0, 0] = 1.0
+    loss1 = float(block.regularization_loss().data)
+    assert loss1 > loss0


### PR DESCRIPTION
## Summary
- add smooth_bins and weight_decay regularization helpers
- hook RiemannGridBlock into new regularization utilities
- test regularization penalties under parameter perturbations

## Testing
- `pytest tests/test_riemann_regularization.py -q`
- `pytest -q` *(fails: bw_tanh() missing 1 required positional argument: 'y'; unsupported operand type(s) for *: 'NoneType' and 'NoneType')*

------
https://chatgpt.com/codex/tasks/task_e_68b13bec6660832aafc034ce1aee4a8c