### PR TITLE
Prevent control redraw in Riemann demo GUI

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -853,23 +853,31 @@ def display_worker(
             data = (data - mn) / (mx - mn + 1e-8)
         return (data * 255).clip(0, 255).astype(np.uint8)
 
+    last_sources: list[str] = []
+    last_types: list[str] = []
+
     def refresh_menus():
+        nonlocal last_sources, last_types
         sources = frame_cache.available_sources()
-        for var, menu in zip(row_vars, row_menus):
-            m = menu["menu"]
-            m.delete(0, "end")
-            for s in sources:
-                m.add_command(label=s, command=tk._setit(var, s))
-            if var.get() not in sources and sources:
-                var.set(sources[0])
+        if sources != last_sources:
+            for var, menu in zip(row_vars, row_menus):
+                m = menu["menu"]
+                m.delete(0, "end")
+                for s in sources:
+                    m.add_command(label=s, command=tk._setit(var, s))
+                if var.get() not in sources and sources:
+                    var.set(sources[0])
+            last_sources = sources
         types = frame_cache.available_types()
-        for var, menu in zip(col_vars, col_menus):
-            m = menu["menu"]
-            m.delete(0, "end")
-            for t in types:
-                m.add_command(label=t, command=tk._setit(var, t))
-            if var.get() not in types and types:
-                var.set(types[0])
+        if types != last_types:
+            for var, menu in zip(col_vars, col_menus):
+                m = menu["menu"]
+                m.delete(0, "end")
+                for t in types:
+                    m.add_command(label=t, command=tk._setit(var, t))
+                if var.get() not in types and types:
+                    var.set(types[0])
+            last_types = types
 
     frame_index = 0
 


### PR DESCRIPTION
## Summary
- Cache available sources and frame types in Riemann demo GUI to avoid unnecessary menu rebuilds
- Rebuild option menus only when data changes so controls stay responsive while images update

## Testing
- `pytest tests/test_geometry_factory.py tests/test_riemann_grid_block.py tests/test_riemann_regularization.py tests/test_riemann_pipeline_grad.py -q` *(fails: No gradient found for input at index 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b511838818832a8c0b0e9441612607