### PR TITLE
Prioritize NumPy backend in tensor resolution

### DIFF
--- a/src/common/tensors/AGENTS.md
+++ b/src/common/tensors/AGENTS.md
@@ -9,6 +9,7 @@ This directory hosts the implementations of tensor operations for different nume
 ### Backend Policy
 
 - The **NumPy backend** is the default and canonical implementation.
+- Backend resolution loops must check for `"numpy"` before `"torch"`, ensuring NumPy is always preferred when available.
 - **Do not import, install, or rely on PyTorch (`torch`)**. The dependency is too heavy for this project.
 - If an operation is missing, implement it in the NumPy backend rather than reaching for PyTorch or other large frameworks.
 

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -617,13 +617,14 @@ class AbstractTensor:
 
     @staticmethod
     def check_or_build_registry():
+        cls = None
         if not BACKEND_REGISTRY:
             try:
-                from . import torch_backend  # noqa: F401
+                from . import numpy_backend  # noqa: F401
             except Exception:
                 pass
             try:
-                from . import numpy_backend  # noqa: F401
+                from . import torch_backend  # noqa: F401
             except Exception:
                 pass
             try:
@@ -631,7 +632,7 @@ class AbstractTensor:
             except Exception:
                 pass
 
-        for backend_name in ("torch", "numpy", "pure_python"):
+        for backend_name in ("numpy", "torch", "pure_python"):
             backend_cls = BACKEND_REGISTRY.get(backend_name)
             if backend_cls is not None:
                 cls = backend_cls
@@ -792,11 +793,11 @@ class AbstractTensor:
         # Backend selection (attempt to register common backends)
         if cls is None:
             try:
-                from . import torch_backend  # noqa: F401
+                from . import numpy_backend  # noqa: F401
             except Exception:
                 pass
             try:
-                from . import numpy_backend  # noqa: F401
+                from . import torch_backend  # noqa: F401
             except Exception:
                 pass
             try:
@@ -804,7 +805,7 @@ class AbstractTensor:
             except Exception:
                 pass
 
-            for backend_name in ("torch", "numpy", "pure_python"):
+            for backend_name in ("numpy", "torch", "pure_python"):
                 backend_cls = BACKEND_REGISTRY.get(backend_name)
                 if backend_cls is not None:
                     cls = backend_cls

--- a/src/common/tensors/abstraction_methods/creation.py
+++ b/src/common/tensors/abstraction_methods/creation.py
@@ -254,7 +254,7 @@ def _resolve_cls(cls):
         return cls
     from ..abstraction import BACKEND_REGISTRY  # Local import to avoid circular dependency
 
-    for backend_name in ("torch", "numpy", "pure_python"):
+    for backend_name in ("numpy", "torch", "pure_python"):
         backend_cls = BACKEND_REGISTRY.get(backend_name)
         if backend_cls is not None:
             return backend_cls


### PR DESCRIPTION
## Summary
- Prefer NumPy backend when resolving tensor classes during creation and arange
- Initialize backend registry with NumPy ahead of PyTorch and clarify policy in AGENTS

## Testing
- `pip install setuptools`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b2855c7a80832a997c5a1900b2ff88