### PR TITLE
Wrap networks with abstract_nn core

### DIFF
--- a/src/common/tensors/abstract_nn/__init__.py
+++ b/src/common/tensors/abstract_nn/__init__.py
@@ -1,4 +1,4 @@
-from .core import Linear, Sequential, Model, RectConv2d, RectConv3d, MaxPool2d, Flatten
+from .core import Linear, Sequential, Model, RectConv2d, RectConv3d, MaxPool2d, Flatten, wrap_module
 from .activations import ReLU, Sigmoid, Tanh, Identity
 from .losses import MSELoss, CrossEntropyLoss, BCEWithLogitsLoss
 from .optimizer import Adam

--- a/tests/test_laplace_and_local_state_network_gradients.py
+++ b/tests/test_laplace_and_local_state_network_gradients.py
@@ -315,6 +315,17 @@ def test_local_state_network_with_regularization_loss():
             f"{getattr(param, '_label', 'param')} (shape={shape}): grad={'present' if param.grad is not None else 'missing'}"
         )
 
+
+def test_regularization_loss_backward_registers_grads():
+    """Calling _regularization_loss.backward should populate grads for all params."""
+    metric_tensor_func = lambda *args, **kwargs: None
+    net = LocalStateNetwork(metric_tensor_func, (2, 2, 2), DEFAULT_CONFIGURATION, max_depth=1)
+    padded_raw = AbstractTensor.randn((2, 2, 2, 3, 3, 3))
+    net.forward(padded_raw, lambda_reg=0.5)
+    net._regularization_loss.backward()
+    for p in net.parameters(include_all=True):
+        assert p.grad is not None
+
 if __name__ == "__main__":
     import sys
     import argparse


### PR DESCRIPTION
## Summary
- add `wrap_module` helper that registers network `forward`/`__call__` with autograd and runs internals under `no_grad`
- export the wrapper and apply it to `Model` and `LocalStateNetwork`
- simplify regularization loss backward to funnel zeros through `LocalStateNetwork.backward`

## Testing
- `pytest tests/test_laplace_and_local_state_network_gradients.py::test_regularization_loss_backward_registers_grads -q`
- `pytest tests/test_local_state_network.py::test_local_state_network_forward_backward_consistency -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3785606f4832a815dd21603f27a99