### PR TITLE
Fix LinearBlock shape handling and autograd backward

### DIFF
--- a/src/common/tensors/abstract_nn/core.py
+++ b/src/common/tensors/abstract_nn/core.py
@@ -194,11 +194,12 @@ class Linear:
         autograd.tape.annotate(out, label="Linear.forward.output")
         return out
 
-    def backward(self, grad_out: AbstractTensor, x) -> AbstractTensor:
-        #if getattr(self, "_x", None) is None:
-        #    raise RuntimeError("Linear.backward called before forward")
+    def backward(self, grad_out: AbstractTensor) -> AbstractTensor:
+        if getattr(self, "_x", None) is None:
+            raise RuntimeError("Linear.backward called before forward")
+
         grad_out, added = _ensure_batch_dim(grad_out, target_ndim=2)
-        
+        x = self._x
         xT = x.permute(1, 0)
         self.gW = xT @ grad_out
         self.W._grad = self.gW


### PR DESCRIPTION
## Summary
- clean up LinearBlock.forward shape routing and channel-first handling
- rely on cached inputs in Linear.backward so autograd can call without extra args

## Testing
- `pytest tests/test_linear_block_grad.py tests/test_linear_block.py tests/test_riemann_pipeline_grad.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b67644ad4c832a9677ded560f55174