### PR TITLE
Remove public tensor_from_list shim

### DIFF
--- a/src/common/tensors/abstract_convolution/ndpca3_laplace_demo.py
+++ b/src/common/tensors/abstract_convolution/ndpca3_laplace_demo.py
@@ -98,7 +98,7 @@ def main(config=None):
     )
     t_minus, t_center, t_plus = -0.6, 1.8, 0.7
     per_dir = [[t_minus / teacher.k, t_center / teacher.k, t_plus / teacher.k] for _ in range(teacher.k)]
-    teacher.taps = AbstractTensor.tensor_from_list(per_dir, tape=autograd.tape, like=like, requires_grad=False)
+    teacher.taps = AbstractTensor.get_tensor(per_dir, tape=autograd.tape, like=like, requires_grad=False)
 
     X = AbstractTensor.randn((B, C, Nu, Nv, Nw), requires_grad=True)
     with AbstractTensor.autograd.no_grad():

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -549,31 +549,6 @@ class AbstractTensor:
                     pass
         return inst
 
-    @classmethod
-    def tensor_from_list(
-        cls,
-        data,
-        dtype=None,
-        device=None,
-        tape: "GradTape" | None = None,
-        *,
-        like: "AbstractTensor" | None = None,
-        requires_grad: bool = False,
-    ):
-        """Public alias to :meth:`_tensor_from_list`.
-
-        This mirrors the historically exposed ``tensor_from_list`` constructor
-        so tests and callers can rely on a stable API. All arguments mirror
-        :meth:`_tensor_from_list` and are forwarded unchanged.
-        """
-        return cls._tensor_from_list(
-            data,
-            dtype=dtype,
-            device=device,
-            tape=tape,
-            like=like,
-            requires_grad=requires_grad,
-        )
     # --- Tensor creation and manipulation methods ---
 
     def full_(
@@ -2400,8 +2375,6 @@ def default_to_backend(source_ops, tensor, target_ops):
     import inspect
     cls = type(target_ops)
     raw = inspect.getattr_static(cls, "_tensor_from_list", None)
-    if raw is None:
-        raw = inspect.getattr_static(cls, "tensor_from_list", None)
     tape = getattr(target_ops, "_tape", None)
     if isinstance(raw, classmethod):
         try:

--- a/src/common/tensors/riemann/spectral.py
+++ b/src/common/tensors/riemann/spectral.py
@@ -27,7 +27,7 @@ class SpectralConv3D:
         w = [[[AbstractTensor.random.gauss(0.0, scale) for _ in range(self.num_modes)]
               for _ in range(self.in_channels)]
              for _ in range(self.out_channels)]
-        self.Wspec = AbstractTensor.tensor_from_list(w, requires_grad=True, tape=autograd.tape)
+        self.Wspec = AbstractTensor.get_tensor(w, requires_grad=True, tape=autograd.tape)
         autograd.tape.create_tensor_node(self.Wspec)
         self.Wspec._label = "SpectralConv3D.Wspec"
         autograd.tape.annotate(self.Wspec, label=self.Wspec._label)

--- a/tests/common/tensors/test_backward_graph_export.py
+++ b/tests/common/tensors/test_backward_graph_export.py
@@ -15,7 +15,7 @@ def _reset_tape():
     autograd.tape = GradTape()
 
 def _tensor(data):
-    t = Tensor.tensor_from_list(data)
+    t = Tensor.tensor(data)
     t.requires_grad_(True)
     return t
 

--- a/tests/common/tensors/test_cache_tags.py
+++ b/tests/common/tensors/test_cache_tags.py
@@ -15,7 +15,7 @@ def _reset_tape():
 
 
 def _tensor(data):
-    t = Tensor.tensor_from_list(data)
+    t = Tensor.tensor(data)
     t.requires_grad_(True)
     return t
 

--- a/tests/common/tensors/test_forward_graph_export.py
+++ b/tests/common/tensors/test_forward_graph_export.py
@@ -17,7 +17,7 @@ def _reset_tape():
 
 
 def _tensor(data):
-    t = Tensor.tensor_from_list(data)
+    t = Tensor.tensor(data)
     t.requires_grad_(True)
     return t
 

--- a/tests/common/tensors/test_grad_tape_metadata.py
+++ b/tests/common/tensors/test_grad_tape_metadata.py
@@ -16,7 +16,7 @@ def _reset_tape():
 
 
 def _tensor(data):
-    t = Tensor.tensor_from_list(data)
+    t = Tensor.tensor(data)
     t.requires_grad_(True)
     return t
 

--- a/tests/common/tensors/test_required_cache.py
+++ b/tests/common/tensors/test_required_cache.py
@@ -15,7 +15,7 @@ def _reset_tape():
 
 
 def _tensor(data):
-    t = Tensor.tensor_from_list(data)
+    t = Tensor.tensor(data)
     t.requires_grad_(True)
     return t
 

--- a/tests/common/tensors/test_training_state_and_train.py
+++ b/tests/common/tensors/test_training_state_and_train.py
@@ -17,7 +17,7 @@ def _reset_tape():
 
 
 def _param(value):
-    t = Tensor.tensor_from_list([value])
+    t = Tensor.tensor([value])
     t.requires_grad_(True)
     return t
 
@@ -26,8 +26,8 @@ def _param(value):
 def test_export_training_state():
     w = _param(1.0)
     b = _param(0.5)
-    x = Tensor.tensor_from_list([2.0])
-    y = Tensor.tensor_from_list([5.0])
+    x = Tensor.tensor([2.0])
+    y = Tensor.tensor([5.0])
     pred = w * x + b
     err = pred - y
     loss = err * err
@@ -48,8 +48,8 @@ def test_export_training_state():
 @pytest.mark.skipif(Tensor is None, reason="NumPy backend not available")
 def test_train_updates_parameter():
     w = _param(0.0)
-    x = Tensor.tensor_from_list([1.0])
-    y = Tensor.tensor_from_list([2.0])
+    x = Tensor.tensor([1.0])
+    y = Tensor.tensor([2.0])
 
     def loss_fn():
         pred = w * x

--- a/tests/test_bce_with_logits_loss.py
+++ b/tests/test_bce_with_logits_loss.py
@@ -38,8 +38,8 @@ if JAXTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_bce_with_logits_forward_backward(backend_name, Backend):
-    logits = Backend.tensor_from_list([[0.0], [2.0], [-2.0]])
-    target = Backend.tensor_from_list([[0.0], [1.0], [0.0]])
+    logits = Backend.tensor([[0.0], [2.0], [-2.0]])
+    target = Backend.tensor([[0.0], [1.0], [0.0]])
     loss = BCEWithLogitsLoss()
     val = loss.forward(logits, target)
     if hasattr(val, "tolist"):

--- a/tests/test_linear_bias_broadcast.py
+++ b/tests/test_linear_bias_broadcast.py
@@ -28,14 +28,14 @@ if NumPyTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_linear_bias_broadcast_and_grad(backend_name, Backend):
-    like = Backend.tensor_from_list([[0.0]])
+    like = Backend.tensor([[0.0]])
     layer = Linear(in_dim=2, out_dim=2, like=like)
     layer.W = Backend.zeros((2, 2))
-    layer.b = Backend.tensor_from_list([[1.0, 2.0]])
-    x = Backend.tensor_from_list([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+    layer.b = Backend.tensor([[1.0, 2.0]])
+    x = Backend.tensor([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
     out = layer.forward(x)
     assert out.tolist() == [[1.0, 2.0]] * 3
-    grad_out = Backend.tensor_from_list([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
+    grad_out = Backend.tensor([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]])
     layer.backward(grad_out)
     assert tuple(layer.gb.shape) == (1, 2)
     assert layer.gb.tolist() == [[3.0, 3.0]]
@@ -44,7 +44,7 @@ def test_linear_bias_broadcast_and_grad(backend_name, Backend):
 def test_expand_is_view_on_numpy():
     if NumPyTensorOperations is None:
         pytest.skip("numpy backend not available")
-    t = NumPyTensorOperations.tensor_from_list([[1.0, 2.0]])
+    t = NumPyTensorOperations.tensor([[1.0, 2.0]])
     expanded = t.expand((3, 2))
     assert np.shares_memory(expanded.data, t.data)
 
@@ -52,6 +52,6 @@ def test_expand_is_view_on_numpy():
 def test_expand_accepts_varargs():
     if NumPyTensorOperations is None:
         pytest.skip("numpy backend not available")
-    t = NumPyTensorOperations.tensor_from_list([[1.0, 2.0]])
+    t = NumPyTensorOperations.tensor([[1.0, 2.0]])
     expanded = t.expand(3, 2)
     assert expanded.shape == (3, 2)

--- a/tests/test_linear_bias_shape.py
+++ b/tests/test_linear_bias_shape.py
@@ -27,6 +27,6 @@ if NumPyTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_linear_bias_shape_is_row_vector(backend_name, Backend):
-    like = Backend.tensor_from_list([[0.0]])
+    like = Backend.tensor([[0.0]])
     layer = Linear(in_dim=1, out_dim=1, like=like)
     assert tuple(layer.b.shape) == (1, 1)

--- a/tests/test_mse_loss.py
+++ b/tests/test_mse_loss.py
@@ -37,7 +37,7 @@ if JAXTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_mse_loss_backward_multi_dim(backend_name, Backend):
-    pred = Backend.tensor_from_list([[1.0, 2.0], [3.0, 4.0]])
+    pred = Backend.tensor([[1.0, 2.0], [3.0, 4.0]])
     target = Backend.zeros((2, 2))
     loss = MSELoss()
     grad = loss.backward(pred, target)
@@ -46,7 +46,7 @@ def test_mse_loss_backward_multi_dim(backend_name, Backend):
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_mse_loss_forward_multi_dim(backend_name, Backend):
-    pred = Backend.tensor_from_list([[1.0, 2.0], [3.0, 4.0]])
+    pred = Backend.tensor([[1.0, 2.0], [3.0, 4.0]])
     target = Backend.zeros((2, 2))
     loss = MSELoss()
     val = loss.forward(pred, target)

--- a/tests/test_ndpca3conv3d_grad.py
+++ b/tests/test_ndpca3conv3d_grad.py
@@ -7,7 +7,7 @@ np.random.seed(0)
 
 def _make_metric(D,H,W):
     g = np.tile(np.eye(3, dtype=np.float32), (D, H, W, 1, 1))
-    return T.tensor_from_list(g.tolist())
+    return T.tensor(g.tolist())
 
 def _finite_diff(layer, x, package, param, idx, eps=1e-5):
     orig = param[idx]
@@ -50,9 +50,9 @@ def _finite_diff_pointwise(layer, x, package, W, idx, eps=1e-5):
 
 
 def test_ndpca3conv3d_gradients_no_pointwise():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2,2,2), pointwise=False)
-    x = T.tensor_from_list(np.random.rand(1,1,2,2,2).tolist())
+    x = T.tensor(np.random.rand(1,1,2,2,2).tolist())
     x.requires_grad_(True)
     metric = _make_metric(2,2,2)
     package = {"metric": {"g": metric, "inv_g": metric}}
@@ -68,9 +68,9 @@ def test_ndpca3conv3d_gradients_no_pointwise():
 
 
 def test_ndpca3conv3d_gradients_with_pointwise():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(1, 2, like=like, grid_shape=(2,2,2), pointwise=True)
-    x = T.tensor_from_list(np.random.rand(1,1,2,2,2).tolist())
+    x = T.tensor(np.random.rand(1,1,2,2,2).tolist())
     x.requires_grad_(True)
     metric = _make_metric(2,2,2)
     package = {"metric": {"g": metric, "inv_g": metric}}
@@ -90,9 +90,9 @@ def test_ndpca3conv3d_gradients_with_pointwise():
 
 
 def test_ndpca3conv3d_zero_grad_no_pointwise():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2, 2, 2), pointwise=False)
-    x = T.tensor_from_list(np.random.rand(1,1,2,2,2).tolist())
+    x = T.tensor(np.random.rand(1,1,2,2,2).tolist())
     x.requires_grad_(True)
     metric = _make_metric(2,2,2)
     package = {"metric": {"g": metric, "inv_g": metric}}
@@ -104,9 +104,9 @@ def test_ndpca3conv3d_zero_grad_no_pointwise():
 
 
 def test_ndpca3conv3d_zero_grad_with_pointwise():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(1, 2, like=like, grid_shape=(2, 2, 2), pointwise=True)
-    x = T.tensor_from_list(np.random.rand(1,1,2,2,2).tolist())
+    x = T.tensor(np.random.rand(1,1,2,2,2).tolist())
     x.requires_grad_(True)
     metric = _make_metric(2,2,2)
     package = {"metric": {"g": metric, "inv_g": metric}}

--- a/tests/test_ndpca3conv3d_principal_axis_blend.py
+++ b/tests/test_ndpca3conv3d_principal_axis_blend.py
@@ -5,11 +5,11 @@ from src.common.tensors.numpy_backend import NumPyTensorOperations as T
 
 def _make_metric(D, H, W):
     g = np.tile(np.eye(3, dtype=np.float32), (D, H, W, 1, 1))
-    return T.tensor_from_list(g.tolist())
+    return T.tensor(g.tolist())
 
 
 def test_principal_axis_blend_weights_sum_to_k():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     layer = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2, 2, 2), k=3, pointwise=False)
     metric = _make_metric(2, 2, 2)
     wU, wV, wW = layer._principal_axis_blend(metric)

--- a/tests/test_ndpca3conv3d_stencil.py
+++ b/tests/test_ndpca3conv3d_stencil.py
@@ -9,7 +9,7 @@ from src.common.tensors.abstract_convolution.ndpca3conv import (
 
 def _make_metric(D, H, W):
     g = np.tile(np.eye(3, dtype=np.float32), (D, H, W, 1, 1))
-    return T.tensor_from_list(g.tolist())
+    return T.tensor(g.tolist())
 
 
 def _numpy_shift(arr, axis, step):
@@ -45,7 +45,7 @@ def _manual_conv(x, offsets, weights):
 
 
 def test_ndpca3conv3d_asymmetric_stencil():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     offsets = (-2, -1, 0, 1, 2)
     conv = NDPCA3Conv3d(
         1,
@@ -60,7 +60,7 @@ def test_ndpca3conv3d_asymmetric_stencil():
     for i in range(conv.k):
         conv.taps.data[i] = np.array(weights) / conv.k
     x_np = np.arange(1 * 1 * 5 * 5 * 5, dtype=np.float32).reshape(1, 1, 5, 5, 5)
-    x = T.tensor_from_list(x_np.tolist())
+    x = T.tensor(x_np.tolist())
     metric = _make_metric(5, 5, 5)
     package = {"metric": {"g": metric, "inv_g": metric}}
     y = conv.forward(x, package=package)
@@ -69,7 +69,7 @@ def test_ndpca3conv3d_asymmetric_stencil():
 
 
 def test_ndpca3conv3d_three_tap_equivalence():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     offsets = (-1, 0, 1)
     conv = NDPCA3Conv3d(
         1,
@@ -84,7 +84,7 @@ def test_ndpca3conv3d_three_tap_equivalence():
     for i in range(conv.k):
         conv.taps.data[i] = np.array(weights) / conv.k
     x_np = np.arange(1 * 1 * 3 * 3 * 3, dtype=np.float32).reshape(1, 1, 3, 3, 3)
-    x = T.tensor_from_list(x_np.tolist())
+    x = T.tensor(x_np.tolist())
     metric = _make_metric(3, 3, 3)
     package = {"metric": {"g": metric, "inv_g": metric}}
     y = conv.forward(x, package=package)
@@ -93,7 +93,7 @@ def test_ndpca3conv3d_three_tap_equivalence():
 
 
 def test_ndpca3conv3d_normalizes_taps():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(
         1,
         1,
@@ -107,7 +107,7 @@ def test_ndpca3conv3d_normalizes_taps():
     )
     conv.taps.data[0] = np.array([1.0, 1.0, 1.0])
     x_np = np.ones((1, 1, 3, 3, 3), dtype=np.float32)
-    x = T.tensor_from_list(x_np.tolist())
+    x = T.tensor(x_np.tolist())
     metric = _make_metric(3, 3, 3)
     package = {"metric": {"g": metric, "inv_g": metric}}
     y = conv.forward(x, package=package)
@@ -115,9 +115,9 @@ def test_ndpca3conv3d_normalizes_taps():
 
 
 def test_shift3d_wrapper_defaults_and_matches_var():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     arr_np = np.arange(1 * 1 * 3 * 3 * 3, dtype=np.float32).reshape(1, 1, 3, 3, 3)
-    arr = T.tensor_from_list(arr_np.tolist())
+    arr = T.tensor(arr_np.tolist())
     bc = ("dirichlet", "dirichlet")
 
     out_def, mask_def = _shift3d(arr, axis=2, bc=bc, length=1)

--- a/tests/test_rectconv3d.py
+++ b/tests/test_rectconv3d.py
@@ -19,7 +19,7 @@ if NumPyTensorOperations is not None:
 def test_rectconv3d_backward_matches_numerical(backend_name, Backend):
     random.seed(0)
     np.random.seed(0)
-    like = Backend.tensor_from_list([0.0])
+    like = Backend.tensor([0.0])
     layer = RectConv3d(
         in_channels=1,
         out_channels=1,
@@ -28,7 +28,7 @@ def test_rectconv3d_backward_matches_numerical(backend_name, Backend):
         bias=True,
     )
     x_data = np.random.randn(1, 1, 3, 3, 3)
-    x = Backend.tensor_from_list(x_data.tolist())
+    x = Backend.tensor(x_data.tolist())
 
     y = layer.forward(x)
     grad_out = y * 0 + 1

--- a/tests/test_repeat_behavior.py
+++ b/tests/test_repeat_behavior.py
@@ -18,7 +18,7 @@ def _has_zero_column(data):
 
 @pytest.mark.parametrize("backend_cls", [PurePythonTensorOperations, NumPyTensorOperations])
 def test_repeat_no_alias_or_zero_column(backend_cls):
-    t = backend_cls.tensor_from_list([[1, 2], [3, 4]])
+    t = backend_cls.tensor([[1, 2], [3, 4]])
     r = t.repeat(repeats=2, dim=0)
     assert not _has_zero_column(r.data)
     r.data[0][0] = 99
@@ -28,7 +28,7 @@ def test_repeat_no_alias_or_zero_column(backend_cls):
 
 @pytest.mark.parametrize("backend_cls", [PurePythonTensorOperations, NumPyTensorOperations])
 def test_repeat_interleave_no_alias(backend_cls):
-    t = backend_cls.tensor_from_list([[1, 2], [3, 4]])
+    t = backend_cls.tensor([[1, 2], [3, 4]])
     r = t.repeat_interleave(repeats=2, dim=0)
     assert not _has_zero_column(r.data)
     r.data[0][0] = 99
@@ -36,7 +36,7 @@ def test_repeat_interleave_no_alias(backend_cls):
 
 
 def test_pure_repeat_tuple_no_alias():
-    t = PurePythonTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    t = PurePythonTensorOperations.tensor([[1, 2], [3, 4]])
     r = t.repeat(repeats=(2, 1))
     assert not _has_zero_column(r.data)
     r.data[0][0] = 99
@@ -45,7 +45,7 @@ def test_pure_repeat_tuple_no_alias():
 
 @pytest.mark.skipif(not _has_jax, reason="jax not available")
 def test_jax_repeat_no_alias_or_zero_column():
-    t = JAXTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    t = JAXTensorOperations.tensor([[1, 2], [3, 4]])
     r = t.repeat(repeats=2, dim=0)
     assert not _has_zero_column(r.data)
     r.data[0][0] = 99

--- a/tests/test_requires_grad.py
+++ b/tests/test_requires_grad.py
@@ -3,13 +3,13 @@ from src.common.tensors.abstract_nn.core import Linear
 from src.common.tensors.abstract_convolution.ndpca3conv import NDPCA3Conv3d
 
 def test_linear_parameters_require_grad():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     layer = Linear(2, 3, like=like)
     assert layer.W.requires_grad
     assert layer.b is not None and layer.b.requires_grad
 
 def test_ndpca3conv_pointwise_linear_requires_grad():
-    like = T.tensor_from_list([[0.0]])
+    like = T.tensor([[0.0]])
     conv = NDPCA3Conv3d(1, 2, like=like, grid_shape=(1, 1, 1), pointwise=True)
     assert conv.taps.requires_grad
     assert conv.pointwise is not None

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -41,8 +41,8 @@ def to_list(x):
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_basic_add_and_zeros(backend_name, Backend):
-    a = Backend.tensor_from_list([[1, 2], [3, 4]])
-    b = Backend.tensor_from_list([[5, 6], [7, 8]])
+    a = Backend.tensor([[1, 2], [3, 4]])
+    b = Backend.tensor([[5, 6], [7, 8]])
     result = a + b
     assert result.tolist() == [[6, 8], [10, 12]]
     zeros = Backend.zeros((2, 2))
@@ -51,14 +51,14 @@ def test_basic_add_and_zeros(backend_name, Backend):
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_flatten(backend_name, Backend):
-    a = Backend.tensor_from_list([[1, 2], [3, 4]])
+    a = Backend.tensor([[1, 2], [3, 4]])
     flat = a.flatten()
     assert flat.tolist() == [1, 2, 3, 4]
 
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_prod(backend_name, Backend):
-    a = Backend.tensor_from_list([[1, 2], [3, 4]])
+    a = Backend.tensor([[1, 2], [3, 4]])
     assert to_list(a.prod()) == 24
     assert to_list(a.prod(dim=0)) == [3, 8]
     assert to_list(a.prod(dim=1, keepdim=True)) == [[2], [12]]
@@ -68,6 +68,6 @@ def test_prod(backend_name, Backend):
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_view_flat_handles_non_contiguous(backend_name, Backend):
     # swapaxes produces a non-contiguous view for some backends (e.g., PyTorch)
-    t = Backend.tensor_from_list([[1, 2], [3, 4]]).swapaxes(0, 1)
+    t = Backend.tensor([[1, 2], [3, 4]]).swapaxes(0, 1)
     flat = t.view_flat()
     assert flat.tolist() == [1, 3, 2, 4]

--- a/tests/test_tensor_benchmark.py
+++ b/tests/test_tensor_benchmark.py
@@ -18,7 +18,7 @@ if NumPyTensorOperations is not None:
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_benchmark_records_timings(backend_name, Backend):
     def workload():
-        x = Backend.tensor_from_list([1, 2, 3])
+        x = Backend.tensor([1, 2, 3])
         x.track_time = True
         _ = x + x
         time.sleep(0.001)

--- a/tests/test_tensor_grad.py
+++ b/tests/test_tensor_grad.py
@@ -4,14 +4,14 @@ from src.common.tensors.abstraction import AbstractTensor
 
 
 def test_grad_attribute():
-    x = T.tensor_from_list([[1.0, 2.0], [3.0, 4.0]])
+    x = T.tensor([[1.0, 2.0], [3.0, 4.0]])
     x.requires_grad_(True)
     (x * x).sum().backward()
     assert x.grad is not None
 
 
 def test_autograd_computes_when_unset():
-    x = T.tensor_from_list([1.0, 2.0])
+    x = T.tensor([1.0, 2.0])
     x.requires_grad_(True)
     loss = (x * x).sum()
     x.autograd.tape.mark_loss(loss)
@@ -22,7 +22,7 @@ def test_autograd_computes_when_unset():
 
 
 def test_zero_grad_resets():
-    x = T.tensor_from_list([1.0, 2.0])
+    x = T.tensor([1.0, 2.0])
     x.requires_grad_(True)
     (x * x).sum().backward()
     assert x.grad is not None

--- a/tests/test_tensor_list_coercion.py
+++ b/tests/test_tensor_list_coercion.py
@@ -37,6 +37,6 @@ if JAXTensorOperations is not None:
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_python_list_operands(backend_name, Backend):
-    t = Backend.tensor_from_list([1, 2, 3])
+    t = Backend.tensor([1, 2, 3])
     assert (t - [1, 1, 1]).tolist() == [0, 1, 2]
     assert ([1, 1, 1] - t).tolist() == [0, -1, -2]

--- a/tests/test_torch_repeat_dim.py
+++ b/tests/test_torch_repeat_dim.py
@@ -5,7 +5,7 @@ from src.common.tensors.torch_backend import PyTorchTensorOperations
 
 
 def test_repeat_clone_when_no_repeats():
-    t = PyTorchTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    t = PyTorchTensorOperations.tensor([[1, 2], [3, 4]])
     r = t.repeat()
     assert torch.equal(r.data, t.data)
     r.data[0, 0] = 99
@@ -17,13 +17,13 @@ def test_repeat_clone_when_no_repeats():
 
 
 def test_repeat_scalar():
-    s = PyTorchTensorOperations.tensor_from_list(5)
+    s = PyTorchTensorOperations.tensor(5)
     r = s.repeat(repeats=3, dim=0)
     assert r.data.tolist() == [5, 5, 5]
 
 
 def test_repeat_along_dims():
-    t = PyTorchTensorOperations.tensor_from_list([[1, 2], [3, 4]])
+    t = PyTorchTensorOperations.tensor([[1, 2], [3, 4]])
     r0 = t.repeat(repeats=2, dim=0)
     assert r0.data.tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
     r1 = t.repeat(repeats=2, dim=1)

--- a/tests/test_trig_functions.py
+++ b/tests/test_trig_functions.py
@@ -43,7 +43,7 @@ if JAXTensorOperations is not None:
 @pytest.mark.parametrize("backend_name,BackendCls", BACKENDS)
 def test_trigonometric_suite(backend_name, BackendCls):
     vals = [0.5, 0.8]
-    t = BackendCls.tensor_from_list(vals, dtype=None, device=None)
+    t = BackendCls.tensor(vals, dtype=None, device=None)
     arr = np.array(vals)
 
     np.testing.assert_allclose(t.sin().tolist(), np.sin(arr))
@@ -60,7 +60,7 @@ def test_trigonometric_suite(backend_name, BackendCls):
     np.testing.assert_allclose(t.atanh().tolist(), np.arctanh(arr))
 
     acosh_vals = [1.0, 2.0]
-    t_acosh = BackendCls.tensor_from_list(acosh_vals, dtype=None, device=None)
+    t_acosh = BackendCls.tensor(acosh_vals, dtype=None, device=None)
     np.testing.assert_allclose(t_acosh.acosh().tolist(), np.arccosh(np.array(acosh_vals)))
 
     np.testing.assert_allclose(t.sec().tolist(), 1 / np.cos(arr))


### PR DESCRIPTION
## Summary
- drop obsolete `tensor_from_list` alias from the tensor abstraction
- update demos and tests to construct tensors via `get_tensor`/`tensor`

## Testing
- `pytest` *(fails: KeyError in test_ndpca3conv3d_process_diagram_replay.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b202dd6b98832a971ae1384dcd6e63