### PR TITLE
Advise targeted pytest suites in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ All modes must share the same primitive op definitions; only orchestration diffe
 - **src/visualizations** — reel and cassette playback demos.
 - **tests** — pytest suite covering analogue fidelity, compiler features and machine behaviour.
 
-Always run `pytest` before committing; new code must emit audible PCM and honour §§6–7.
+Run targeted `pytest` suites for the modules you touch before committing; new code must emit audible PCM and honour §§6–7.
 
 ---
 

--- a/src/common/tensors/AGENTS.md
+++ b/src/common/tensors/AGENTS.md
@@ -15,7 +15,7 @@ This directory hosts the implementations of tensor operations for different nume
 
 **Important:** Each backend must implement `_apply_operator` from `AbstractTensor`. This single method handles all arithmetic primitives. Avoid creating additional bespoke operator helpers – Python's magic methods already route standard arithmetic through `_apply_operator`.
 
-Follow the repository coding standards and remember to run the test suite after modifications.
+Follow the repository coding standards and run targeted `pytest` tests after modifications.
 
 ## Development Ethos
 


### PR DESCRIPTION
## Summary
- Adjust root agent guidelines to encourage running only relevant pytest suites before committing
- Update tensor backend agent guidance to specify targeted pytest testing after modifications

## Testing
- `pytest tests/test_analog_stub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a0fa116c832a944d109db4bdd906