### PR TITLE
Use pixel art classifier as default Riemann demo task

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -315,8 +315,8 @@ def build_config():
         },
         "training": {
             "B": 4,
-            "C": 3,
-            "task": "md5_unrolled",
+            "C": 1,
+            "task": "pixel_art_classifier",
             "boundary_conditions": ("dirichlet",) * 6,
             "k": 3,
             "eig_from": "g",


### PR DESCRIPTION
## Summary
- Switch Riemann demo training config to use `pixel_art_classifier` task
- Adjust default channel count to match classifier input

## Testing
- `pytest tests/test_riemann_pipeline_grad.py::test_riemann_pipeline_with_lsn_backward_updates_params -q`
- `pytest tests/test_md5_unrolled_task.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61a463244832a9dade90934d88b35