### PR TITLE
Include raw Laplace params in metric steered conv3D wrapper

### DIFF
--- a/src/common/tensors/abstract_convolution/metric_steered_conv3d.py
+++ b/src/common/tensors/abstract_convolution/metric_steered_conv3d.py
@@ -154,9 +154,7 @@ class MetricSteeredConv3DWrapper:
             self.local_state_network = lsn
         if lsn is not None:
             unused = []
-            if self.deploy_mode == "raw":
-                unused = list(lsn.parameters(include_all=True, include_structural=True))
-            elif self.deploy_mode == "weighted":
+            if self.deploy_mode == "weighted":
                 if hasattr(lsn, "spatial_layer") and hasattr(lsn.spatial_layer, "parameters"):
                     unused.extend(lsn.spatial_layer.parameters())
                 inner = getattr(lsn, "inner_state", None)
@@ -174,7 +172,7 @@ class MetricSteeredConv3DWrapper:
                     return params
 
                 unused = gather_weight_branch(lsn)
-            else:
+            elif self.deploy_mode != "raw":
                 raise ValueError("Invalid deploy_mode. Use 'raw', 'weighted', or 'modulated'.")
 
             # Ensure all non-structural parameters have gradient placeholders


### PR DESCRIPTION
## Summary
- Stop tagging LocalStateNetwork parameters as structural in raw deploy mode
- Only mark unused branches for weighted or modulated Laplace variants
- Add regression tests ensuring raw mode exposes LocalStateNetwork parameters and receives regularization gradients

## Testing
- `pytest` *(fails: tests/common/tensors/test_cache_tags.py::test_cache_tags_and_zero_grad, tests/common/tensors/test_training_state_and_train.py::test_export_training_state, tests/test_ascii_kernel_nn.py::test_nn_classifier_matches_reference_bitmasks, tests/test_ascii_render.py::test_to_ascii_diff_preserves_color, tests/test_laplace_nd.py::test_laplace_builds_with_numpy, tests/test_laplace_nd.py::test_compute_partials_and_normals_strict, tests/test_linear_block.py::test_linear_block_debug, tests/test_linear_single_vector.py::test_linear_single_vector_trains[NumPy-NumPyTensorOperations], tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_no_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_zero_grad_with_pointwise, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise, tests/test_riemann_grid_block.py::test_forward_shape_and_grad_pca_nd, tests/test_tensor_grad.py::test_grad_attribute, tests/test_tensor_grad.py::test_zero_grad_resets, tests/test_wrap_module_without_backward.py::test_wrap_module_skips_backward_registration_and_allows_grad)*
- `pytest tests/test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads_raw_mode -q`
- `pytest tests/test_structural_bypass_parameters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3ba3a4ee0832aae04f00472c30f77