### PR TITLE
Handle 1D inputs in transpose helper

### DIFF
--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -119,7 +119,7 @@ helpers_spec: Dict[str, str] = {
     "eps":
         "A small positive constant to guard divisions/logs/square-roots (e.g., 1e-12).",
     "T":
-        "T(X): transpose last two dims of X (matrix transpose).",
+        "T(X): transpose last two dims of X (matrix transpose); vectors are treated as row matrices.",
 }
 
 def unbroadcast(G, target_shape):
@@ -190,6 +190,12 @@ def eps():
     return 1e-12
 
 def T(X):
+    ndim = getattr(X, "ndim", len(getattr(X, "shape", ())))
+    if ndim < 2:
+        if ndim == 0:
+            X = X.reshape((1, 1))
+        else:
+            X = X.reshape((1, X.shape[0]))
     return X.transpose(-2, -1)
 
 BACKWARD_RULES: Dict[str, Dict[str, Any]] = {

--- a/tests/test_backward_registry.py
+++ b/tests/test_backward_registry.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from src.common.tensors.abstraction import get_backward_tool
 from src.common.tensors.backward import BackwardRegistry
+from src.common.tensors.backward_registry import T as transpose_helper
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
 
 
 def test_get_backward_tool_add():
@@ -23,3 +25,10 @@ def test_backward_pipeline_sequence():
     reg.register('f2', f2)
     pipeline = reg.build(['f1', 'f2'])
     assert pipeline(3) == 8
+
+
+def test_T_handles_1d_input():
+    x = T.tensor([1.0, 2.0, 3.0])
+    y = transpose_helper(x)
+    assert y.shape == (3, 1)
+    assert np.allclose(y.data, np.array([[1.0], [2.0], [3.0]]))


### PR DESCRIPTION
## Summary
- expand vectors to 2-D before transposing in backward registry helper `T`
- document updated `T` behavior
- test transpose helper on 1-D input

## Testing
- `pytest tests/test_backward_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26e4e63f8832ab6177958d7f7acb7