### PR TITLE
Skip backward registry for modules without backward implementations

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -26,6 +26,13 @@ def wrap_module(module):
     if getattr(module, "_nncore_wrapped", False):
         return module
 
+    # Only wrap modules that provide an explicit backward implementation.
+    # Modules without ``backward`` should rely on their internal operations
+    # for autograd, so we leave them untouched to avoid suppressing gradient
+    # recording.
+    if not callable(getattr(module, "backward", None)):
+        return module
+
     name = module.__class__.__name__
 
     orig_forward = getattr(module, "forward", None)

--- a/tests/test_wrap_module_without_backward.py
+++ b/tests/test_wrap_module_without_backward.py
@@ -1,0 +1,26 @@
+import numpy as np
+from src.common.tensors import AbstractTensor
+from src.common.tensors.abstract_nn import wrap_module
+from src.common.tensors.backward import BACKWARD_REGISTRY
+
+
+class NoBackwardModule:
+    def forward(self, x):
+        return x * x
+
+
+def test_wrap_module_skips_backward_registration_and_allows_grad():
+    autograd = AbstractTensor.autograd
+    autograd.tape._nodes.clear()
+
+    m = NoBackwardModule()
+    wrap_module(m)
+
+    name = m.__class__.__name__
+    assert f"{name}.forward" not in BACKWARD_REGISTRY._methods
+    assert f"{name}.__call__" not in BACKWARD_REGISTRY._methods
+
+    x = AbstractTensor.tensor([2.0], requires_grad=True)
+    y = m.forward(x)
+    y.sum().backward()
+    assert np.allclose(x.grad.data, np.array([4.0]))


### PR DESCRIPTION
## Summary
- Avoid wrapping modules lacking a `backward` method so their internals handle autograd normally
- Add regression test confirming that such modules aren't registered with the backward registry

## Testing
- `pytest -q` *(fails: cache tag persistence, training state export, ascii classifier, linear block gradients, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b38efc56d0832aa4cfc63f347e96e0