### PR TITLE
Use weighted view for LocalStateNetwork spatial path

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -387,19 +387,19 @@ class LocalStateNetwork:
 
         weighted_padded = padded_raw * g_weight_layer + g_bias_layer
 
-        padded_view = padded_raw.reshape((B, D, H, W, -1))
+        weighted_view = weighted_padded.reshape((B, D, H, W, -1))
 
         if isinstance(self.spatial_layer, RectConv3d):
-            padded_view = padded_view.transpose(1, 4)
-            padded_view = padded_view.transpose(2, 4)
-            padded_view = padded_view.transpose(3, 4)
-            modulated = self.spatial_layer.forward(padded_view)
+            weighted_view = weighted_view.transpose(1, 4)
+            weighted_view = weighted_view.transpose(2, 4)
+            weighted_view = weighted_view.transpose(3, 4)
+            modulated = self.spatial_layer.forward(weighted_view)
             modulated = modulated.transpose(3, 4)
             modulated = modulated.transpose(2, 4)
             modulated = modulated.transpose(1, 4)
             modulated = modulated.reshape((B, D, H, W, -1))
         else:
-            flat_view = padded_view.reshape((-1, padded_view.shape[-1]))
+            flat_view = weighted_view.reshape((-1, weighted_view.shape[-1]))
             modulated = self.spatial_layer.forward(flat_view)
             modulated = modulated.reshape((B, D, H, W, -1))
 


### PR DESCRIPTION
## Summary
- reshape the weighted tensor before spatial modulation
- propagate weighted view through spatial layer instead of raw input

## Testing
- `pytest -q` *(fails: 18 failed, 373 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b46f3737b0832abfe6fb3a847f662f