### PR TITLE
Handle -1 dimensions in expand

### DIFF
--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -515,7 +515,21 @@ class NumPyTensorOperations(AbstractTensor):
         return np.concatenate(tensors, axis=dim)
 
     def expand_(self, shape):
-        return np.broadcast_to(self.data, shape)
+        import numpy as np
+        try:
+            new_shape = tuple(
+                self.data.shape[i] if s == -1 else s
+                for i, s in enumerate(shape)
+            )
+        except IndexError as exc:
+            raise ValueError(
+                f"expand_ requires shape of length {self.data.ndim}, got {len(shape)}"
+            ) from exc
+        if len(new_shape) != self.data.ndim:
+            raise ValueError(
+                f"expand_ requires shape of length {self.data.ndim}, got {len(new_shape)}"
+            )
+        return np.broadcast_to(self.data, new_shape)
     def repeat_interleave_(self, repeats=1, dim=None):
         if dim is None:
             dim = 0

--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -835,10 +835,20 @@ class PurePythonTensorOperations(AbstractTensor):
     def expand_(self, shape):
         """Broadcast ``self.data`` to ``shape`` using pure Python lists."""
         data = self.data
-        target = list(shape)
         orig_shape = list(_get_shape(data))
-        if len(orig_shape) != len(target):
-            raise NotImplementedError("expand_ requires same number of dims as target shape")
+        try:
+            new_shape = tuple(
+                orig_shape[i] if s == -1 else s for i, s in enumerate(shape)
+            )
+        except IndexError as exc:
+            raise ValueError(
+                f"expand_ requires shape of length {len(orig_shape)}, got {len(shape)}"
+            ) from exc
+        if len(new_shape) != len(orig_shape):
+            raise ValueError(
+                f"expand_ requires shape of length {len(orig_shape)}, got {len(new_shape)}"
+            )
+        target = list(new_shape)
 
         def expand_rec(lst, dim):
             if dim == len(target):

--- a/tests/test_expand_negative_one.py
+++ b/tests/test_expand_negative_one.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from src.common.tensors.pure_backend import PurePythonTensorOperations
+
+try:  # optional dependency
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover
+    NumPyTensorOperations = None
+
+BACKENDS = [("PurePython", PurePythonTensorOperations)]
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+
+
+@pytest.mark.parametrize("name,Backend", BACKENDS)
+def test_expand_with_negative_one(name, Backend):
+    data = np.zeros((1, 1, 2, 3, 4)).tolist()
+    t = Backend.tensor(data)
+    expanded = t.expand(2, 3, -1, -1, -1)
+    assert expanded.shape == (2, 3, 2, 3, 4)


### PR DESCRIPTION
## Summary
- allow `-1` entries in tensor `expand_` shape for NumPy and pure python backends
- add regression test exercising `expand` with `-1` placeholders

## Testing
- `python -m pytest` *(fails: ValueError/AttributeError in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b3854bfb2c832ab4d2538aa3f24724