### PR TITLE
Handle 1D parameter images in Riemann demo

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -609,6 +609,9 @@ def main(
                     p_img = p_img.mean(axis=0)
                 if g_img.ndim == 3:
                     g_img = g_img.mean(axis=0)
+                # Ensure images have at least 2 dimensions for concatenation
+                p_img = np.atleast_2d(p_img)
+                g_img = np.atleast_2d(g_img)
                 # Normalize and convert to RGB
                 p_img = (_normalize(p_img) * 255).astype(np.uint8)
                 g_img = (_normalize(g_img) * 255).astype(np.uint8)

--- a/tests/test_laplace_nd.py
+++ b/tests/test_laplace_nd.py
@@ -17,7 +17,7 @@ def test_laplace_builds_with_numpy():
         coordinate_system="rectangular", N_u=N, N_v=N, N_w=N, Lx=Lx, Ly=Ly, Lz=Lz, device="cpu",
     )
     BL = laplace.BuildLaplace3D(grid_domain=grid_domain, precision=None, resolution=N)
-    L_dense, L_scipy = BL.build_general_laplace(
+    L_dense, L_scipy, _ = BL.build_general_laplace(
         grid_u=grid_u,
         grid_v=grid_v,
         grid_w=grid_w,
@@ -89,7 +89,7 @@ def test_compute_partials_and_normals_strict(monkeypatch):
     )
     BL = laplace.BuildLaplace3D(grid_domain=grid_domain, precision=None, resolution=N)
 
-    laplacian_tensor, laplacian_sparse = BL.build_general_laplace(
+    laplacian_tensor, laplacian_sparse, _ = BL.build_general_laplace(
         grid_u=grid_u,
         grid_v=grid_v,
         grid_w=grid_w,


### PR DESCRIPTION
## Summary
- Prevent axis errors in `riemann_convolutional_demo` when visualizing 1D parameter and gradient arrays
- Update Laplace tests to unpack the package returned from `build_general_laplace`

## Testing
- `pytest tests/test_laplace_and_local_state_network_gradients.py::test_laplace_gradient -q`
- `pytest tests/test_laplace_nd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4cf735dd0832a824c9412cc967fc5