### PR TITLE
Add FiLM and coordinate embedding options

### DIFF
--- a/docs/riemann_grid_block.md
+++ b/docs/riemann_grid_block.md
@@ -45,8 +45,8 @@ back to the defaults listed below.
 ```python
 {
     "mode": "pre_linear" | "fixed" | "soft_assign" = "fixed",
-    "film": bool = False,
-    "coords": str | None = None,
+    "film": {"enabled": bool} = {"enabled": False},
+    "coords": {"type": "raw"|"fourier", "dims": int} | None = None,
     "inject_coords": bool = False,
     "map": "row_major" | "1to1" | "normalized_span" = "row_major",
 }
@@ -78,7 +78,11 @@ cfg = {
         "grid_shape": (2, 2, 2),
         "boundary_conditions": (True,) * 6,
     },
-    "casting": {"mode": "pre_linear", "film": True, "coords": "uv"},
+    "casting": {
+        "mode": "pre_linear",
+        "film": {"enabled": True},
+        "coords": {"type": "raw", "dims": 3},
+    },
     "conv": {
         "in_channels": 3,
         "out_channels": 4,

--- a/docs/riemann_grid_block_example.py
+++ b/docs/riemann_grid_block_example.py
@@ -9,7 +9,11 @@ cfg = {
         "grid_shape": (2, 2, 2),
         "boundary_conditions": (True,) * 6,
     },
-    "casting": {"mode": "pre_linear", "film": True, "coords": "uv"},
+    "casting": {
+        "mode": "pre_linear",
+        "film": {"enabled": True},
+        "coords": {"type": "raw", "dims": 3},
+    },
     "conv": {
         "in_channels": 3,
         "out_channels": 4,


### PR DESCRIPTION
## Summary
- Support per-voxel FiLM modulation with learnable gamma and beta tensors
- Enable coordinate embeddings (raw UVW or Fourier) with configurable dimensions
- Expand config validation, docs, and tests for FiLM and coordinate options

## Testing
- `pytest tests/test_riemann_grid_block.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a2e079cc832aa38f304acba29384