### PR TITLE
Register activation ops with backward registry

### DIFF
--- a/src/common/tensors/abstract_nn/activations.py
+++ b/src/common/tensors/abstract_nn/activations.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 from ..abstraction import AbstractTensor
+from ..autograd import autograd
+from ..backward import BACKWARD_REGISTRY
+import sys
 
 # -------- helpers (pure-tensor, numerically stable) --------
 
@@ -16,6 +19,12 @@ def _sigmoid_stable(x: AbstractTensor) -> AbstractTensor:
 
 def _tanh_stable(x: AbstractTensor) -> AbstractTensor:
     return x.tanh()
+
+def _hard_sigmoid(x: AbstractTensor) -> AbstractTensor:
+    lo = x.less(-2.5)
+    hi = x.greater(2.5)
+    mid = (x.greater_equal(-2.5)) * (x.less_equal(2.5))
+    return lo * 0.0 + hi * 1.0 + mid * (0.2 * x + 0.5)
 
 # -------- base --------
 
@@ -39,24 +48,27 @@ class Identity(Activation):
 class ReLU(Activation):
     """y = max(x, 0)"""
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        return x * pos
+        with autograd.no_grad():
+            pos = x.greater(0.0)
+            y = x * pos
+        autograd.record("relu", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        return grad_out * pos
+        return bw_relu(grad_out, x)
 
 class LeakyReLU(Activation):
     """y = x if x>0 else alpha*x"""
     def __init__(self, alpha: float = 0.01):
         self.alpha = float(alpha)
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        neg = x.less_equal(0.0)
-        return x * pos + (self.alpha * x) * neg
+        with autograd.no_grad():
+            pos = x.greater(0.0)
+            neg = x.less_equal(0.0)
+            y = x * pos + (self.alpha * x) * neg
+        autograd.record("leaky_relu", [x], y, params={"alpha": self.alpha})
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        neg = x.less_equal(0.0)
-        return grad_out * (pos + (self.alpha * neg))
+        return bw_leaky_relu(grad_out, x, self.alpha)
     def __repr__(self) -> str:
         return f"LeakyReLU(alpha={self.alpha})"
 
@@ -65,38 +77,45 @@ class ELU(Activation):
     def __init__(self, alpha: float = 1.0):
         self.alpha = float(alpha)
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        neg = x.less_equal(0.0)
-        return x * pos + (self.alpha * (x.exp() - 1.0)) * neg
+        with autograd.no_grad():
+            pos = x.greater(0.0)
+            neg = x.less_equal(0.0)
+            y = x * pos + (self.alpha * (x.exp() - 1.0)) * neg
+        autograd.record("elu", [x], y, params={"alpha": self.alpha})
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        pos = x.greater(0.0)
-        neg = x.less_equal(0.0)
-        return grad_out * (pos + (self.alpha * x.exp()) * neg)
+        return bw_elu(grad_out, x, self.alpha)
     def __repr__(self) -> str:
         return f"ELU(alpha={self.alpha})"
 
 class Sigmoid(Activation):
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        return _sigmoid_stable(x)
+        with autograd.no_grad():
+            y = _sigmoid_stable(x)
+        autograd.record("sigmoid", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        y = _sigmoid_stable(x)
-        return grad_out * y * (1.0 - y)
+        return bw_sigmoid(grad_out, x)
 
 class Tanh(Activation):
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        return _tanh_stable(x)
+        with autograd.no_grad():
+            y = _tanh_stable(x)
+        autograd.record("tanh", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        y = _tanh_stable(x)
-        return grad_out * (1.0 - (y * y))
+        return bw_tanh(grad_out, x)
 
 class SiLU(Activation):  # aka Swish
     """y = x * sigmoid(x)"""
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        s = _sigmoid_stable(x)
-        return x * s
+        with autograd.no_grad():
+            s = _sigmoid_stable(x)
+            y = x * s
+        autograd.record("silu", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        s = _sigmoid_stable(x)
-        return grad_out * (s * (1.0 + x * (1.0 - s)))
+        return bw_silu(grad_out, x)
 
 class GELU(Activation):
     """
@@ -106,58 +125,117 @@ class GELU(Activation):
     _K = 0.7978845608028654  # sqrt(2/pi)
     _C = 0.044715
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        x3 = x * x * x
-        inner = self._K * (x + self._C * x3)
-        t = _tanh_stable(inner)
-        return 0.5 * x * (1.0 + t)
+        with autograd.no_grad():
+            x3 = x * x * x
+            inner = self._K * (x + self._C * x3)
+            t = _tanh_stable(inner)
+            y = 0.5 * x * (1.0 + t)
+        autograd.record("gelu", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        x2 = x * x
-        x3 = x2 * x
-        inner = self._K * (x + self._C * x3)
-        t = _tanh_stable(inner)
-        # dt/dx = (1 - t^2) * d(inner)/dx
-        din_dx = self._K * (1.0 + 3.0 * self._C * x2)
-        dt_dx = (1.0 - t * t) * din_dx
-        dy_dx = 0.5 * (1.0 + t) + 0.5 * x * dt_dx
-        return grad_out * dy_dx
+        return bw_gelu(grad_out, x)
 
 # -------- hard/lightweight variants (no exp/log) --------
 
 class HardSigmoid(Activation):
     """y = clamp(0, 1, 0.2*x + 0.5) implemented piecewise to avoid clamp dependency"""
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        lo = x.less(-2.5)            # y=0
-        hi = x.greater(2.5)          # y=1
-        mid = (x.greater_equal(-2.5)) * (x.less_equal(2.5))
-        return lo * 0.0 + hi * 1.0 + mid * (0.2 * x + 0.5)
+        with autograd.no_grad():
+            y = _hard_sigmoid(x)
+        autograd.record("hard_sigmoid", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        mid = (x.greater_equal(-2.5)) * (x.less_equal(2.5))
-        return grad_out * (0.2 * mid)
+        return bw_hard_sigmoid(grad_out, x)
 
 class HardSwish(Activation):
     """y = x * hard_sigmoid(x)"""
-    def __init__(self):
-        self._hsig = HardSigmoid()
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        return x * self._hsig.forward(x)
+        with autograd.no_grad():
+            h = _hard_sigmoid(x)
+            y = x * h
+        autograd.record("hard_swish", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
-        h = self._hsig.forward(x)
-        dh = self._hsig.backward(x, grad_out=AbstractTensor.get_tensor(1.0))  # derivative skeleton
-        # d(x*h)/dx = h + x * h'
-        return grad_out * (h + x * (dh / grad_out))  # avoid constructing new constants
+        return bw_hard_swish(grad_out, x)
     def __repr__(self) -> str:
         return "HardSwish()"
 
 class ReLU6(Activation):
     """y = min(max(x,0), 6) implemented piecewise"""
     def forward(self, x: AbstractTensor) -> AbstractTensor:
-        neg = x.less_equal(0.0)
-        sat = x.greater_equal(6.0)
-        mid = (x.greater(0.0)) * (x.less(6.0))
-        return neg * 0.0 + sat * 6.0 + mid * x
+        with autograd.no_grad():
+            neg = x.less_equal(0.0)
+            sat = x.greater_equal(6.0)
+            mid = (x.greater(0.0)) * (x.less(6.0))
+            y = neg * 0.0 + sat * 6.0 + mid * x
+        autograd.record("relu6", [x], y)
+        return y
     def backward(self, x: AbstractTensor, grad_out: AbstractTensor) -> AbstractTensor:
+        return bw_relu6(grad_out, x)
+
+# -------- backward registry bindings --------
+
+def bw_relu(g, x):
+    with autograd.no_grad():
+        pos = x.greater(0.0)
+        return g * pos
+
+def bw_leaky_relu(g, x, alpha):
+    with autograd.no_grad():
+        pos = x.greater(0.0)
+        neg = x.less_equal(0.0)
+        return g * (pos + (alpha * neg))
+
+def bw_elu(g, x, alpha):
+    with autograd.no_grad():
+        pos = x.greater(0.0)
+        neg = x.less_equal(0.0)
+        return g * (pos + (alpha * x.exp()) * neg)
+
+def bw_sigmoid(g, x):
+    with autograd.no_grad():
+        y = _sigmoid_stable(x)
+        return g * y * (1.0 - y)
+
+def bw_tanh(g, x):
+    with autograd.no_grad():
+        y = _tanh_stable(x)
+        return g * (1.0 - (y * y))
+
+def bw_silu(g, x):
+    with autograd.no_grad():
+        s = _sigmoid_stable(x)
+        return g * (s * (1.0 + x * (1.0 - s)))
+
+def bw_gelu(g, x):
+    with autograd.no_grad():
+        x2 = x * x
+        x3 = x2 * x
+        inner = GELU._K * (x + GELU._C * x3)
+        t = _tanh_stable(inner)
+        din_dx = GELU._K * (1.0 + 3.0 * GELU._C * x2)
+        dt_dx = (1.0 - t * t) * din_dx
+        dy_dx = 0.5 * (1.0 + t) + 0.5 * x * dt_dx
+        return g * dy_dx
+
+def bw_hard_sigmoid(g, x):
+    with autograd.no_grad():
+        mid = (x.greater_equal(-2.5)) * (x.less_equal(2.5))
+        return g * (0.2 * mid)
+
+def bw_hard_swish(g, x):
+    with autograd.no_grad():
+        h = _hard_sigmoid(x)
+        mid = (x.greater_equal(-2.5)) * (x.less_equal(2.5))
+        dh = 0.2 * mid
+        return g * (h + x * dh)
+
+def bw_relu6(g, x):
+    with autograd.no_grad():
         mid = (x.greater(0.0)) * (x.less(6.0))
-        return grad_out * mid
+        return g * mid
+
+BACKWARD_REGISTRY.register_from_module(sys.modules[__name__])
 
 # -------- registry (nice for configs) --------
 


### PR DESCRIPTION
## Summary
- ensure activation forward passes run under `no_grad` and are recorded to match backward rules
- register activation backward functions with the global backward registry

## Testing
- `pytest` *(fails: tests/test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise)*

------
https://chatgpt.com/codex/tasks/task_e_68b233c5c458832a85c5fd16650788b2