### PR TITLE
Restore spatial dims in LinearBlock and adjust Riemann demo

### DIFF
--- a/src/common/tensors/abstract_nn/linear_block.py
+++ b/src/common/tensors/abstract_nn/linear_block.py
@@ -49,7 +49,7 @@ class LinearBlock:
 
     def parameters(self):
         return self.model.parameters()
-    def forward(self, x):
+    def forward(self, x, flatten_spatial: bool = False):
 
         # Infer the adapter I/O once so we can route shapes correctly.
         in_dim = int(self.model.layers[0].W.shape[0])
@@ -74,16 +74,17 @@ class LinearBlock:
 
         # Case C: channels-first tensor where channel axis = 1 (e.g., B,C,*,*,*).
         if ndim >= 3 and int(shape[1]) == in_dim:
-            B = int(shape[0]); C = int(shape[1])
-            # Flatten spatial dims to one axis.
+            B = int(shape[0])
+            C = int(shape[1])
             spatial = 1
             for s in shape[2:]:
                 spatial *= int(s)
-            # (B, C, S) -> (B*S, C) so Linear sees C as features.
             xs = x.reshape((B, C, spatial)).swapaxes(1, 2).reshape((B * spatial, C))
             ys = self.model.forward(xs)  # (B*S, out_dim)
-            # Return 2-D tensor: collapse spatial locations into the feature axis.
-            y = ys.reshape((B, out_dim * spatial))
+            y = ys.reshape((B, spatial, out_dim)).swapaxes(1, 2)
+            y = y.reshape((B, out_dim, *shape[2:]))
+            if flatten_spatial:
+                return y.reshape((B, out_dim * spatial))
             return y
 
         else:


### PR DESCRIPTION
## Summary
- Allow LinearBlock to preserve spatial dimensions by default with optional `flatten_spatial` flag
- Ensure Riemann convolution demo keeps unflattened predictions for PCA visualisation and flattens only for loss
- Add regression test exercising channels-first LinearBlock output and `pca_to_rgb`

## Testing
- `pytest tests/test_linear_block.py tests/test_linear_block_grad.py tests/test_riemann_pipeline_grad.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6375474cc832a8f62322081ff9fb5