### PR TITLE
Raise error for invalid LinearBlock shape

### DIFF
--- a/src/common/tensors/abstract_nn/linear_block.py
+++ b/src/common/tensors/abstract_nn/linear_block.py
@@ -87,3 +87,6 @@ class LinearBlock:
             y = ys.reshape((B, spatial, out_dim)).swapaxes(1, 2).reshape((B, out_dim, *shape[2:]))
             return y
 
+        else:
+            raise ValueError(f"Unexpected input shape {shape}")
+

--- a/tests/test_linear_block.py
+++ b/tests/test_linear_block.py
@@ -23,3 +23,16 @@ def test_linear_block_debug():
     outputs = model.forward(inputs)
     loss = ((outputs - targets) ** 2).mean()
     loss.backward()
+
+
+def test_linear_block_invalid_shape():
+    input_dim = 4
+    output_dim = 2
+    like = AT.get_tensor()
+
+    model = LinearBlock(input_dim, output_dim, like)
+
+    bad_input = AT.randn((3, input_dim + 1))
+
+    with pytest.raises(ValueError):
+        model.forward(bad_input)


### PR DESCRIPTION
## Summary
- raise a `ValueError` when `LinearBlock.forward` receives an unsupported input shape
- add regression test ensuring invalid shapes trigger the error

## Testing
- `pytest tests/test_linear_block.py`


------
https://chatgpt.com/codex/tasks/task_e_68b621a82590832ab61a9ca7b218c0de