### PR TITLE
Fix tap weight gradient connectivity in NDPCA3Conv3d

### DIFF
--- a/src/common/tensors/abstract_convolution/ndpca3conv.py
+++ b/src/common/tensors/abstract_convolution/ndpca3conv.py
@@ -292,7 +292,8 @@ class NDPCA3Conv3d:
         if self.normalize:
             taps = taps / (taps.sum(dim=1, keepdim=True) + 1e-12)
             autograd.tape.annotate(taps, label="NDPCA3Conv3d.taps_normalized")
-        tap_sums = taps.sum(dim=0).reshape(len(self.offsets), 1, 1, 1, 1)
+        tap_sums = taps.sum(dim=0, keepdim=True)
+        tap_sums = tap_sums.reshape(len(self.offsets), 1, 1, 1, 1)
         autograd.tape.annotate(tap_sums, label="NDPCA3Conv3d.tap_sums")
 
         # Broadcast axis weights to (1,1,D,H,W)

--- a/tests/test_ndpca3conv3d_taps_grad_not_none.py
+++ b/tests/test_ndpca3conv3d_taps_grad_not_none.py
@@ -1,0 +1,17 @@
+import numpy as np
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
+from src.common.tensors.abstract_convolution.ndpca3conv import NDPCA3Conv3d
+
+def test_ndpca3conv3d_taps_grad_not_none():
+    like = T.tensor([[0.0]])
+    conv = NDPCA3Conv3d(1, 1, like=like, grid_shape=(2, 2, 2), pointwise=False)
+    x = T.tensor(np.random.rand(1, 1, 2, 2, 2).tolist())
+    x.requires_grad_(True)
+    g = np.tile(np.eye(3, dtype=np.float32), (2, 2, 2, 1, 1))
+    metric = T.tensor(g.tolist())
+    package = {"metric": {"g": metric, "inv_g": metric}}
+    y = conv.forward(x, package=package)
+    y.sum().backward()
+    assert conv.taps.grad is not None
+    assert conv.taps.grad.data.shape == conv.taps.data.shape
+    assert np.all(np.abs(conv.taps.grad.data) > 0)


### PR DESCRIPTION
## Summary
- keep tap weight sums from detaching in `NDPCA3Conv3d.forward`
- add regression test checking that convolution taps receive gradients

## Testing
- `pytest tests/test_ndpca3conv3d_taps_grad_not_none.py -q`
- `pytest` *(fails: AttributeError: 'NoneType' object has no attribute 'data', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b393e17ecc832a94bd2c91aa291b87