### PR TITLE
Ensure inner LocalStateNetwork receives weighted gradients

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -495,8 +495,7 @@ class LocalStateNetwork:
         # Propagate through any inner state network
         grad_mod = grad_modulated_padded
         if self.inner_state is not None:
-            zero = grad_mod * 0
-            grad_mod = self.inner_state.backward(zero, grad_mod)
+            grad_mod = self.inner_state.backward(grad_weighted_padded, grad_mod)
 
         grad_mod = grad_mod.reshape((B, D, H, W, -1))
 


### PR DESCRIPTION
## Summary
- propagate weighted-branch gradients into nested LocalStateNetwork

## Testing
- `python - <<'PY'
import numpy as np
from src.common.tensors.abstract_convolution.local_state_network import LocalStateNetwork, DEFAULT_CONFIGURATION
from src.common.tensors.abstraction import AbstractTensor

def metric_func(*args, **kwargs):
    g = AbstractTensor.zeros((1,1,3,3))
    return g, g, AbstractTensor.tensor(1.0)

lsn = LocalStateNetwork(metric_func, (1,1,1), DEFAULT_CONFIGURATION)

padded_raw = AbstractTensor.randn((1,1,1,1,3,3,3))
weighted, modulated, reg = lsn.forward(padded_raw)

grad_w = AbstractTensor.randn(weighted.shape)
grad_m = AbstractTensor.randn(modulated.shape)

input_grad = lsn.backward(grad_w, grad_m)

print('inner g_weight grad sum', lsn.inner_state.g_weight_layer._grad.sum().item())
print('inner g_bias grad sum', lsn.inner_state.g_bias_layer._grad.sum().item())
PY`
- `pytest` *(fails: tests/common/tensors/test_cache_tags.py::test_cache_tags_and_zero_grad, tests/common/tensors/test_training_state_and_train.py::test_export_training_state, tests/test_ascii_kernel_nn.py::test_nn_classifier_matches_reference_bitmasks, tests/test_ascii_render.py::test_to_ascii_diff_preserves_color, tests/test_laplace_nd.py::test_laplace_builds_with_numpy, tests/test_laplace_nd.py::test_compute_partials_and_normals_strict, tests/test_linear_block.py::test_linear_block_debug, tests/test_linear_single_vector.py::test_linear_single_vector_trains[NumPy-NumPyTensorOperations], tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_no_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_gradients_with_pointwise, tests/test_ndpca3conv3d_grad.py::test_ndpca3conv3d_zero_grad_with_pointwise, tests/test_ndpca3conv3d_process_diagram_replay.py::test_demo_replay_path_does_not_raise, tests/test_riemann_grid_block.py::test_forward_shape_and_grad_pca_nd, tests/test_structural_bypass_parameters.py::test_raw_mode_includes_local_state_network_params, tests/test_tensor_grad.py::test_grad_attribute, tests/test_tensor_grad.py::test_zero_grad_resets)`

------
https://chatgpt.com/codex/tasks/task_e_68b45f97f880832abb817bc558a48714