### PR TITLE
Pool pixel art classifier logits over spatial dimensions

### DIFF
--- a/learning_tasks/pixel_art_classifier_task/README.md
+++ b/learning_tasks/pixel_art_classifier_task/README.md
@@ -19,4 +19,6 @@ where:
 * `category` – dictionary with `label` and `name` entries for the shape.
 
 The loss composer exposes `NUM_LOGITS` equal to the number of shapes and
-returns a cross‑entropy loss over the logits slice.
+returns a cross‑entropy loss over the logits slice. Logits may include spatial
+dimensions; these are globally averaged before classification so each sample
+contributes one ``num_logits`` vector.


### PR DESCRIPTION
## Summary
- pool pixel art classifier logits across spatial dimensions before applying cross-entropy
- clarify in documentation and README that spatial dims are globally averaged prior to classification

## Testing
- `pytest tests/test_pixel_art_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68b61c92c7c0832a98322c7078517ceb