### PR TITLE
Add pluggable learning tasks and loss composer

### DIFF
--- a/learning_tasks/__init__.py
+++ b/learning_tasks/__init__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import SimpleNamespace
+
+
+def get_task(name: str) -> SimpleNamespace:
+    """Return helpers for the named learning task.
+
+    The returned namespace exposes ``pump_queue``, ``build_loss_composer`` and
+    ``num_logits``.  Tasks are loaded lazily to keep optional dependencies
+    isolated.
+    """
+
+    mod = import_module(f"learning_tasks.{name}_task")
+    return SimpleNamespace(
+        pump_queue=mod.pump_queue,
+        build_loss_composer=getattr(mod, "build_loss_composer"),
+        num_logits=getattr(mod, "NUM_LOGITS", 0),
+    )

--- a/learning_tasks/loss_composer.py
+++ b/learning_tasks/loss_composer.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Callable, List, Tuple
+
+
+class LossComposer:
+    """Compose multiple loss components into a single scalar.
+
+    Components are added via :meth:`add` with a slice selecting the predicted
+    channels, a ``target_fn`` that derives the matching target tensor, and a
+    ``loss_fn`` that produces a scalar loss given ``(pred, target, categories)``.
+    """
+
+    def __init__(self) -> None:
+        self._components: List[Tuple[slice, Callable, Callable]] = []
+
+    def add(
+        self,
+        pred_slice: slice,
+        target_fn: Callable,
+        loss_fn: Callable,
+    ) -> None:
+        """Register a loss component.
+
+        Parameters
+        ----------
+        pred_slice:
+            Slice applied along the channel dimension of the network output.
+        target_fn:
+            Function ``target_fn(target, categories)`` returning the tensor to
+            compare against ``pred_slice``.
+        loss_fn:
+            Callable ``loss_fn(pred, target, categories)`` yielding a scalar
+            loss value.
+        """
+
+        self._components.append((pred_slice, target_fn, loss_fn))
+
+    def __call__(self, y, target, categories) -> object:
+        total = 0
+        for pred_slice, target_fn, loss_fn in self._components:
+            pred_part = y[:, pred_slice]
+            tgt_part = target_fn(target, categories)
+            total = total + loss_fn(pred_part, tgt_part, categories)
+        return total

--- a/learning_tasks/md5_unrolled_task/__init__.py
+++ b/learning_tasks/md5_unrolled_task/__init__.py
@@ -21,10 +21,13 @@ from queue import Queue
 from typing import Dict, List, Tuple
 
 import numpy as np
+from learning_tasks.loss_composer import LossComposer
 
 # MD5 constants
 S = [7, 12, 17, 22] * 4 + [5, 9, 14, 20] * 4 + [4, 11, 16, 23] * 4 + [6, 10, 15, 21] * 4
 K = [int(abs(math.sin(i + 1)) * (1 << 32)) & 0xFFFFFFFF for i in range(64)]
+
+NUM_LOGITS = 0
 
 
 def _left_rotate(x: int, c: int) -> int:
@@ -134,3 +137,15 @@ def pump_queue(
         q.put((inp, tgt, category))
         if delay:
             time.sleep(delay)
+
+
+def build_loss_composer(C: int, num_logits: int = NUM_LOGITS) -> LossComposer:
+    """Return a :class:`LossComposer` for the MD5 task."""
+
+    composer = LossComposer()
+
+    def mse(pred, tgt, _cats):
+        return ((pred - tgt) ** 2).mean()
+
+    composer.add(slice(0, C), lambda tgt, _cats: tgt, mse)
+    return composer


### PR DESCRIPTION
## Summary
- introduce a generic `LossComposer` to combine per-feature losses
- move low-entropy and MD5 task logic into dedicated modules with their own loss composers
- update Riemann demo to select tasks via `get_task`, defaulting to the MD5 (SHA) task

## Testing
- `pytest tests/test_riemann_regularization.py tests/test_riemann_pipeline_grad.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5387146a4832a8cb6d0cf628f1a57