### PR TITLE
Add corrupted noise mode to pixel art classifier

### DIFF
--- a/learning_tasks/pixel_art_classifier_task/README.md
+++ b/learning_tasks/pixel_art_classifier_task/README.md
@@ -1,8 +1,15 @@
 # Pixel Art Classifier Task
 
-This learning task emits simple 8×8 pixel art shapes with spectral noise.
+This learning task emits simple 8×8 pixel art shapes with configurable noise.
 Models receive a noisy version of one of the shapes and must classify which
 shape was chosen.
+
+Two noise modes are available:
+
+* **spectral** – (default) adds noise that shares the magnitude spectrum of the
+  clean shape but uses randomized phase.
+* **corrupt** – randomly replaces a fraction of the shape's pixels with uniform
+  noise, simulating recognition from corrupted inputs.
 
 Samples produced by `pump_queue` are tuples of `(input, target, category)`
 where:

--- a/tests/test_pixel_art_tasks.py
+++ b/tests/test_pixel_art_tasks.py
@@ -8,10 +8,14 @@ from learning_tasks.pixel_art_reconstruct_task import pump_queue as rec_pump
 from learning_tasks.pixel_shapes import SHAPE_NAMES, SHAPES
 
 
-def _get_one(pump):
+def _get_one(pump, **kwargs):
     q: Queue = Queue()
     stop = threading.Event()
-    thread = threading.Thread(target=pump, args=(q, (8, 8), 1), kwargs={"stop_event": stop})
+    thread = threading.Thread(
+        target=pump,
+        args=(q, (8, 8), 1),
+        kwargs={"stop_event": stop, **kwargs},
+    )
     thread.start()
     item = q.get(timeout=2)
     stop.set()
@@ -25,6 +29,13 @@ def test_classifier_pump_queue_shapes():
     assert tgt.shape == (1, 8, 8)
     assert cat["name"] in SHAPE_NAMES
     assert 0 <= cat["label"] < len(SHAPE_NAMES)
+
+
+def test_classifier_corrupt_mode():
+    inp, tgt, _ = _get_one(clf_pump, noise_mode="corrupt")
+    assert inp.shape == (1, 8, 8)
+    assert tgt.shape == (1, 8, 8)
+    assert not np.allclose(inp, tgt)
 
 
 def test_reconstruct_pump_queue_shapes():


### PR DESCRIPTION
## Summary
- Allow pixel art classifier to choose between spectral or corrupted noise inputs
- Document noise modes in classifier README
- Test corrupted noise option in pixel art tasks

## Testing
- `pytest tests/test_pixel_art_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68b61ab16aec832a8a5934466261b3af