### PR TITLE
Ensure conv3d gradients and auto-register tensor layers

### DIFF
--- a/src/common/tensors/abstract_convolution/metric_steered_conv3d.py
+++ b/src/common/tensors/abstract_convolution/metric_steered_conv3d.py
@@ -14,6 +14,7 @@ from .laplace_nd import BuildLaplace3D, GridDomain
 from .ndpca3conv import NDPCA3Conv3d
 from ..abstraction import AbstractTensor
 from ..autograd import autograd
+from ..abstract_nn import wrap_module
 
 
 class MetricSteeredConv3DWrapper:
@@ -116,6 +117,7 @@ class MetricSteeredConv3DWrapper:
             eig_from=eig_from,
             pointwise=pointwise,
         )
+        wrap_module(self)
 
     def _build_laplace_package(self, boundary_conditions):
         builder = BuildLaplace3D(
@@ -141,7 +143,7 @@ class MetricSteeredConv3DWrapper:
             for p in lsn.parameters(include_all=True, include_structural=True):
                 if getattr(p, "grad", None) is None:
                     try:
-                        p.grad = AbstractTensor.zeros_like(p)
+                        p._grad = AbstractTensor.zeros_like(p)
                     except Exception:
                         pass
 

--- a/src/common/tensors/abstract_convolution/ndpca3conv.py
+++ b/src/common/tensors/abstract_convolution/ndpca3conv.py
@@ -3,7 +3,7 @@ from typing import Tuple, Literal
 import numpy as np
 
 from ..abstraction import AbstractTensor
-from ..abstract_nn.core import Linear  # for optional 1x1 mixing
+from ..abstract_nn.core import Linear, wrap_module  # for optional 1x1 mixing
 from ..abstract_nn.utils import from_list_like
 from ..autograd import autograd
 
@@ -191,6 +191,7 @@ class NDPCA3Conv3d:
                 bias=False,
                 _label_prefix=f"{_label_prefix+'.' if _label_prefix else ''}NDPCA3Conv3d.pointwise",
             )
+        wrap_module(self)
 
     # --- standard layer API ---
     def parameters(self):

--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -139,6 +139,7 @@ class Linear:
         logger.debug(
             f"Linear layer weights shape: {getattr(self.W, 'shape', None)}; bias shape: {getattr(self.b, 'shape', None) if self.b is not None else None}"
         )
+        wrap_module(self)
 
     def parameters(self) -> List[AbstractTensor]:
         return [p for p in (self.W, self.b) if p is not None]
@@ -201,6 +202,7 @@ class Flatten:
     def __init__(self, like: AbstractTensor):
         self.like = like
         self._shape = None
+        wrap_module(self)
 
     def parameters(self) -> List[AbstractTensor]:
         return []
@@ -270,6 +272,7 @@ class RectConv2d:
         self._cols = None
         self._x_shape = None
         self._added = False
+        wrap_module(self)
 
     def parameters(self) -> List[AbstractTensor]:
         return [p for p in (self.W, self.b) if p is not None]
@@ -422,6 +425,7 @@ class RectConv3d:
         self._cols = None
         self._x_shape = None
         self._added = False
+        wrap_module(self)
 
     def parameters(self) -> List[AbstractTensor]:
         return [p for p in (self.W, self.b) if p is not None]
@@ -499,6 +503,9 @@ class RectConv3d:
         self.gW = gW.sum(dim=0).reshape(*self.W.shape)
         if self.b is not None:
             self.gb = grad_mat.sum(dim=(0, 2)).reshape(*self.b.shape)
+        self.W._grad = self.gW
+        if self.b is not None:
+            self.b._grad = self.gb
         Wm = self.W.reshape(self.out_channels, -1)
         WT = Wm.transpose(0, 1)
         dcols = WT @ grad_mat
@@ -536,6 +543,7 @@ class MaxPool2d:
         self._L = None
         self._kHW = None
         self._added = False
+        wrap_module(self)
 
     def parameters(self) -> List[AbstractTensor]:
         return []


### PR DESCRIPTION
## Summary
- Auto-wrap core layers (Linear, Flatten, RectConv2d/3d, MaxPool2d) so they register with the autograd tape
- Mirror RectConv3d weight and bias gradients into `_grad`
- Wrap NDPCA3Conv3d and MetricSteeredConv3DWrapper; use `_grad` placeholders for local state nets
- Assert recursion depth and gradient presence in convolutional modulator test

## Testing
- `pytest tests/test_laplace_and_local_state_network_gradients.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37e932d10832a981767488462e28a