### PR TITLE
Flatten LinearBlock channels-first output

### DIFF
--- a/src/common/tensors/abstract_nn/linear_block.py
+++ b/src/common/tensors/abstract_nn/linear_block.py
@@ -82,8 +82,8 @@ class LinearBlock:
             # (B, C, S) -> (B*S, C) so Linear sees C as features.
             xs = x.reshape((B, C, spatial)).swapaxes(1, 2).reshape((B * spatial, C))
             ys = self.model.forward(xs)  # (B*S, out_dim)
-            # Restore to (B, out_dim, *spatial_shape)
-            y = ys.reshape((B, spatial, out_dim)).swapaxes(1, 2).reshape((B, out_dim, *shape[2:]))
+            # Return 2-D tensor: collapse spatial locations into the feature axis.
+            y = ys.reshape((B, out_dim * spatial))
             return y
 
         else:

--- a/tests/test_linear_block.py
+++ b/tests/test_linear_block.py
@@ -71,10 +71,11 @@ def test_linear_block_channels_first_grad():
     model = LinearBlock(input_dim, output_dim, like)
 
     inputs = AT.randn((4, input_dim, 2, 2), requires_grad=True)
-    targets = AT.ones((4, output_dim, 2, 2))
+    spatial = 2 * 2
+    targets = AT.ones((4, output_dim * spatial))
 
     outputs = model.forward(inputs)
-    assert outputs.shape == (4, output_dim, 2, 2)
+    assert outputs.shape == (4, output_dim * spatial)
     loss = ((outputs - targets) ** 2).sum()
     loss.backward()
 

--- a/tests/test_linear_block_grad.py
+++ b/tests/test_linear_block_grad.py
@@ -1,15 +1,19 @@
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_nn.linear_block import LinearBlock
-from src.common.tensors.autograd import autograd, GradTape
+from src.common.tensors.autograd import autograd
 
 
 def test_linear_block_parameters_track_gradients():
-    autograd.tape = GradTape()
     like = AbstractTensor.get_tensor(0)
     block = LinearBlock(4, 2, like)
+    params = list(block.parameters())
+    for p in params:
+        autograd.tape.create_tensor_node(p)
     x = AbstractTensor.randn((3, 4), requires_grad=True)
     y = block.forward(x)
     loss = (y * y).sum()
-    params = list(block.parameters())
-    grads = autograd.grad(loss, params, allow_unused=True)
-    assert grads[0] is not None
+    loss.backward()
+    for layer in block.model.layers:
+        assert getattr(layer, "gW", None) is not None
+        if layer.b is not None:
+            assert getattr(layer, "gb", None) is not None


### PR DESCRIPTION
## Summary
- flatten spatial dimensions in `LinearBlock` case C so channels-first inputs yield 2-D outputs
- adjust `riemann_convolutional_demo` and tests to handle flattened predictions
- ensure LinearBlock in Riemann pipeline receives non-zero parameter gradients

## Testing
- `pytest tests/test_linear_block.py -q`
- `pytest tests/test_linear_block_grad.py -q`
- `pytest tests/test_riemann_pipeline_grad.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63196814c832a975964dc34bf4c10