### PR TITLE
Fix Riemann demo animation caching

### DIFF
--- a/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
+++ b/src/common/tensors/abstract_convolution/riemann_convolutional_demo.py
@@ -1004,12 +1004,18 @@ def display_worker(
         layout = [[var.get() for var in row] for row in grid_vars]
         current_cmap = cmap_var.get()
         current_norm = norm_var.get()
-        if layout != last_layout or current_cmap != last_cmap or current_norm != last_norm or changed:
+        if layout != last_layout or current_cmap != last_cmap or current_norm != last_norm:
             frame_index = 0
             frame_cache.composite_cache.clear()
             last_layout = [row[:] for row in layout]
             last_cmap = current_cmap
             last_norm = current_norm
+        elif changed:
+            # New frames require a recomposition of the layout but should not
+            # rewind the animation.  `process_queue` already cleared the
+            # composite cache when draining the queue, so simply ensure the
+            # next composition rebuilds without resetting ``frame_index``.
+            frame_cache.composite_cache.clear()
         grid = frame_cache.compose_layout_at(layout, frame_index)
         grid = apply_colormap(grid, current_cmap)
         grid = _apply_norm(grid, current_norm)
@@ -1086,11 +1092,18 @@ def main(
     )
     worker = threading.Thread(target=training_worker, args=args)
     worker.start()
-    display_worker(frame_cache, stop_event, shared_state, update_ms=update_ms, max_epochs=max_epochs)
+    display_worker(
+        frame_cache, stop_event, shared_state, update_ms=update_ms, max_epochs=max_epochs
+    )
     worker.join()
-    #frame_cache.process_queue()
-    #frame_cache.save_animation("input_prediction", os.path.join(output_dir, "input_prediction.png"), cmap=cmap)
-    #frame_cache.save_animation("params_grads", os.path.join(output_dir, "params_grads.png"), cmap=cmap)
+    # Drain any remaining frames and export cached animations.
+    frame_cache.process_queue()
+    frame_cache.save_animation(
+        "input_prediction", os.path.join(output_dir, "input_prediction.gif"), cmap=cmap
+    )
+    frame_cache.save_animation(
+        "params_grads", os.path.join(output_dir, "params_grads.gif"), cmap=cmap
+    )
     print(f"Exported animations to the '{output_dir}/' directory.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- avoid resetting frame index when new frames arrive in Riemann demo GUI
- drain frame queue and save cached animations on exit

## Testing
- `pytest tests/test_riemann_grid_block.py tests/test_riemann_pipeline_grad.py tests/test_riemann_regularization.py` *(fails: KeyError: 'regularization')*

------
https://chatgpt.com/codex/tasks/task_e_68b6f499bcc0832aa35e7ad55482fb2c