### PR TITLE
Fix eye reshape for arbitrary batch dimensions

### DIFF
--- a/src/common/tensors/linalg.py
+++ b/src/common/tensors/linalg.py
@@ -32,8 +32,8 @@ def eye(n: int, *, dtype=None, device=None, batch_shape: Tuple[int, ...] = ()) -
     j = AbstractTensor.arange(n, dtype=long_type, device=device).reshape((1, n)).expand((n, n))
     E = (i == j).to_dtype(dtype or float_type)
     if batch_shape:
-        # expand: (1,1,n,n) -> (*batch, n, n)
-        E = E.reshape((1, 1, n, n)).expand(tuple(batch_shape) + (n, n))
+        # expand: (1,...,1,n,n) -> (*batch, n, n)
+        E = E.reshape((1,) * len(batch_shape) + (n, n)).expand(tuple(batch_shape) + (n, n))
     return E
 
 # ----------------------- vector ops --------------------------

--- a/tests/test_eye_batch_dims.py
+++ b/tests/test_eye_batch_dims.py
@@ -1,0 +1,11 @@
+import numpy as np
+from src.common.tensors.abstraction import AbstractTensor
+
+
+def test_eye_three_plus_batch_dims():
+    E = AbstractTensor.eye(4, batch_shape=(2, 3, 4))
+    assert E.get_shape() == (2, 3, 4, 4, 4)
+    expected = np.eye(4, dtype=E.data.dtype)
+    expected = expected.reshape((1, 1, 1, 4, 4))
+    expected = np.broadcast_to(expected, (2, 3, 4, 4, 4))
+    assert np.allclose(E.data, expected)


### PR DESCRIPTION
## Summary
- handle arbitrary batch dimensions in `linalg.eye` by reshaping with variable leading ones
- add regression test ensuring `eye` works with three or more batch dimensions

## Testing
- `pytest tests/test_eye_batch_dims.py -q`
- `pytest -q` *(fails: AssertionError in test_cache_tags_and_zero_grad, AttributeError in multiple other tests, ValueError in laplace tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b38a2c851c832a83f3cf4a813d4e25