### PR TITLE
Fix linear block shape handling and add gradient tests

### DIFF
--- a/src/common/tensors/abstract_nn/linear_block.py
+++ b/src/common/tensors/abstract_nn/linear_block.py
@@ -56,7 +56,7 @@ class LinearBlock:
         out_dim = int(self.model.layers[-1].W.shape[1])
 
         # Helper: robust shape tuple for AbstractTensor / numpy-backed
-        shape = xt.shape() if callable(getattr(xt, "shape", None)) else xt.shape
+        shape = x.shape() if callable(getattr(x, "shape", None)) else x.shape
         ndim = len(shape)
 
         # Case A: already 2D (N, in_dim) — just run the MLP.

--- a/tests/test_linear_block.py
+++ b/tests/test_linear_block.py
@@ -24,6 +24,12 @@ def test_linear_block_debug():
     loss = ((outputs - targets) ** 2).mean()
     loss.backward()
 
+    # Gradients should propagate to all Linear layers
+    for layer in model.model.layers:
+        assert getattr(layer, "gW", None) is not None
+        if layer.b is not None:
+            assert getattr(layer, "gb", None) is not None
+
 
 def test_linear_block_invalid_shape():
     input_dim = 4
@@ -36,3 +42,43 @@ def test_linear_block_invalid_shape():
 
     with pytest.raises(ValueError):
         model.forward(bad_input)
+
+
+def test_linear_block_last_axis_features_grad():
+    input_dim = 6
+    output_dim = 4
+    like = AT.get_tensor()
+    model = LinearBlock(input_dim, output_dim, like)
+
+    inputs = AT.randn((2, 3, input_dim), requires_grad=True)
+    targets = AT.zeros((2, 3, output_dim))
+
+    outputs = model.forward(inputs)
+    assert outputs.shape == (2, 3, output_dim)
+    loss = outputs.sum()
+    loss.backward()
+
+    for layer in model.model.layers:
+        assert getattr(layer, "gW", None) is not None
+        if layer.b is not None:
+            assert getattr(layer, "gb", None) is not None
+
+
+def test_linear_block_channels_first_grad():
+    input_dim = 5
+    output_dim = 7
+    like = AT.get_tensor()
+    model = LinearBlock(input_dim, output_dim, like)
+
+    inputs = AT.randn((4, input_dim, 2, 2), requires_grad=True)
+    targets = AT.ones((4, output_dim, 2, 2))
+
+    outputs = model.forward(inputs)
+    assert outputs.shape == (4, output_dim, 2, 2)
+    loss = ((outputs - targets) ** 2).sum()
+    loss.backward()
+
+    for layer in model.model.layers:
+        assert getattr(layer, "gW", None) is not None
+        if layer.b is not None:
+            assert getattr(layer, "gb", None) is not None


### PR DESCRIPTION
## Summary
- Use `x` for shape inference in `LinearBlock` and call `shape()` when available
- Add tests covering 2D, last-axis, and channels-first inputs to ensure gradients reach every `Linear` layer

## Testing
- `python -m pytest tests/test_linear_block.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6291820e4832a8287b380ddc4b179