### PR TITLE
Add skeleton modules for cached whiteboard pipeline

### DIFF
--- a/src/common/tensors/autoautograd/AGENTS.md
+++ b/src/common/tensors/autoautograd/AGENTS.md
@@ -1,0 +1,40 @@
+# Autoautograd Whiteboard Pipeline Notes
+
+This directory hosts the whiteboard cache, runtime, and related scheduling glue.
+It implements the "spot" integrator design: jobs operate on node-local state with
+per-node versions and stress-based updates.
+
+## Design Spec Recap
+- **Timeless integration**: updates depend on the multiset of impulses, not wall-clock.
+- **Node-local causality**: each node has a version counter; cache keys combine op identity with these tokens.
+- **Cache packages**: `(forward, grads)` are reusable when node versions and op identity match.
+- **Single-backward discipline**: each whiteboard session runs exactly one forward/backward pair.
+- **Queue → triage → cache-or-compute → bin → whiteboard → separate → return** pipeline batches misses by shape.
+
+## Current Implementation & Drift
+- Modules are stubs only; no cache backend, whiteboard execution, or batching logic exists yet.
+- Root-level scripts still call the legacy bridge and ignore these modules.
+- Node version tracking and stress integrator hooks are not wired, so cache safety and
+  error-relative updates are theoretical.
+- Tests fail outside of a narrow matmul case; expect breakage until the bridge and
+  scheduling layers are implemented.
+
+## Potential Issues / Compromises
+- Stubs risk diverging from the pure math spec if filled piecemeal.
+- Cache keys depend on version or value digests; without a concrete hash policy we
+  may see unintended collisions.
+- Batch whiteboard execution will require allocator pooling; failure to honour
+  the NumPy-first policy could violate `src/common/tensors/AGENTS.md`.
+- Integrator remains time-free but the rest of the repo assumes epoch counters;
+  migrating will need careful coordination.
+
+## Migration Guidance
+- Root-level scripts (`backend.py`, demos in repository root) should gradually
+  replace per-call packing with `integration/bridge_v2.push_impulses_from_op_v2`.
+- When implementing, forward results should be emitted via `ResultSink` instead of
+  printing to stdout.
+- The legacy autograd bridge can be deleted once `bridge_v2` is wired through
+  `Ops.call` and tests cover caching behaviour.
+
+Run targeted `pytest` suites after edits. Follow the NumPy-first policy and avoid
+introducing heavy dependencies.

--- a/src/common/tensors/autoautograd/__init__.py
+++ b/src/common/tensors/autoautograd/__init__.py
@@ -1,0 +1,4 @@
+"""Autoautograd runtime and cache utilities."""
+
+__all__ = []
+

--- a/src/common/tensors/autoautograd/whiteboard_cache.py
+++ b/src/common/tensors/autoautograd/whiteboard_cache.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence, Tuple, Hashable, Protocol
+
+
+@dataclass(frozen=True)
+class ParamSig:
+    """Node-local causality token for caching.
+
+    Tracks the node identifier and either a version number or a value digest.
+    """
+
+    node_id: int
+    attr: str
+    version: Optional[int] = None
+    value_digest8: Optional[bytes] = None
+
+
+@dataclass(frozen=True)
+class OpKey:
+    """Stable cache key for a local op.
+
+    Composes the operator identity with shape information, weighting policy,
+    quantized scale and residual values, and an ordered tuple of ``ParamSig``
+    instances aligned with the source identifiers.
+    """
+
+    op: str
+    k: int
+    F: int
+    weight: str
+    scale_q: int
+    residual_q: int
+    params: Tuple[ParamSig, ...]
+
+
+class CacheBackend(Protocol):
+    """Key→package storage with bounded footprint."""
+
+    def get(self, key: OpKey) -> Optional[Tuple[Any, Any]]:  # pragma: no cover - protocol stub
+        """Retrieve a cached package if available."""
+
+    def put(self, key: OpKey, y: Any, g: Any) -> None:  # pragma: no cover - protocol stub
+        """Store a cache package."""
+
+
+class WhiteboardCache:
+    """Hashed and versioned package cache.
+
+    This class is a light wrapper that constructs cache keys and delegates
+    storage duties to a provided backend implementation.
+    """
+
+    def __init__(self, store: CacheBackend) -> None:
+        """Initialize the cache with a backend store."""
+        # TODO: Wire up the backend store and any bookkeeping structures.
+        raise NotImplementedError
+
+    def make_key(
+        self,
+        *,
+        op: str,
+        src_ids: Sequence[int],
+        F: int,
+        weight: str,
+        scale: float,
+        residual: float,
+        get_attr: callable,
+        get_attr_version: Optional[callable] = None,
+        attr_name: str = "theta",
+    ) -> OpKey:
+        """Build an ``OpKey`` for a job.
+
+        The key incorporates node-local versions or value digests to maintain
+        cache correctness without reference to global epochs.
+        """
+        # TODO: Implement key construction with quantization and version lookups.
+        raise NotImplementedError
+
+    def get(self, key: OpKey) -> Optional[Tuple[Any, Any]]:
+        """Return a cached package if present."""
+        # TODO: Delegate to the backend store.
+        raise NotImplementedError
+
+    def put(self, key: OpKey, y: Any, g: Any) -> None:
+        """Insert a package into the cache."""
+        # TODO: Delegate to the backend store.
+        raise NotImplementedError
+

--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Callable, Optional, Sequence, Tuple
+
+
+class WhiteboardMode:
+    """Single-backward, non-accumulating tape scope."""
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        """Prepare any context state."""
+        # TODO: Initialize resources required for whiteboard execution.
+        raise NotImplementedError
+
+    def __enter__(self) -> "WhiteboardMode":  # pragma: no cover - context stub
+        """Enter the whiteboard mode."""
+        # TODO: Establish the environment for a single backward pass.
+        raise NotImplementedError
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context stub
+        """Tear down the whiteboard mode."""
+        # TODO: Clean up allocated resources.
+        raise NotImplementedError
+
+
+def run_op_and_grads_cached(
+    *,
+    op: str,
+    src_ids: Sequence[int],
+    weight: str,
+    scale: float,
+    residual: float,
+    get_attr: Callable[[int], Any],
+    get_attr_version: Optional[Callable[[int], Optional[int]]] = None,
+    scalarize: Optional[Callable[[Any], Any]] = None,
+) -> Tuple[Any, Any]:
+    """Return forward value and local gradients, using a cache when possible.
+
+    The implementation should consult a ``WhiteboardCache`` instance. On a cache
+    miss, it must perform a single forward and backward pass within a
+    ``WhiteboardMode`` context. The returned gradients align with ``src_ids``.
+    """
+    # TODO: Implement cache lookup and whiteboard execution.
+    raise NotImplementedError
+

--- a/src/common/tensors/graph/__init__.py
+++ b/src/common/tensors/graph/__init__.py
@@ -1,0 +1,4 @@
+"""Graph tensor view helpers."""
+
+__all__ = []
+

--- a/src/common/tensors/graph/node_attr_view.py
+++ b/src/common/tensors/graph/node_attr_view.py
@@ -1,0 +1,10 @@
+"""Re-export of the graph attribute view utilities."""
+
+from ..autoautograd.node_tensor import (
+    NodeAttrView,
+    BackendPolicy,
+    NumpyPolicy,
+)
+
+__all__ = ["NodeAttrView", "BackendPolicy", "NumpyPolicy"]
+

--- a/src/common/tensors/integration/__init__.py
+++ b/src/common/tensors/integration/__init__.py
@@ -1,0 +1,4 @@
+"""Integration bridges and adapters."""
+
+__all__ = []
+

--- a/src/common/tensors/integration/bridge_v2.py
+++ b/src/common/tensors/integration/bridge_v2.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Sequence, Optional
+
+from ..autoautograd.whiteboard_runtime import run_op_and_grads_cached
+from ..scheduling.results import OpResult, ResultSink
+
+
+def push_impulses_from_op_v2(
+    sys,
+    op: str,
+    src_ids: Sequence[int],
+    out_id: int,
+    *,
+    residual: Optional[float],
+    scale: float,
+    weight: str,
+    result_sink: Optional[ResultSink] = None,
+) -> float:
+    """Cached whiteboard path for operator execution.
+
+    This bridge should gather node attributes, compute the operator's forward
+    value and local gradients (using caching when possible), push impulses into
+    ``sys`` and optionally publish an ``OpResult``.
+    """
+    # TODO: Implement the bridge using ``run_op_and_grads_cached``.
+    raise NotImplementedError
+

--- a/src/common/tensors/ops/__init__.py
+++ b/src/common/tensors/ops/__init__.py
@@ -1,0 +1,4 @@
+"""Operator registry and definitions."""
+
+__all__ = []
+

--- a/src/common/tensors/ops/registry.py
+++ b/src/common/tensors/ops/registry.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+
+class OpRegistry:
+    """Maps op symbol → callable and its scalarization rule for gradients."""
+
+    def __init__(self) -> None:
+        """Create an empty operator registry."""
+        # TODO: Initialize internal storage for ops and scalarizers.
+        raise NotImplementedError
+
+    def register(self, name: str, fn: Callable[..., Any], *, scalarize: Callable[[Any], Any]) -> None:
+        """Register a new operator and its scalarization rule."""
+        # TODO: Store the function and scalarization callable.
+        raise NotImplementedError
+
+    def get(self, name: str) -> Callable[..., Any]:
+        """Return the operator callable associated with ``name``."""
+        # TODO: Retrieve the operator implementation.
+        raise NotImplementedError
+
+    def get_scalarize(self, name: str) -> Callable[[Any], Any]:
+        """Return the scalarization rule for ``name``."""
+        # TODO: Retrieve the scalarization function.
+        raise NotImplementedError
+

--- a/src/common/tensors/pooling/__init__.py
+++ b/src/common/tensors/pooling/__init__.py
@@ -1,0 +1,4 @@
+"""Tensor pooling and preallocation utilities."""
+
+__all__ = []
+

--- a/src/common/tensors/pooling/tensor_pool.py
+++ b/src/common/tensors/pooling/tensor_pool.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+
+class TensorPool:
+    """Preallocator keyed by ``(shape, dtype, device)``."""
+
+    def acquire(self, shape: Tuple[int, ...], *, dtype=None, device=None) -> Any:
+        """Return a tensor buffer with the requested specification."""
+        # TODO: Implement pool lookup or allocate a new buffer.
+        raise NotImplementedError
+
+    def release(self, buf: Any) -> None:
+        """Return a buffer to the pool."""
+        # TODO: Implement buffer recycling.
+        raise NotImplementedError
+
+    def observe(self, shape: Tuple[int, ...], *, dtype=None, device=None) -> None:
+        """Record allocation statistics for pre-warming."""
+        # TODO: Track allocation patterns.
+        raise NotImplementedError
+

--- a/src/common/tensors/scheduling/__init__.py
+++ b/src/common/tensors/scheduling/__init__.py
@@ -1,0 +1,4 @@
+"""Scheduling utilities for batched operation execution."""
+
+__all__ = []
+

--- a/src/common/tensors/scheduling/op_queue.py
+++ b/src/common/tensors/scheduling/op_queue.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class OpJob:
+    """Unit of work for the experiencer → worker path."""
+
+    op: str
+    src_ids: Tuple[int, ...]
+    out_id: int
+    scale: float
+    residual: Optional[float]
+    weight: str
+    job_id: str
+
+
+class OpQueue:
+    """Thread-safe FIFO / MPMC queue API for ``OpJob`` instances."""
+
+    def put(self, job: OpJob) -> None:
+        """Enqueue a job for later processing."""
+        # TODO: Implement enqueue semantics.
+        raise NotImplementedError
+
+    def get_batch(self, max_n: int) -> List[OpJob]:
+        """Retrieve up to ``max_n`` jobs in FIFO order."""
+        # TODO: Implement batched dequeue semantics.
+        raise NotImplementedError
+

--- a/src/common/tensors/scheduling/results.py
+++ b/src/common/tensors/scheduling/results.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Tuple
+
+
+@dataclass(frozen=True)
+class OpResult:
+    """Id-tagged result with forward value and local gradients."""
+
+    job_id: str
+    out_id: int
+    y: Any
+    grads: Any  # shape (k, F) aligned to src_ids
+
+
+class ResultSink:
+    """Result delivery: queue OR callback registry."""
+
+    def publish(self, r: OpResult) -> None:
+        """Deliver a result to its consumer."""
+        # TODO: Implement publication to a queue or callback.
+        raise NotImplementedError
+

--- a/src/common/tensors/scheduling/triage.py
+++ b/src/common/tensors/scheduling/triage.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+from .op_queue import OpJob
+from .results import OpResult, ResultSink
+
+
+@dataclass(frozen=True)
+class BinKey:
+    """Shape-equivalence class for batching."""
+
+    op: str
+    k: int
+    F: int
+    weight: str
+
+
+class TriageEngine:
+    """Triage: cache hits → immediate results; misses → bins."""
+
+    def __init__(self, *, whiteboard_runner: Any) -> None:
+        """Create a triage engine with a whiteboard execution helper."""
+        # TODO: Store the runner and prepare any caches.
+        raise NotImplementedError
+
+    def process(
+        self,
+        jobs: Sequence[OpJob],
+        *,
+        get_attr,
+        get_attr_version,
+        result_sink: ResultSink,
+    ) -> None:
+        """Process a batch of jobs, routing hits and misses appropriately."""
+        # TODO: Implement batching, cache lookup, and execution.
+        raise NotImplementedError
+


### PR DESCRIPTION
## Summary
- scaffold autoautograd cache and whiteboard runtime interfaces
- add scheduling, pooling, ops registry, and integration bridge stubs
- re-export graph node attribute view for upcoming tensor work

## Testing
- `pytest tests/test_cffi_matmul.py -q`
- `pytest -q` *(fails: AttributeError 'int' object has no attribute 'unravel_index_', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6588160832ab2d7e3cdb511f624