### PR TITLE
Add permute tensor operation and backend support

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -2159,6 +2159,7 @@ _bind_and_wrap({
     "reshape": _reshape_methods.reshape,
     "flatten": _reshape_methods.flatten,
     "transpose": _reshape_methods.transpose,
+    "permute": _reshape_methods.permute,
     "unsqueeze": _reshape_methods.unsqueeze,
     "squeeze": _reshape_methods.squeeze,
     "swapaxes": _reshape_methods.swapaxes,
@@ -2225,6 +2226,7 @@ _bind_and_wrap({
 AbstractTensor.reshape = _reshape_methods.reshape
 AbstractTensor.flatten = _reshape_methods.flatten
 AbstractTensor.transpose = _reshape_methods.transpose
+AbstractTensor.permute = _reshape_methods.permute
 AbstractTensor.unsqueeze = _reshape_methods.unsqueeze
 AbstractTensor.squeeze = _reshape_methods.squeeze
 AbstractTensor.swapaxes = _reshape_methods.swapaxes

--- a/src/common/tensors/backward.py
+++ b/src/common/tensors/backward.py
@@ -109,3 +109,6 @@ BACKWARD_REGISTRY = BackwardRegistry()
 
 from .backward_registry import BACKWARD_RULES
 BACKWARD_REGISTRY.register_from_backward_rules(BACKWARD_RULES)
+
+# Expose permute backward function for direct imports
+bw_permute = BACKWARD_REGISTRY._methods["permute"]

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -214,6 +214,10 @@ class NumPyTensorOperations(AbstractTensor):
         softmax = e_x / np.sum(e_x, axis=dim, keepdims=True)
         return np.log(softmax)
 
+    def permute_(self, dims):
+        import numpy as np
+        return np.transpose(self.data, axes=dims)
+
     def transpose_(self, dim0, dim1):
         import numpy as np
         axes = list(range(self.data.ndim))

--- a/tests/test_autograd_permute.py
+++ b/tests/test_autograd_permute.py
@@ -1,0 +1,24 @@
+import pytest
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations as Tensor
+except Exception:  # pragma: no cover - optional dependency
+    Tensor = None  # type: ignore
+
+from src.common.tensors.autograd import autograd
+from src.common.tensors.backward import bw_permute
+
+
+@pytest.mark.skipif(Tensor is None, reason="NumPy backend not available")
+def test_bw_permute_handles_axes():
+    x = Tensor.arange(6).reshape(2, 3).astype("float32")
+    x.requires_grad_(True)
+    y = x.permute(1, 0).sum()
+    autograd.grad(y, [x])
+    assert x._grad.shape == x.shape
+    assert x._grad.tolist() == [[1, 1, 1], [1, 1, 1]]
+
+    g = Tensor.ones_like(x.permute(1, 0))
+    gx = bw_permute(g, x, [1, 0])
+    assert gx.tolist() == [[1, 1, 1], [1, 1, 1]]
+


### PR DESCRIPTION
## Summary
- add `permute` reshape utility with numpy fallback
- register `permute` on `AbstractTensor`
- implement `permute_` for NumPy and pure Python backends
- expose `bw_permute` for autograd and test gradient handling

## Testing
- `pytest tests/test_autograd_permute.py::test_bw_permute_handles_axes -q`
- `pytest tests/test_laplace_and_local_state_network_gradients.py::test_local_state_network_modulated_mode_gradient -q`


------
https://chatgpt.com/codex/tasks/task_e_68b313c4fb64832a9cc48297057676f1