### PR TITLE
Normalize negative transpose and swapaxes indices

### DIFF
--- a/src/common/tensors/abstraction_methods/reshape.py
+++ b/src/common/tensors/abstraction_methods/reshape.py
@@ -47,10 +47,16 @@ def transpose(self, dim0: int = 0, dim1: int = 1) -> "AbstractTensor":
     """Return a transposed tensor as an AbstractTensor."""
     from ..abstraction import AbstractTensor
 
+    shape = getattr(self, "shape", ())
+    ndim = len(shape)
+    if not (-ndim <= dim0 < ndim) or not (-ndim <= dim1 < ndim):
+        raise ValueError("dim0 or dim1 out of range")
+    dim0 %= ndim
+    dim1 %= ndim
+
     if hasattr(self, "transpose_"):
-        perm = list(range(len(getattr(self, "shape", ()))))
-        if dim0 < len(perm) and dim1 < len(perm):
-            perm[dim0], perm[dim1] = perm[dim1], perm[dim0]
+        perm = list(range(ndim))
+        perm[dim0], perm[dim1] = perm[dim1], perm[dim0]
         finalize = AbstractTensor._pre_autograd(
             "permute", [self], params={"perm": perm}
         )
@@ -74,10 +80,16 @@ def unsqueeze(self, dim: int) -> "AbstractTensor":
 def swapaxes(self, axis1: int, axis2: int) -> "AbstractTensor":
     from ..abstraction import AbstractTensor
 
+    shape = getattr(self, "shape", ())
+    ndim = len(shape)
+    if not (-ndim <= axis1 < ndim) or not (-ndim <= axis2 < ndim):
+        raise ValueError("axis1 or axis2 out of range")
+    axis1 %= ndim
+    axis2 %= ndim
+
     if hasattr(self, "swapaxes_"):
-        perm = list(range(len(getattr(self, "shape", ()))))
-        if axis1 < len(perm) and axis2 < len(perm):
-            perm[axis1], perm[axis2] = perm[axis2], perm[axis1]
+        perm = list(range(ndim))
+        perm[axis1], perm[axis2] = perm[axis2], perm[axis1]
         finalize = AbstractTensor._pre_autograd(
             "permute", [self], params={"perm": perm}
         )

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -71,3 +71,45 @@ def test_view_flat_handles_non_contiguous(backend_name, Backend):
     t = Backend.tensor([[1, 2], [3, 4]]).swapaxes(0, 1)
     flat = t.view_flat()
     assert flat.tolist() == [1, 3, 2, 4]
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_transpose_negative_indices(backend_name, Backend):
+    t = Backend.tensor([[1, 2, 3], [4, 5, 6]])
+    neg = t.transpose(-2, -1)
+    pos = t.transpose(0, 1)
+    assert neg.tolist() == pos.tolist()
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_transpose_invalid_indices(backend_name, Backend):
+    t = Backend.tensor([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        t.transpose(2, 0)
+    with pytest.raises(ValueError):
+        t.transpose(0, 2)
+    with pytest.raises(ValueError):
+        t.transpose(-3, 0)
+    with pytest.raises(ValueError):
+        t.transpose(0, -3)
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_swapaxes_negative_indices(backend_name, Backend):
+    t = Backend.tensor([[1, 2, 3], [4, 5, 6]])
+    neg = t.swapaxes(-2, -1)
+    pos = t.swapaxes(0, 1)
+    assert neg.tolist() == pos.tolist()
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_swapaxes_invalid_indices(backend_name, Backend):
+    t = Backend.tensor([[1, 2], [3, 4]])
+    with pytest.raises(ValueError):
+        t.swapaxes(2, 0)
+    with pytest.raises(ValueError):
+        t.swapaxes(0, 2)
+    with pytest.raises(ValueError):
+        t.swapaxes(-3, 0)
+    with pytest.raises(ValueError):
+        t.swapaxes(0, -3)


### PR DESCRIPTION
## Summary
- normalize negative indices in `transpose` and `swapaxes` and validate bounds
- add tests for negative and out-of-range axis handling

## Testing
- `pytest -q` *(fails: tests/common/tensors/test_cache_tags.py::test_cache_tags_and_zero_grad, tests/common/tensors/test_training_state_and_train.py::test_export_training_state)*
- `pytest tests/test_tensor_basic_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26e4acd68832ab0ffeab9ac49582f