### PR TITLE
Pad parameter visuals in Riemann demo

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -653,7 +653,12 @@ def main(
                 pair = np.concatenate([p_img, g_img], axis=-1)
                 pairs.append(pair)
             if pairs:
-                params_grads_frame = np.concatenate(pairs, axis=0)
+                max_w = max(pair.shape[1] for pair in pairs)
+                padded_pairs = [
+                    np.pad(pair, ((0, 0), (0, max_w - pair.shape[1])), mode="constant")
+                    for pair in pairs
+                ]
+                params_grads_frame = np.concatenate(padded_pairs, axis=0)
             else:
                 params_grads_frame = np.zeros((h, w * 2), dtype=np.uint8)
 


### PR DESCRIPTION
## Summary
- pad parameter/gradient visualization frames so concatenation succeeds

## Testing
- `pytest tests/test_riemann_regularization.py -q`
- `pytest tests/test_riemann_grid_block.py -q` *(fails: No gradient found for input at index 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d573bac4832a84f15fba458318c1