### PR TITLE
Add broadcast PID gradient controller and SGD optimizer

### DIFF
--- a/src/common/tensors/abstract_nn/optimizer.py
+++ b/src/common/tensors/abstract_nn/optimizer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Dict, List, Tuple
 from ..abstraction import AbstractTensor as AT
 from .utils import zeros_like
+from ..bpid import BPID
 
 
 class Adam:
@@ -95,4 +96,18 @@ def adam_step(
     return p_new, m_new, v_new, t_new
 
 
-__all__ = ["Adam", "adam_step"]
+class BPIDSGD:
+    """SGD optimizer with broadcast PID gradient processing."""
+
+    def __init__(self, params: List[AT], lr: float = 1e-2,
+                 kp: float = 1.0, ki: float = 0.0, kd: float = 0.0):
+        self.lr = lr
+        self.pid = BPID(kp, ki, kd)
+
+    def step(self, params: List[AT], grads: List[AT]) -> List[AT]:
+        adj = self.pid.step(params, grads)
+        lr = self.lr
+        return [p - lr * g for p, g in zip(params, adj)]
+
+
+__all__ = ["Adam", "adam_step", "BPIDSGD"]

--- a/src/common/tensors/bpid.py
+++ b/src/common/tensors/bpid.py
@@ -1,0 +1,71 @@
+"""Broadcast PID controller for elementwise tensor updates.
+
+This module provides the :class:`BPID` class which maintains a per-parameter
+proportional–integral–derivative controller.  The controller operates elementwise
+on :class:`AbstractTensor` gradients and returns adjusted gradients that can be
+fed into a simple optimizer such as SGD.
+
+The implementation stores integral and previous-error state for each parameter
+using its ``id`` to remain robust even if the caller supplies a new parameter
+list every step.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .abstraction import AbstractTensor as AT
+from .abstract_nn.utils import zeros_like
+
+
+class BPID:
+    """Broadcast PID controller for tensors.
+
+    Parameters are tracked by ``id`` so the state remains consistent even when
+    the parameter list is re-created between steps.
+    """
+
+    def __init__(self, kp: float = 1.0, ki: float = 0.0, kd: float = 0.0):
+        self.kp = float(kp)
+        self.ki = float(ki)
+        self.kd = float(kd)
+        self._integral: Dict[int, AT] = {}
+        self._prev_error: Dict[int, AT] = {}
+
+    def reset(self) -> None:
+        """Clear all accumulated state."""
+        self._integral.clear()
+        self._prev_error.clear()
+
+    def _init_params(self, params: List[AT]) -> None:
+        for p in params:
+            key = id(p)
+            if key not in self._integral or self._integral[key].shape != p.shape:
+                self._integral[key] = zeros_like(p)
+                self._prev_error[key] = zeros_like(p)
+
+    def step(self, params: List[AT], grads: List[AT]) -> List[AT]:
+        """Process gradients through the PID controller.
+
+        Parameters
+        ----------
+        params:
+            List of parameter tensors corresponding to ``grads``.
+        grads:
+            Raw gradient tensors (error terms).
+        """
+        self._init_params(params)
+        kp, ki, kd = self.kp, self.ki, self.kd
+        out: List[AT] = []
+        for p, g in zip(params, grads):
+            key = id(p)
+            integ = self._integral[key] + g
+            deriv = g - self._prev_error[key]
+            adjusted = kp * g + ki * integ + kd * deriv
+            self._integral[key] = integ
+            self._prev_error[key] = g
+            out.append(adjusted)
+        return out
+
+
+__all__ = ["BPID"]

--- a/tests/test_bpid_sgd.py
+++ b/tests/test_bpid_sgd.py
@@ -1,0 +1,14 @@
+from src.common.tensors.abstract_nn.optimizer import BPIDSGD
+from src.common.tensors.abstraction import AbstractTensor as AT
+
+
+def test_bpid_sgd_integral_accumulation():
+    p = AT.get_tensor([0.0])
+    g = AT.get_tensor([1.0])
+    opt = BPIDSGD([p], lr=1.0, kp=0.0, ki=1.0, kd=0.0)
+    new_p = opt.step([p], [g])[0]
+    AT.copyto(p, new_p)
+    assert p.tolist() == [-1.0]
+    new_p = opt.step([p], [g])[0]
+    AT.copyto(p, new_p)
+    assert p.tolist() == [-3.0]


### PR DESCRIPTION
## Summary
- add standalone BPID class for per-parameter PID gradient processing
- wire BPIDSGD optimizer that combines broadcast PID with SGD
- cover integral accumulation behavior with unit test

## Testing
- `pytest tests/test_replay_training_step.py tests/test_bpid_sgd.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4b0ba2f0c832aa3ebb6246ccd83f5