### PR TITLE
feat: add diamond pixel art shape

### DIFF
--- a/learning_tasks/pixel_art_classifier_task/README.md
+++ b/learning_tasks/pixel_art_classifier_task/README.md
@@ -2,7 +2,7 @@
 
 This learning task emits simple 8×8 pixel art shapes with spectral noise.
 Models receive a noisy version of one of the shapes and must classify which
-shape was chosen.
+shape was chosen. Available shapes include a square, triangle, X and diamond.
 
 Samples produced by `pump_queue` are tuples of `(input, target, category)`
 where:

--- a/learning_tasks/pixel_art_reconstruct_task/README.md
+++ b/learning_tasks/pixel_art_reconstruct_task/README.md
@@ -2,7 +2,7 @@
 
 This task provides latent noise fields whose spectral magnitude matches one of
 the embedded pixel art shapes.  The model must reconstruct the original shape
-from the noise.
+from the noise. Supported shapes are the square, triangle, X and diamond.
 
 `pump_queue` yields `(input, target, category)` tuples:
 

--- a/learning_tasks/pixel_shapes.py
+++ b/learning_tasks/pixel_shapes.py
@@ -47,10 +47,25 @@ X_SHAPE = np.array(
     dtype=np.float32,
 )
 
+DIAMOND = np.array(
+    [
+        [0, 0, 0, 1, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 1, 0, 0],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 1, 1, 1, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 1, 1, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    dtype=np.float32,
+)
+
 SHAPES = {
     "square": SQUARE,
     "triangle": TRIANGLE,
     "x": X_SHAPE,
+    "diamond": DIAMOND,
 }
 
 SHAPE_NAMES = list(SHAPES.keys())


### PR DESCRIPTION
## Summary
- add diamond shape to shared pixel art library
- mention new shape in pixel art classifier and reconstruction task docs

## Testing
- `pytest tests/test_pixel_art_tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68b61acf8414832ab698dc8942ea4135