### PR TITLE
Accumulate gradient for LocalStateNetwork weights

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -253,7 +253,13 @@ class LocalStateNetwork:
         # Gradient through weight layer
         g_weight_layer = self.g_weight_layer.reshape((1, 1, 1, 1, 3, 3, 3))
         grad_from_weight = grad_weighted_padded * g_weight_layer
-        self.g_weight_layer = (grad_weighted_padded * padded_raw).sum(dim=(0, 1, 2, 3))
+
+        # Accumulate gradient for g_weight_layer without altering the weight tensor
+        grad_weight = (grad_weighted_padded * padded_raw).sum(dim=(0, 1, 2, 3))
+        if getattr(self.g_weight_layer, "_grad", None) is None:
+            self.g_weight_layer._grad = grad_weight
+        else:
+            self.g_weight_layer._grad = self.g_weight_layer._grad + grad_weight
 
         # Propagate through any inner state network
         grad_mod = grad_modulated_padded


### PR DESCRIPTION
## Summary
- Accumulate the weight-layer gradient in `LocalStateNetwork.backward` without overwriting the parameter tensor
- Preserve original weight values for later forward passes

## Testing
- `pytest tests/test_laplace_and_local_state_network_gradients.py::test_local_state_network_weighted_mode_gradient -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b30adabdf8832a872fbe5ec4ea2dcd