### PR TITLE
Pad parameter tiles to common size in frame cache

### DIFF
--- a/tests/test_frame_cache_group.py
+++ b/tests/test_frame_cache_group.py
@@ -2,11 +2,10 @@ import numpy as np
 from src.common.tensors.abstract_convolution.render_cache import FrameCache
 
 
-def test_compose_group_enforces_tile_size():
+def test_compose_group_pads_tiles_to_common_size():
     cache = FrameCache()
     cache.enqueue("param0_grad", np.zeros((2, 3), dtype=np.uint8))
     cache.enqueue("param1_grad", np.zeros((3, 2), dtype=np.uint8))
     cache.process_queue()
-    assert cache.tile_height == 16 and cache.tile_width == 24
     grid = cache.compose_group("grads")
-    assert grid.shape == (16, 48)
+    assert grid.shape == (24, 48)


### PR DESCRIPTION
## Summary
- stop enforcing a global tile size when enqueuing frames
- pad parameter and gradient tiles to a common size when composing groups
- update tests for new padding behaviour

## Testing
- `pytest tests/test_frame_cache_group.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b537f2ad90832aa2cca1c0984e220b