### PR TITLE
Unify frame cache tiling and add group compositing

### DIFF
--- a/tests/test_frame_cache_group.py
+++ b/tests/test_frame_cache_group.py
@@ -1,0 +1,12 @@
+import numpy as np
+from src.common.tensors.abstract_convolution.render_cache import FrameCache
+
+
+def test_compose_group_enforces_tile_size():
+    cache = FrameCache()
+    cache.enqueue("param0_grad", np.zeros((2, 3), dtype=np.uint8))
+    cache.enqueue("param1_grad", np.zeros((3, 2), dtype=np.uint8))
+    cache.process_queue()
+    assert cache.tile_height == 16 and cache.tile_width == 24
+    grid = cache.compose_group("grads")
+    assert grid.shape == (16, 48)


### PR DESCRIPTION
## Summary
- Track a common tile size in `FrameCache`, resizing mismatched frames and exposing a `grid` option for grouped layouts
- Add `FrameCache.compose_group` to arrange group frames in a near-square grid and integrate it into the GUI
- Pad parameter and gradient visuals to a global target size before enqueueing during training

## Testing
- `pytest tests/test_vignette_mask.py tests/test_frame_cache_group.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5335ca990832abc325a14cd3eddfe