### PR TITLE
Return regularization loss from LocalStateNetwork

### DIFF
--- a/src/common/tensors/abstract_convolution/laplace_nd.py
+++ b/src/common/tensors/abstract_convolution/laplace_nd.py
@@ -451,6 +451,7 @@ class BuildLaplace3D:
         raw_tensor = state_outputs['padded_raw']
         weighted_tensor = state_outputs['weighted_padded']
         modulated_tensor = state_outputs['modulated_padded']
+        regularization_loss = state_outputs.get('regularization_loss')
 
         # 3. Select Appropriate Tensor Based on deploy_mode
         if deploy_mode == 'raw':
@@ -688,6 +689,7 @@ class BuildLaplace3D:
                 "vals": coo_vals,
             },
             "local_state_network": local_state_network,
+            "regularization_loss": regularization_loss,
             "config": {
                 "stencil": INT_LAPLACEBELTRAMI_STENCIL if 'INT_LAPLACEBELTRAMI_STENCIL' in globals() else None,
                 "dtype": str(self.precision) if hasattr(self, 'precision') else None,

--- a/tests/test_metric_steered_conv3d_local_state_grad.py
+++ b/tests/test_metric_steered_conv3d_local_state_grad.py
@@ -46,6 +46,9 @@ def test_local_state_network_params_receive_grads_raw_mode():
     x = AbstractTensor.randn((1, 1, N, N, N))
     layer.forward(x)
     lsn = layer.laplace_package["local_state_network"]
-    lsn._regularization_loss.backward()
+    layer.laplace_package["regularization_loss"].backward()
+    zero_w = AbstractTensor.zeros_like(lsn._weighted_padded)
+    zero_m = AbstractTensor.zeros_like(lsn._modulated_padded)
+    lsn.backward(zero_w, zero_m, lambda_reg=0.5)
     params = lsn.parameters(include_all=True, include_structural=True)
     assert all(getattr(p, "_grad", None) is not None for p in params)


### PR DESCRIPTION
## Summary
- expose regularization loss from `LocalStateNetwork.forward` and propagate through Laplace builder
- compute regularization gradients during `backward`
- test that `g_weight_layer` receives gradients when regularization is enabled

## Testing
- `pytest` *(fails: tests failing including test_metric_steered_conv3d_local_state_grad.py::test_local_state_network_params_receive_grads_raw_mode, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_no_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_zero_grad_with_pointwise, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise, tests/test_riemann_grid_block.py::test_forward_output_shape_pre_linear, tests/test_riemann_grid_block.py::test_parameters_registered_pre_linear, tests/test_riemann_grid_block.py::test_forward_end_to_end_pre_linear, tests/test_riemann_grid_block.py::test_forward_output_shape_fixed_mode, tests/test_riemann_grid_block.py::test_soft_assign_not_implemented, tests/test_riemann_grid_block.py::test_casting_row_major_deterministic, tests/test_riemann_grid_block.py::test_casting_1to1_mapping, tests/test_riemann_grid_block.py::test_coordinate_fourier_embedding_dims, tests/test_riemann_grid_block.py::test_geometry_factory_pca_nd_demo_config, tests/test_riemann_grid_block.py::test_forward_shape_and_grad_pca_nd, tests/test_riemann_grid_block.py::test_parameter_counts_pca_nd, tests/test_structural_bypass_parameters.py::test_raw_mode_includes_local_state_network_params, tests/test_tensor_grad.py::test_grad_attribute, tests/test_tensor_grad.py::test_zero_grad_resets)*

------
https://chatgpt.com/codex/tasks/task_e_68b447653c8c832aaf85421e363eddc2