### PR TITLE
Add parameter labels for RectConv3d

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -320,6 +320,7 @@ class RectConv3d:
         dilation: int | tuple[int, int, int] = 1,
         like: AbstractTensor,
         bias: bool = True,
+        _label_prefix=None,
     ):
         self.like = like
         self.in_channels = in_channels
@@ -347,11 +348,15 @@ class RectConv3d:
         self.W.requires_grad_(True)
         self.W._tape = autograd.tape
         autograd.tape.create_tensor_node(self.W)
+        self.W._label = f"{_label_prefix+'.' if _label_prefix else ''}RectConv3d.W"
+        autograd.tape.annotate(self.W, label=self.W._label)
         self.b = from_list_like([0.0] * out_channels, like=like) if bias else None
         if self.b is not None:
             self.b.requires_grad_(True)
             self.b._tape = autograd.tape
             autograd.tape.create_tensor_node(self.b)
+            self.b._label = f"{_label_prefix+'.' if _label_prefix else ''}RectConv3d.b"
+            autograd.tape.annotate(self.b, label=self.b._label)
         self.gW = zeros_like(self.W)
         self.gb = zeros_like(self.b) if self.b is not None else None
         self._x = None


### PR DESCRIPTION
## Summary
- label RectConv3d weights and biases with optional prefix for clearer autograd reporting

## Testing
- `pytest` *(fails: tests/common/tensors/test_cache_tags.py::test_cache_tags_and_zero_grad, tests/common/tensors/test_training_state_and_train.py::test_export_training_state, tests/test_laplace_nd.py::test_laplace_builds_with_numpy, tests/test_laplace_nd.py::test_compute_partials_and_normals_strict, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_no_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise, tests/test_tensor_grad.py::test_grad_attribute, tests/test_tensor_grad.py::test_zero_grad_resets)*

------
https://chatgpt.com/codex/tasks/task_e_68b33c752728832a900fac8905fe3de2