### PR TITLE
Stretch frame cache tiles to fill layout

### DIFF
--- a/tests/test_frame_cache_group.py
+++ b/tests/test_frame_cache_group.py
@@ -2,14 +2,16 @@ import numpy as np
 from src.common.tensors.abstract_convolution.render_cache import FrameCache, add_vignette
 
 
-def test_compose_group_pads_tiles_to_common_size():
+def test_compose_group_resizes_tiles_to_common_size():
     cache = FrameCache()
     cache.enqueue("param0_grad", np.zeros((2, 3), dtype=np.uint8))
-    cache.enqueue("param1_grad", np.zeros((3, 2), dtype=np.uint8))
+    cache.enqueue("param1_grad", np.full((3, 2), 255, dtype=np.uint8))
     cache.process_queue()
     grid = cache.compose_group("grads")
     # Stored grid remains at original resolution
     assert grid.shape == (3, 6)
+    # Second tile should be fully populated after resizing
+    assert np.all(grid[:, 3:] == 255)
     # Upscaling is deferred until rendering
     upscaled = add_vignette(grid)
     assert upscaled.shape == (24, 48)


### PR DESCRIPTION
## Summary
- Resize cached frames to a common tile before composing layouts so small images no longer leave empty padding
- Update group composition test to reflect tile resizing behaviour

## Testing
- `pytest tests/test_frame_cache_group.py tests/test_frame_cache_clear.py tests/test_frame_cache_store_scaled.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6ef81a670832a87258fc9d788dbf5