### PR TITLE
Fix linear block output usage and add gradient test

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -652,8 +652,9 @@ def training_worker(
         if deep_research:
             print("[DEEP-RESEARCH] input data:", _to_numpy(x))
             print("[DEEP-RESEARCH] predicted data:", _to_numpy(y))
-        pred = y[:, :C]
-        loss = loss_composer(y, target, batch_cats)
+        pred = y
+        autograd.tape.auto_annotate_eval(pred)
+        loss = loss_composer(pred, target, batch_cats)
         LSN_loss = conv_layer.local_state_network._regularization_loss
         print(f"Epoch {epoch}: loss={loss.item()}, LSN_loss={LSN_loss.item()}")
         loss = LSN_loss + loss

--- a/src/common/tensors/abstract_nn/linear_block.py
+++ b/src/common/tensors/abstract_nn/linear_block.py
@@ -56,7 +56,7 @@ class LinearBlock:
         out_dim = int(self.model.layers[-1].W.shape[1])
 
         # Helper: robust shape tuple for AbstractTensor / numpy-backed
-        shape = xt.shape() if callable(getattr(xt, "shape", None)) else xt.shape
+        shape = x.shape() if callable(getattr(x, "shape", None)) else x.shape
         ndim = len(shape)
 
         # Case A: already 2D (N, in_dim) — just run the MLP.


### PR DESCRIPTION
## Summary
- Use full LinearBlock output in Riemann demo loss and logging
- Correct LinearBlock forward shape inference
- Add test ensuring LinearBlock participates in gradient flow

## Testing
- `pytest tests/test_linear_block.py tests/test_riemann_pipeline_grad.py::test_riemann_pipeline_linear_block_params_receive_grads -q`

------
https://chatgpt.com/codex/tasks/task_e_68b62929a1a0832a8e9ae61f92d4ee0e