### PR TITLE
feat: add training controls to riemann demo

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -17,12 +17,15 @@ from .ndpca3transform import PCABasisND, fit_metric_pca
 from ..abstraction import AbstractTensor
 from ..autograd import autograd
 from ..riemann.geometry_factory import build_geometry
-from src.common.tensors.abstract_nn.optimizer import BPIDSGD, Adam
+# from src.common.tensors.abstract_nn.optimizer import BPIDSGD  # TODO: optional later
+from src.common.tensors.abstract_nn.optimizer import Adam, SGD
 import numpy as np
 from pathlib import Path
 from skimage import measure
 from .laplace_nd import BuildLaplace3D
 import os
+import math
+import time
 from PIL import Image
 import threading
 from .render_cache import FrameCache
@@ -342,6 +345,7 @@ def build_config():
 
 def training_worker(
     frame_cache: FrameCache,
+    shared_state: dict,
     config=None,
     viz_every=1,
     low_entropy_every=5,
@@ -494,11 +498,29 @@ def training_worker(
 
     params, _ = collect_params_and_grads()
 
-    optimizer = Adam(params, lr=5e-2)
+    def init_optimizer(name: str, params, lr: float):
+        name_l = name.lower()
+        if name_l == "sgd":
+            return SGD(params, lr=lr)
+        # if name_l == "bpidsgd":
+        #     return BPIDSGD(params, lr=lr)  # disabled: produces NaNs
+        return Adam(params, lr=lr)
+
+    opt_name = shared_state.get("optimizer", "Adam")
+    lr = shared_state.get("lr", 5e-2)
+    optimizer = init_optimizer(opt_name, params, lr)
+    current_opt, current_lr = opt_name, lr
     loss_fn = lambda y, t: ((y - t) ** 2).mean() * 100
     for epoch in range(1, max_epochs + 1):
         if stop_event is not None and stop_event.is_set():
             break
+        while shared_state.get("epoch_limit", max_epochs) < epoch:
+            if stop_event is not None and stop_event.is_set():
+                break
+            time.sleep(0.1)
+        if stop_event is not None and stop_event.is_set():
+            break
+        params, _ = collect_params_and_grads()
         # Zero gradients for all params
         for p in params:
             if hasattr(p, 'zero_grad'):
@@ -533,6 +555,16 @@ def training_worker(
         lsn.backward(grad_w, grad_m, lambda_reg=0.5)
         # Re-collect params and grads (in case new tensors were created)
         params, grads = collect_params_and_grads()
+        new_opt = shared_state.get("optimizer", current_opt)
+        new_lr = shared_state.get("lr", current_lr)
+        if (
+            shared_state.get("reset_opt")
+            or new_opt != current_opt
+            or new_lr != current_lr
+        ):
+            optimizer = init_optimizer(new_opt, params, new_lr)
+            current_opt, current_lr = new_opt, new_lr
+            shared_state["reset_opt"] = False
         if deep_research:
             for i, p in enumerate(params):
                 print(f"[DEEP-RESEARCH] param {i}:", _to_numpy(p))
@@ -671,7 +703,13 @@ def training_worker(
         stop_event.set()
 
 
-def display_worker(frame_cache: FrameCache, stop_event: threading.Event, update_ms: int = 100) -> None:
+def display_worker(
+    frame_cache: FrameCache,
+    stop_event: threading.Event,
+    shared_state: dict,
+    update_ms: int = 100,
+    max_epochs: int | None = None,
+) -> None:
     """Simple Tkinter UI that streams cached frames to a live window.
 
     Parameters
@@ -704,6 +742,59 @@ def display_worker(frame_cache: FrameCache, stop_event: threading.Event, update_
     row_frame.pack(side=tk.LEFT)
     col_frame = tk.Frame(controls)
     col_frame.pack(side=tk.LEFT)
+
+    # Optimizer selection
+    opt_var = tk.StringVar(value=shared_state.get("optimizer", "Adam"))
+    opt_menu = tk.OptionMenu(controls, opt_var, "Adam", "SGD")  # "BPIDSGD" disabled
+    opt_menu.pack(side=tk.LEFT)
+
+    def on_opt_change(*_):
+        shared_state["optimizer"] = opt_var.get()
+        shared_state["reset_opt"] = True
+
+    opt_var.trace_add("write", on_opt_change)
+    tk.Button(controls, text="Reset Optimizer", command=lambda: shared_state.__setitem__("reset_opt", True)).pack(side=tk.LEFT)
+
+    # Learning rate logarithmic slider
+    lr_var = tk.DoubleVar(value=math.log10(shared_state.get("lr", 5e-2)))
+    lr_scale = tk.Scale(
+        controls,
+        from_=-5,
+        to=0,
+        resolution=0.1,
+        orient=tk.HORIZONTAL,
+        variable=lr_var,
+        label="log10 lr",
+    )
+    lr_scale.pack(side=tk.LEFT)
+    lr_label = tk.Label(controls, text=f"lr={shared_state.get('lr', 5e-2):.1e}")
+    lr_label.pack(side=tk.LEFT)
+
+    def on_lr_change(*_):
+        lr = 10 ** lr_var.get()
+        shared_state["lr"] = lr
+        shared_state["reset_opt"] = True
+        lr_label.config(text=f"lr={lr:.1e}")
+
+    lr_var.trace_add("write", on_lr_change)
+
+    # Epoch limit slider
+    cap_max = max_epochs if max_epochs is not None else 1
+    epoch_cap_var = tk.IntVar(value=shared_state.get("epoch_limit", cap_max))
+    epoch_scale = tk.Scale(
+        controls,
+        from_=1,
+        to=cap_max,
+        orient=tk.HORIZONTAL,
+        variable=epoch_cap_var,
+        label="Epoch Limit",
+    )
+    epoch_scale.pack(side=tk.LEFT)
+
+    def on_epoch_change(*_):
+        shared_state["epoch_limit"] = epoch_cap_var.get()
+
+    epoch_cap_var.trace_add("write", on_epoch_change)
 
     row_vars = []
     row_menus = []
@@ -819,8 +910,15 @@ def main(
     frame_cache = FrameCache(target_height=target_height, target_width=target_width)
     Path(output_dir).mkdir(parents=True, exist_ok=True)
     stop_event = threading.Event()
+    shared_state = {
+        "epoch_limit": max_epochs,
+        "optimizer": "Adam",
+        "lr": 5e-2,
+        "reset_opt": False,
+    }
     args = (
         frame_cache,
+        shared_state,
         config,
         viz_every,
         low_entropy_every,
@@ -835,7 +933,7 @@ def main(
     )
     worker = threading.Thread(target=training_worker, args=args)
     worker.start()
-    display_worker(frame_cache, stop_event, update_ms=update_ms)
+    display_worker(frame_cache, stop_event, shared_state, update_ms=update_ms, max_epochs=max_epochs)
     worker.join()
     frame_cache.process_queue()
     frame_cache.save_animation("input_prediction", os.path.join(output_dir, "input_prediction.png"))

--- a/src/common/tensors/abstract_nn/optimizer.py
+++ b/src/common/tensors/abstract_nn/optimizer.py
@@ -96,6 +96,17 @@ def adam_step(
     return p_new, m_new, v_new, t_new
 
 
+class SGD:
+    """Vanilla stochastic gradient descent optimizer."""
+
+    def __init__(self, params: List[AT], lr: float = 1e-2):
+        self.lr = lr
+
+    def step(self, params: List[AT], grads: List[AT]) -> List[AT]:
+        lr = self.lr
+        return [p - lr * g for p, g in zip(params, grads)]
+
+
 class BPIDSGD:
     """SGD optimizer with broadcast PID gradient processing."""
 
@@ -110,4 +121,4 @@ class BPIDSGD:
         return [p - lr * g for p, g in zip(params, adj)]
 
 
-__all__ = ["Adam", "adam_step", "BPIDSGD"]
+__all__ = ["Adam", "adam_step", "BPIDSGD", "SGD"]

--- a/tests/test_bpid_sgd.py
+++ b/tests/test_bpid_sgd.py
@@ -1,4 +1,4 @@
-from src.common.tensors.abstract_nn.optimizer import BPIDSGD
+from src.common.tensors.abstract_nn.optimizer import BPIDSGD, SGD
 from src.common.tensors.abstraction import AbstractTensor as AT
 
 
@@ -12,3 +12,11 @@ def test_bpid_sgd_integral_accumulation():
     new_p = opt.step([p], [g])[0]
     AT.copyto(p, new_p)
     assert p.tolist() == [-3.0]
+
+
+def test_sgd_step():
+    p = AT.get_tensor([0.0])
+    g = AT.get_tensor([1.0])
+    opt = SGD([p], lr=0.1)
+    new_p = opt.step([p], [g])[0]
+    assert new_p.tolist() == [-0.1]


### PR DESCRIPTION
## Summary
- replace BPIDSGD with standard SGD optimizer and comment out unstable BPIDSGD
- expose Adam/SGD selection in Riemann demo UI and add unit test for SGD

## Testing
- `pytest tests/test_bpid_sgd.py tests/test_riemann_regularization.py tests/test_riemann_grid_block.py` (1 failing: ValueError: No gradient found for input at index 1)


------
https://chatgpt.com/codex/tasks/task_e_68b50cbb9a98832aa3230353a22671ee