### PR TITLE
Use zero_grad for g_weight_layer gradients

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -105,8 +105,8 @@ class LocalStateNetwork:
         """
         Zero all gradients for this network and submodules.
         """
-        if hasattr(self.g_weight_layer, 'zero_'):
-            self.g_weight_layer.zero_()
+        if hasattr(self.g_weight_layer, 'zero_grad'):
+            self.g_weight_layer.zero_grad()
         else:
             self.g_weight_layer = AbstractTensor.zeros_like(self.g_weight_layer)
         if hasattr(self.spatial_layer, 'zero_grad') and callable(self.spatial_layer.zero_grad):


### PR DESCRIPTION
## Summary
- ensure `LocalStateNetwork.g_weight_layer` uses `zero_grad()` instead of zeroing its tensor directly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68b30ac7d004832a802faa5e2afe1f91