### PR TITLE
Ensure regularization loss uses tensor zero

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -250,7 +250,11 @@ class LocalStateNetwork:
         # Regularisation bookkeeping
         self._lambda_reg = 0.0
         self._smoothness = False
-        self._regularization_loss = 0.0
+        self._regularization_loss = AbstractTensor.zeros(
+            (),
+            dtype=self.g_weight_layer.dtype,
+            device=getattr(self.g_weight_layer, 'device', None),
+        )
 
     # --------- Regularisation Helper --------- #
     @staticmethod
@@ -388,7 +392,11 @@ class LocalStateNetwork:
                 weighted_padded, modulated_padded, smooth
             )
         else:
-            self._regularization_loss = 0.0
+            self._regularization_loss = AbstractTensor.zeros(
+                (),
+                dtype=self.g_weight_layer.dtype,
+                device=getattr(self.g_weight_layer, 'device', None),
+            )
 
         return weighted_padded, modulated_padded
 


### PR DESCRIPTION
## Summary
- Keep `LocalStateNetwork._regularization_loss` as an `AbstractTensor` so `backward()` always works

## Testing
- `pytest` *(fails: test_cache_tags_and_zero_grad, test_export_training_state, test_local_state_network_with_regularization_loss, test_laplace_nd::test_laplace_builds_with_numpy, test_laplace_nd::test_compute_partials_and_normals_strict, test_local_state_network::test_regularization_modifies_weight_gradient, test_ndpca3conv3d_grad::test_ndpca3conv3d_gradients_no_pointwise, test_ndpca3conv3d_grad::test_ndpca3conv3d_gradients_with_pointwise, test_ndpca3conv3d_process_diagram_replay::test_demo_replay_path_does_not_raise, test_tensor_grad::test_grad_attribute, test_tensor_grad::test_zero_grad_resets)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c9d2bc0832a8e7db75abcc64880