### PR TITLE
Handle empty arrays in visualization normalization

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -56,6 +56,9 @@ def normalize_for_visualization(arr):
 
     arr = _to_numpy(arr)
 
+    if arr.size == 0:
+        raise ValueError("normalize_for_visualization() received an empty array")
+
     # Collapse leading batch/channel dimensions for 4D/5D (or higher) inputs
     if arr.ndim in (4, 5):
         arr = arr.mean(axis=(0, 1))

--- a/tests/test_normalize_for_visualization.py
+++ b/tests/test_normalize_for_visualization.py
@@ -1,0 +1,15 @@
+import numpy as np
+import warnings
+import pytest
+
+from src.common.tensors.abstract_convolution.riemann_convolutional_demo import (
+    normalize_for_visualization,
+)
+
+
+def test_normalize_for_visualization_empty_array():
+    arr = np.array([])
+    with warnings.catch_warnings(record=True) as w:
+        with pytest.raises(ValueError):
+            normalize_for_visualization(arr)
+    assert w == []


### PR DESCRIPTION
## Summary
- guard `normalize_for_visualization` against empty arrays
- add regression test ensuring empty input triggers `ValueError` without warnings

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_normalize_for_visualization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63f7df9a4832a960c15b1aa8c824b