### PR TITLE
Add pixel art learning tasks with spectral noise

### DIFF
--- a/learning_tasks/pixel_art_classifier_task/README.md
+++ b/learning_tasks/pixel_art_classifier_task/README.md
@@ -1,0 +1,15 @@
+# Pixel Art Classifier Task
+
+This learning task emits simple 8×8 pixel art shapes with spectral noise.
+Models receive a noisy version of one of the shapes and must classify which
+shape was chosen.
+
+Samples produced by `pump_queue` are tuples of `(input, target, category)`
+where:
+
+* `input` – noisy shape array of shape `(1, 8, 8)`.
+* `target` – the clean shape image (unused by the loss composer).
+* `category` – dictionary with `label` and `name` entries for the shape.
+
+The loss composer exposes `NUM_LOGITS` equal to the number of shapes and
+returns a cross‑entropy loss over the logits slice.

--- a/learning_tasks/pixel_art_classifier_task/__init__.py
+++ b/learning_tasks/pixel_art_classifier_task/__init__.py
@@ -1,0 +1,66 @@
+"""Pixel art classification task.
+
+Generates noisy versions of simple pixel art shapes and asks the model to
+classify which shape was chosen.  The noise shares the spectral magnitude of
+the clean shape but has randomized phase, providing different textures for each
+shape.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from queue import Queue
+from typing import Dict, Tuple
+
+import numpy as np
+from src.common.tensors.abstraction import AbstractTensor
+from src.common.tensors.abstract_nn.losses import CrossEntropyLoss
+from learning_tasks.loss_composer import LossComposer
+from learning_tasks.pixel_shapes import SHAPES, SHAPE_NAMES
+
+NUM_LOGITS = len(SHAPE_NAMES)
+
+
+def _spectral_noise(img: np.ndarray) -> np.ndarray:
+    """Generate noise sharing ``img``'s magnitude spectrum."""
+    fft = np.fft.fftn(img)
+    mag = np.abs(fft)
+    phase = np.exp(1j * np.random.uniform(0.0, 2 * np.pi, fft.shape))
+    return np.fft.ifftn(mag * phase).real
+
+
+def pump_queue(
+    q: Queue,
+    grid_shape: Tuple[int, int],
+    channels: int,
+    *,
+    stop_event: threading.Event | None = None,
+    delay: float = 0.0,
+) -> None:
+    """Continuously fill ``q`` with classification samples."""
+    while stop_event is None or not stop_event.is_set():
+        idx = int(np.random.randint(len(SHAPE_NAMES)))
+        name = SHAPE_NAMES[idx]
+        shape = SHAPES[name][None, ...]
+        inp = shape + _spectral_noise(shape[0])
+        tgt = shape
+        category: Dict[str, int | str] = {"label": idx, "name": name}
+        q.put((inp, tgt, category))
+        if delay:
+            time.sleep(delay)
+
+
+def build_loss_composer(C: int, num_logits: int = NUM_LOGITS) -> LossComposer:
+    """Return a :class:`LossComposer` for the classifier task."""
+    ce_loss = CrossEntropyLoss()
+    AT = AbstractTensor
+    composer = LossComposer()
+
+    def cat_target(_tgt, cats):
+        return AT.get_tensor(np.array([c["label"] for c in cats]))
+
+    def ce(pred, tgt, _cats):
+        return ce_loss(pred.reshape(len(tgt), num_logits), tgt)
+
+    composer.add(slice(0, num_logits), cat_target, ce)
+    return composer

--- a/learning_tasks/pixel_art_reconstruct_task/README.md
+++ b/learning_tasks/pixel_art_reconstruct_task/README.md
@@ -1,0 +1,14 @@
+# Pixel Art Reconstruction Task
+
+This task provides latent noise fields whose spectral magnitude matches one of
+the embedded pixel art shapes.  The model must reconstruct the original shape
+from the noise.
+
+`pump_queue` yields `(input, target, category)` tuples:
+
+* `input` – spectral noise shaped like a chosen pixel art image, `(1, 8, 8)`.
+* `target` – the corresponding clean shape.
+* `category` – dictionary with `label` and `name` describing the shape.
+
+The loss composer supplies a mean‑squared error between the prediction and the
+target image.

--- a/learning_tasks/pixel_art_reconstruct_task/__init__.py
+++ b/learning_tasks/pixel_art_reconstruct_task/__init__.py
@@ -1,0 +1,53 @@
+"""Pixel art reconstruction from spectral noise."""
+from __future__ import annotations
+
+import threading
+import time
+from queue import Queue
+from typing import Dict, Tuple
+
+import numpy as np
+from learning_tasks.loss_composer import LossComposer
+from learning_tasks.pixel_shapes import SHAPES, SHAPE_NAMES
+
+NUM_LOGITS = 0
+
+
+def _spectral_noise(img: np.ndarray) -> np.ndarray:
+    """Generate noise with the magnitude spectrum of ``img``."""
+    fft = np.fft.fftn(img)
+    mag = np.abs(fft)
+    phase = np.exp(1j * np.random.uniform(0.0, 2 * np.pi, fft.shape))
+    return np.fft.ifftn(mag * phase).real
+
+
+def pump_queue(
+    q: Queue,
+    grid_shape: Tuple[int, int],
+    channels: int,
+    *,
+    stop_event: threading.Event | None = None,
+    delay: float = 0.0,
+) -> None:
+    """Continuously fill ``q`` with reconstruction samples."""
+    while stop_event is None or not stop_event.is_set():
+        idx = int(np.random.randint(len(SHAPE_NAMES)))
+        name = SHAPE_NAMES[idx]
+        shape = SHAPES[name][None, ...]
+        inp = _spectral_noise(shape[0])[None, ...]
+        tgt = shape
+        category: Dict[str, int | str] = {"label": idx, "name": name}
+        q.put((inp, tgt, category))
+        if delay:
+            time.sleep(delay)
+
+
+def build_loss_composer(C: int, num_logits: int = NUM_LOGITS) -> LossComposer:
+    """Return a :class:`LossComposer` for the reconstruction task."""
+    composer = LossComposer()
+
+    def mse(pred, tgt, _cats):
+        return ((pred - tgt) ** 2).mean()
+
+    composer.add(slice(0, C), lambda tgt, _cats: tgt, mse)
+    return composer

--- a/learning_tasks/pixel_shapes.py
+++ b/learning_tasks/pixel_shapes.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+
+# Hard-coded pixel art shapes used by multiple learning tasks.
+# Each shape is an 8x8 binary image represented as a float32 array.
+
+SQUARE = np.array(
+    [
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    dtype=np.float32,
+)
+
+TRIANGLE = np.array(
+    [
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 1, 0, 0, 0, 0],
+        [0, 0, 1, 1, 1, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    dtype=np.float32,
+)
+
+X_SHAPE = np.array(
+    [
+        [1, 0, 0, 0, 0, 0, 0, 1],
+        [0, 1, 0, 0, 0, 0, 1, 0],
+        [0, 0, 1, 0, 0, 1, 0, 0],
+        [0, 0, 0, 1, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0, 1, 0, 0],
+        [0, 1, 0, 0, 0, 0, 1, 0],
+        [1, 0, 0, 0, 0, 0, 0, 1],
+    ],
+    dtype=np.float32,
+)
+
+SHAPES = {
+    "square": SQUARE,
+    "triangle": TRIANGLE,
+    "x": X_SHAPE,
+}
+
+SHAPE_NAMES = list(SHAPES.keys())
+

--- a/tests/test_pixel_art_tasks.py
+++ b/tests/test_pixel_art_tasks.py
@@ -1,0 +1,36 @@
+import threading
+from queue import Queue
+
+import numpy as np
+
+from learning_tasks.pixel_art_classifier_task import pump_queue as clf_pump
+from learning_tasks.pixel_art_reconstruct_task import pump_queue as rec_pump
+from learning_tasks.pixel_shapes import SHAPE_NAMES, SHAPES
+
+
+def _get_one(pump):
+    q: Queue = Queue()
+    stop = threading.Event()
+    thread = threading.Thread(target=pump, args=(q, (8, 8), 1), kwargs={"stop_event": stop})
+    thread.start()
+    item = q.get(timeout=2)
+    stop.set()
+    thread.join(timeout=2)
+    return item
+
+
+def test_classifier_pump_queue_shapes():
+    inp, tgt, cat = _get_one(clf_pump)
+    assert inp.shape == (1, 8, 8)
+    assert tgt.shape == (1, 8, 8)
+    assert cat["name"] in SHAPE_NAMES
+    assert 0 <= cat["label"] < len(SHAPE_NAMES)
+
+
+def test_reconstruct_pump_queue_shapes():
+    inp, tgt, cat = _get_one(rec_pump)
+    assert inp.shape == (1, 8, 8)
+    assert tgt.shape == (1, 8, 8)
+    assert not np.allclose(inp, tgt)
+    assert cat["name"] in SHAPE_NAMES
+    assert np.array_equal(tgt[0], SHAPES[cat["name"]])


### PR DESCRIPTION
## Summary
- create shared pixel art shapes module
- add classifier task for noisy pixel art
- add reconstruction task from spectral noise
- test pump_queue output for pixel art tasks

## Testing
- `pytest tests/test_pixel_art_tasks.py tests/test_md5_unrolled_task.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6144b27b4832a88708f90cd277c88