### PR TITLE
Guard NumPy tensor division by zero

### DIFF
--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -300,10 +300,9 @@ class NumPyTensorOperations(AbstractTensor):
             return a * b
         if op == "rmul":
             return a * b
-        if op in ("truediv", "itruediv"):
-            return a / b
-        if op == "rtruediv":
-            return a / b
+        if op in ("truediv", "itruediv", "rtruediv"):
+            out = np.zeros(np.broadcast(a, b).shape, dtype=np.result_type(a, b))
+            return np.divide(a, b, out=out, where=b != 0)
         if op in ("floordiv", "ifloordiv"):
             return np.floor_divide(a, b)
         if op == "rfloordiv":

--- a/tests/test_numpy_divide_by_zero.py
+++ b/tests/test_numpy_divide_by_zero.py
@@ -1,0 +1,17 @@
+import warnings
+import numpy as np
+import pytest
+
+from src.common.tensors.numpy_backend import NumPyTensorOperations
+
+
+@pytest.mark.skipif(NumPyTensorOperations is None or np is None, reason="NumPy backend not available")
+def test_divide_by_zero_returns_finite_no_warning():
+    a = NumPyTensorOperations.tensor([1.0, 2.0])
+    b = NumPyTensorOperations.tensor([0.0, 1.0])
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        result = a / b
+    assert np.all(np.isfinite(result.tolist()))
+    assert not any(issubclass(w.category, RuntimeWarning) for w in record)
+    assert result.tolist() == [0.0, 2.0]


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in NumPy backend using `np.divide` with masked zeros
- add regression test ensuring NumPy truediv returns finite results without warnings

## Testing
- `pytest` (fails: tests/common/tensors/test_cache_tags.py::test_cache_tags_and_zero_grad, tests/common/tensors/test_training_state_and_train.py::test_export_training_state, tests/test_ascii_kernel_nn.py::test_nn_classifier_matches_reference_bitmasks, tests/test_ascii_render.py::test_to_ascii_diff_preserves_color, tests/test_laplace_nd.py::test_laplace_builds_with_numpy, tests/test_laplace_nd.py::test_compute_partials_and_normals_strict, tests/test_linear_block.py::test_linear_block_debug, tests/test_linear_single_vector.py::test_linear_single_vector_trains[NumPy-NumPyTensorOperations], tests/test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads[modulated], tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_no_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_zero_grad_with_pointwise, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise, tests/test_riemann_grid_block.py::test_forward_shape_and_grad_pca_nd, tests/test_tensor_grad.py::test_grad_attribute, tests/test_tensor_grad.py::test_zero_grad_resets, tests/test_wrap_module_without_backward.py::test_wrap_module_skips_backward_registration_and_allows_grad)
- `pytest tests/test_numpy_divide_by_zero.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b393fa19a4832a9b30f08ec19a6653