### PR TITLE
Handle ragged parameter grids in Riemann demo

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -554,7 +554,9 @@ def main(
                 p_img = p.reshape(p.shape[0], -1)
                 g_img = g.reshape(g.shape[0], -1)
                 pairs.append(AT.cat([p_img, g_img], dim=1))
-            params_grads_frame = AT.cat(pairs, dim=0) if pairs else AT.zeros((1, 1))
+            params_grads_frame = (
+                AT.pad_cat(pairs, dim=0) if pairs else AT.zeros((1, 1))
+            )
 
             frame_cache["input_prediction"].append(ip_frame)
             frame_cache["params_grads"].append(params_grads_frame)

--- a/src/common/tensors/autograd.py
+++ b/src/common/tensors/autograd.py
@@ -7,7 +7,11 @@ def requires_grad_(self, requires_grad: bool = True):
     """Enable or disable gradient tracking on this tensor."""
     self._requires_grad = requires_grad
     tape = getattr(self, "_tape", None)
-    if tape is not None:
+    if requires_grad:
+        if tape is None:
+            from .autograd import autograd as _autograd  # lazy to avoid cycles
+            tape = _autograd.tape
+            self._tape = tape
         tape.create_tensor_node(self)
     return self
 


### PR DESCRIPTION
## Summary
- Use `pad_cat` when assembling parameter/gradient frames in `riemann_convolutional_demo`
- Register tensors with the autograd tape when enabling `requires_grad`

## Testing
- `python -m src.common.tensors.abstract_convolution.riemann_convolutional_demo --max-epochs 1 --viz-every 1000`
- `pytest tests/common/tensors -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c80cf790832aad6c615887e5d4ca