### PR TITLE
Propagate modulated branch gradients through weight layer

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -452,18 +452,48 @@ class LocalStateNetwork:
         padded_raw = self._cached_padded_raw
         B, D, H, W, _, _, _ = padded_raw.shape
 
-        # Gradient through weight layer
+        # Gradient from the weighted branch (pre-activation)
         g_weight_layer = self.g_weight_layer.reshape((1, 1, 1, 1, 3, 3, 3))
-        grad_from_weight = grad_weighted_padded * g_weight_layer
+        grad_weighted_branch = grad_weighted_padded
+
+        # Propagate through any inner state network
+        grad_mod = grad_modulated_padded
+        if self.inner_state is not None:
+            grad_mod = self.inner_state.backward(
+                grad_weighted_branch,
+                grad_mod,
+                lambda_reg=lambda_reg,
+                smooth=smooth,
+            )
+
+        grad_mod = grad_mod.reshape((B, D, H, W, -1))
+
+        # Backward through spatial layer (modulated branch)
+        if isinstance(self.spatial_layer, RectConv3d):
+            grad_mod = grad_mod.transpose(1, 4)
+            grad_mod = grad_mod.transpose(2, 4)
+            grad_mod = grad_mod.transpose(3, 4)
+            grad_padded_view = self.spatial_layer.backward(grad_mod)
+            grad_padded_view = grad_padded_view.transpose(3, 4)
+            grad_padded_view = grad_padded_view.transpose(2, 4)
+            grad_padded_view = grad_padded_view.transpose(1, 4)
+            grad_from_mod = grad_padded_view.reshape((B, D, H, W, 3, 3, 3))
+        else:
+            flat_grad = grad_mod.reshape((-1, grad_mod.shape[-1]))
+            grad_flat_in = self.spatial_layer.backward(flat_grad)
+            grad_from_mod = grad_flat_in.reshape((B, D, H, W, 3, 3, 3))
+
+        # Combine gradients from weighted and modulated branches
+        total_grad = grad_weighted_branch + grad_from_mod
 
         # Accumulate gradients for g_weight_layer and g_bias_layer
-        grad_weight = (grad_weighted_padded * padded_raw).sum(dim=(0, 1, 2, 3))
+        grad_weight = (total_grad * padded_raw).sum(dim=(0, 1, 2, 3))
         if getattr(self.g_weight_layer, "_grad", None) is None:
             self.g_weight_layer._grad = grad_weight
         else:
             self.g_weight_layer._grad = self.g_weight_layer._grad + grad_weight
 
-        grad_bias = grad_weighted_padded.sum(dim=(0, 1, 2, 3))
+        grad_bias = total_grad.sum(dim=(0, 1, 2, 3))
         if getattr(self.g_bias_layer, "_grad", None) is None:
             self.g_bias_layer._grad = grad_bias
         else:
@@ -492,34 +522,8 @@ class LocalStateNetwork:
             else:
                 self.g_weight_layer._grad = self.g_weight_layer._grad + lambda_reg * reg_grad
 
-        # Propagate through any inner state network
-        grad_mod = grad_modulated_padded
-        if self.inner_state is not None:
-            grad_mod = self.inner_state.backward(
-                grad_weighted_padded,
-                grad_mod,
-                lambda_reg=lambda_reg,
-                smooth=smooth,
-            )
-
-        grad_mod = grad_mod.reshape((B, D, H, W, -1))
-
-        # Backward through spatial layer
-        if isinstance(self.spatial_layer, RectConv3d):
-            grad_mod = grad_mod.transpose(1, 4)
-            grad_mod = grad_mod.transpose(2, 4)
-            grad_mod = grad_mod.transpose(3, 4)
-            grad_padded_view = self.spatial_layer.backward(grad_mod)
-            grad_padded_view = grad_padded_view.transpose(3, 4)
-            grad_padded_view = grad_padded_view.transpose(2, 4)
-            grad_padded_view = grad_padded_view.transpose(1, 4)
-            grad_from_mod = grad_padded_view.reshape((B, D, H, W, 3, 3, 3))
-        else:
-            flat_grad = grad_mod.reshape((-1, grad_mod.shape[-1]))
-            grad_flat_in = self.spatial_layer.backward(flat_grad)
-            grad_from_mod = grad_flat_in.reshape((B, D, H, W, 3, 3, 3))
-
-        grad_input = grad_from_weight + grad_from_mod
+        # Gradient with respect to the original padded_raw
+        grad_input = total_grad * g_weight_layer
 
         # Clear cached tensors
         self._cached_padded_raw = None


### PR DESCRIPTION
## Summary
- Combine weighted and modulated branch gradients in `LocalStateNetwork.backward`
- Accumulate weight and bias gradients using the total gradient
- Return input gradients based on combined branch contributions

## Testing
- `pytest` *(fails: 19 failed, 372 passed, 17 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68b46f38be88832aa927c6b076f7840a