### PR TITLE
Preserve rendered composites when clearing frame cache

### DIFF
--- a/tests/test_frame_cache_clear.py
+++ b/tests/test_frame_cache_clear.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src.common.tensors.abstract_convolution.render_cache import FrameCache
+
+
+def test_clear_preserves_composite_cache():
+    cache = FrameCache()
+    frame = np.zeros((2, 3), dtype=np.uint8)
+    cache.enqueue("a", frame)
+    cache.process_queue()
+    grid = cache.compose_layout([["a"]])
+    cache.clear()
+    cached = cache.compose_layout([["a"]])
+    assert np.array_equal(cached, grid)


### PR DESCRIPTION
## Summary
- allow FrameCache.clear to keep previously rendered composites in memory
- simplify layout hashing so cached composites survive frame eviction
- verify composite caching persists after clear

## Testing
- `pytest tests/test_frame_cache_store_scaled.py tests/test_frame_cache_group.py tests/test_frame_cache_clear.py`


------
https://chatgpt.com/codex/tasks/task_e_68b621f6ea98832a9ebd1c8e53a558a1