### PR TITLE
Refine Laplace structural parameters and gradient tests

### DIFF
--- a/tests/test_metric_steered_conv3d_local_state_grad.py
+++ b/tests/test_metric_steered_conv3d_local_state_grad.py
@@ -13,6 +13,20 @@ def test_local_state_network_params_receive_grads(deploy_mode):
     x.requires_grad_(True)
     out = layer.forward(x)
     lsn = layer.laplace_package['local_state_network']
-    loss = out.sum() + lsn.g_weight_layer.sum()
+    loss = out.sum()
+    if deploy_mode == "weighted":
+        loss = loss + lsn.g_weight_layer.sum() + lsn.g_bias_layer.sum()
+    else:  # modulated
+        reg = None
+        for p in lsn.inner_state.spatial_layer.parameters():
+            reg = p.sum() if reg is None else reg + p.sum()
+        loss = loss + reg
     loss.backward()
-    assert any(p.grad is not None for p in lsn.parameters())
+    if deploy_mode == "weighted":
+        assert getattr(lsn.g_weight_layer, "_grad", None) is not None
+        assert getattr(lsn.g_bias_layer, "_grad", None) is not None
+    else:  # modulated
+        spatial_params = lsn.inner_state.spatial_layer.parameters()
+        assert all(getattr(p, "_grad", None) is not None for p in spatial_params)
+        assert getattr(lsn.g_weight_layer, "_grad", None) is None
+        assert getattr(lsn.g_bias_layer, "_grad", None) is None


### PR DESCRIPTION
## Summary
- Mark only truly unused LocalStateNetwork parameters as structural for each `deploy_mode`
- Ensure `g_weight_layer` and `g_bias_layer` are trainable when active
- Expand tests to verify gradients for active LocalStateNetwork branches

## Testing
- `pytest tests/test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads[weighted] -q`
- `pytest tests/test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads[modulated] -q`
- `pytest tests/test_structural_bypass_parameters.py::test_raw_mode_excludes_local_state_network_params -q`
- `pytest -q` *(fails: test_cache_tags_and_zero_grad, test_export_training_state, test_laplace_nd, test_ndpca3conv3d_gradients_no_pointwise, test_ndpca3conv3d_gradients_with_pointwise, test_ndpca3conv3d_process_diagram_replay, test_grad_attribute, test_zero_grad_resets)*

------
https://chatgpt.com/codex/tasks/task_e_68b360f18028832aa27c0f77d2dcb5d4