### PR TITLE
Label RectConv3d spatial layer in LocalStateNetwork

### DIFF
--- a/src/common/tensors/abstract_convolution/local_state_network.py
+++ b/src/common/tensors/abstract_convolution/local_state_network.py
@@ -224,8 +224,8 @@ class LocalStateNetwork:
                 padding=1,
                 like=like,
                 bias=spatial_bias,
+                _label_prefix=f"{_label_prefix+'.' if _label_prefix else ''}LocalStateNetwork.spatial_layer",
             )
-            # RectConv3d does not have learnable parameters by default, but if it did, label them here
             self.inner_state = LocalStateNetwork(
                 metric_tensor_func,
                 grid_shape,


### PR DESCRIPTION
## Summary
- Pass `_label_prefix` to `RectConv3d` within `LocalStateNetwork` for consistent parameter labelling
- Remove outdated comment about `RectConv3d` learnable parameters

## Testing
- `pytest -q` *(fails: KeyboardInterrupt during SymPy evaluation)*

------
https://chatgpt.com/codex/tasks/task_e_68b49557581c832a908d3c5702756790