### PR TITLE
Add optional pre-scaled frame cache storage

### DIFF
--- a/tests/test_frame_cache_store_scaled.py
+++ b/tests/test_frame_cache_store_scaled.py
@@ -1,0 +1,15 @@
+import numpy as np
+from src.common.tensors.abstract_convolution.render_cache import FrameCache
+
+
+def test_store_scaled_uses_preprocessed_frames():
+    cache = FrameCache(store_scaled=True)
+    frame = np.zeros((2, 3), dtype=np.uint8)
+    cache.enqueue("a", frame)
+    cache.process_queue()
+    stored = cache.cache["a"][0]
+    # add_vignette with default tile=8 expands dimensions by tile
+    assert stored.shape == (16, 24)
+    grid = cache.compose_layout([["a"]])
+    # compose_layout should not apply vignette a second time
+    assert grid.shape == stored.shape


### PR DESCRIPTION
## Summary
- allow FrameCache to store frames already upscaled with vignette using a new `store_scaled` flag
- respect the flag when composing layouts and saving animations
- test pre-scaled option to ensure frames aren't processed twice

## Testing
- `PYTHONPATH=/workspace/Turing pytest /tmp/pytest_run/test_frame_cache_group.py /tmp/pytest_run/test_frame_cache_store_scaled.py /tmp/pytest_run/test_vignette_mask.py`

------
https://chatgpt.com/codex/tasks/task_e_68b61f8282a8832a9a17b522e30b35b5