### PR TITLE
Defer frame upscaling until display

### DIFF
--- a/tests/test_frame_cache_group.py
+++ b/tests/test_frame_cache_group.py
@@ -1,5 +1,5 @@
 import numpy as np
-from src.common.tensors.abstract_convolution.render_cache import FrameCache
+from src.common.tensors.abstract_convolution.render_cache import FrameCache, add_vignette
 
 
 def test_compose_group_pads_tiles_to_common_size():
@@ -8,4 +8,8 @@ def test_compose_group_pads_tiles_to_common_size():
     cache.enqueue("param1_grad", np.zeros((3, 2), dtype=np.uint8))
     cache.process_queue()
     grid = cache.compose_group("grads")
-    assert grid.shape == (24, 48)
+    # Stored grid remains at original resolution
+    assert grid.shape == (3, 6)
+    # Upscaling is deferred until rendering
+    upscaled = add_vignette(grid)
+    assert upscaled.shape == (24, 48)


### PR DESCRIPTION
## Summary
- Store only original-resolution frames in `FrameCache`
- Apply vignette and upscaling lazily when composing layouts or saving animations
- Update tests to reflect deferred upscaling strategy

## Testing
- `pytest tests/test_frame_cache_group.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5eedb2884832ab357c256440aa54e