### PR TITLE
feat: add stack and cat to c tensor backend

### DIFF
--- a/tests/test_cffi_matmul.py
+++ b/tests/test_cffi_matmul.py
@@ -21,3 +21,25 @@ def test_nn_graph_complete_and_cffi_forward_pass():
     B_tensor = ops.tensor_from_list_(B.tolist(), ops.float_dtype_, None)
     result = ops.matmul_(A_tensor, B_tensor)
     assert np.allclose(result.tolist(), expected.tolist())
+
+
+def test_c_backend_stack_and_cat():
+    ops = CTensorOperations()
+    t1 = ops.tensor_from_list_([[1.0, 2.0], [3.0, 4.0]], ops.float_dtype_, None)
+    t2 = ops.tensor_from_list_([[5.0, 6.0], [7.0, 8.0]], ops.float_dtype_, None)
+
+    stacked = ops.stack_([t1, t2], dim=0)
+    assert stacked.shape == (2, 2, 2)
+    assert stacked.tolist() == [
+        [[1.0, 2.0], [3.0, 4.0]],
+        [[5.0, 6.0], [7.0, 8.0]],
+    ]
+
+    cat = ops.cat_([t1, t2], dim=0)
+    assert cat.shape == (4, 2)
+    assert cat.tolist() == [
+        [1.0, 2.0],
+        [3.0, 4.0],
+        [5.0, 6.0],
+        [7.0, 8.0],
+    ]


### PR DESCRIPTION
## Summary
- implement stack_ and cat_ in CTensorOperations via new C helpers
- add C implementations stack_double and cat_double
- cover C backend stacking and concatenation with tests

## Testing
- `pytest` *(fails: cache tag, grad, ASCII, laplace, linear block, metric-*, ndpca3conv3d, numpy divide by zero, riemann grid, tensor grad, wrap module)*
- `pytest tests/test_cffi_matmul.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3a986cbac832a8b77ff2b1a283cdc