### PR TITLE
Add regularization to local state network gradient tests

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -385,7 +385,7 @@ class LocalStateNetwork:
 
         if lambda_reg:
             self._regularization_loss = lambda_reg * self.regularization_loss(
-                weighted_padded, modulated_padded, smooth
+                weighted_padded, modulated_padded
             )
         else:
             self._regularization_loss = 0.0

--- a/tests/test_laplace_and_local_state_network_gradients.py
+++ b/tests/test_laplace_and_local_state_network_gradients.py
@@ -108,7 +108,8 @@ def test_local_state_network_weighted_mode_gradient():
         dense=True,
         f=0.0,
         deploy_mode="weighted",
-        return_package=True
+        return_package=True,
+        lambda_reg=0.5,
     )
 
     local_state_network = package["local_state_network"]
@@ -166,7 +167,8 @@ def test_local_state_network_modulated_mode_gradient():
         dense=True,
         f=0.0,
         deploy_mode="modulated",
-        return_package=True
+        return_package=True,
+        lambda_reg=0.5,
     )
 
     local_state_network = package["local_state_network"]
@@ -235,7 +237,8 @@ def test_local_state_network_convolutional_modulator_gradient():
         f=0.0,
         return_package=True,
         deploy_mode="modulated",
-        local_state_network=local_state_network  # Pass the externally initialized LocalStateNetwork
+        local_state_network=local_state_network,  # Pass the externally initialized LocalStateNetwork
+        lambda_reg=0.5,
     )
 
     local_state_network = package["local_state_network"]


### PR DESCRIPTION
## Summary
- pass `lambda_reg=0.5` to local state network gradient tests
- fix `LocalStateNetwork` to invoke `regularization_loss` with correct arguments

## Testing
- `pytest tests/test_laplace_and_local_state_network_gradients.py::test_local_state_network_weighted_mode_gradient tests/test_laplace_and_local_state_network_gradients.py::test_local_state_network_modulated_mode_gradient tests/test_laplace_and_local_state_network_gradients.py::test_local_state_network_convolutional_modulator_gradient -q`


------
https://chatgpt.com/codex/tasks/task_e_68b35c9e70d8832aa68265674a32c3e6