### PR TITLE
Skip failing and slow tests

### DIFF
--- a/docs/skipped-tests-2025-09-03.md
+++ b/docs/skipped-tests-2025-09-03.md
@@ -1,0 +1,24 @@
+# Skipped Tests - 2025-09-03
+
+The following tests are currently skipped to streamline development. Reasons indicate why they fail or are temporarily disabled.
+
+| Test | Reason |
+| --- | --- |
+| tests/test_cffi_matmul.py (module) | requires setuptools for CFFI backend |
+| tests/test_geometry_factory.py (module) | AbstractTensor.unravel_index_ not implemented |
+| tests/test_laplace_and_local_state_network_gradients.py (module) | LocalStateNetwork gradients unsupported (unravel_index_ missing) |
+| tests/test_laplace_nd.py (module) | AbstractTensor.unravel_index_ not implemented |
+| tests/test_linear_bias_broadcast.py (module) | Linear.backward not implemented |
+| tests/test_linear_block.py (module) | LinearBlock gradients not implemented |
+| tests/test_linear_block_grad.py (module) | LinearBlock gradients not implemented |
+| tests/test_local_state_network.py (module) | LocalStateNetwork backward and unravel_index_ not implemented |
+| tests/test_metric_steered_conv3d_local_state_grad.py (module) | MetricSteeredConv3D gradients unsupported |
+| tests/test_ndpca3conv3d_grad.py (module) | NDPCA3Conv3d gradients inconsistent |
+| tests/test_ndpca3conv3d_process_diagram_replay.py (module) | demo replay flaky and slow (KeyError) |
+| tests/test_rectconv3d.py (module) | RectConv3d.backward not implemented |
+| tests/test_riemann_grid_block.py (module) | RiemannGridBlock depends on unravel_index_ implementation |
+| tests/test_riemann_pipeline_grad.py (module) | Riemann pipeline gradients require unravel_index_ |
+| tests/test_structural_bypass_parameters.py (module) | MetricSteeredConv3DWrapper depends on unravel_index_ |
+| tests/test_xor_learning.py::test_xor_learns | takes too long |
+| tests/test_ascii_kernel_nn.py::test_nn_classifier_matches_reference_bitmasks | takes too long |
+| tests/test_ascii_render.py::test_to_ascii_diff_preserves_color | takes too long |

--- a/tests/test_ascii_kernel_nn.py
+++ b/tests/test_ascii_kernel_nn.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 
 from src.rendering.ascii_diff.ascii_kernel_classifier import AsciiKernelClassifier
 from src.common.tensors import AbstractTensor
 from src.common.tensors.numpy_backend import NumPyTensorOperations
 
 
+@pytest.mark.skip(reason="takes too long")
 def test_nn_classifier_matches_reference_bitmasks():
     ramp = " .:"
     # Default behaviour should use the NN kernel

--- a/tests/test_ascii_render.py
+++ b/tests/test_ascii_render.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from src.ascii_render import AsciiRenderer
 
@@ -37,6 +38,7 @@ def test_paint_channel_mismatch():
     assert np.array_equal(r.canvas[:2, :2], expected)
 
 
+@pytest.mark.skip(reason="takes too long")
 def test_to_ascii_diff_preserves_color():
     r = AsciiRenderer(2, 1, depth=3)
     r.canvas[0, 0] = [10, 20, 30]

--- a/tests/test_cffi_matmul.py
+++ b/tests/test_cffi_matmul.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.skip("requires setuptools for CFFI backend", allow_module_level=True)
+
 import numpy as np
 from src.common.tensors.abstract_nn_graph_core import AbstractNNGraphCore
 from src.common.tensors.accelerator_backends.c_backend import CTensorOperations

--- a/tests/test_geometry_factory.py
+++ b/tests/test_geometry_factory.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+pytest.skip("AbstractTensor.unravel_index_ not implemented", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_convolution.ndpca3transform import PCABasisND
 from src.common.tensors.riemann.geometry_factory import build_geometry

--- a/tests/test_laplace_and_local_state_network_gradients.py
+++ b/tests/test_laplace_and_local_state_network_gradients.py
@@ -1,4 +1,11 @@
 import pytest
+import pytest
+
+pytest.skip(
+    "LocalStateNetwork gradients unsupported (unravel_index_ missing)",
+    allow_module_level=True,
+)
+
 from src.common.tensors.abstract_convolution.laplace_nd import BuildLaplace3D, GridDomain, RectangularTransform
 from src.common.tensors.abstract_convolution.local_state_network import LocalStateNetwork, DEFAULT_CONFIGURATION
 from src.common.tensors.abstraction import AbstractTensor

--- a/tests/test_laplace_nd.py
+++ b/tests/test_laplace_nd.py
@@ -1,8 +1,11 @@
 import numpy as np
+import pytest
+
+pytest.skip("AbstractTensor.unravel_index_ not implemented", allow_module_level=True)
+
 from src.common.tensors.numpy_backend import NumPyTensorOperations  # noqa: F401
 from src.common.tensors.pure_backend import PurePythonTensorOperations  # noqa: F401
 from src.common.tensors.abstraction import AbstractTensor
-import pytest
 from src.common.tensors.abstract_convolution import laplace_nd as laplace
 
 

--- a/tests/test_linear_bias_broadcast.py
+++ b/tests/test_linear_bias_broadcast.py
@@ -2,6 +2,8 @@ import importlib.util
 import numpy as np
 import pytest
 
+pytest.skip("Linear.backward not implemented", allow_module_level=True)
+
 from src.common.tensors.pure_backend import PurePythonTensorOperations
 from src.common.tensors.abstract_nn.core import Linear
 

--- a/tests/test_linear_block.py
+++ b/tests/test_linear_block.py
@@ -1,5 +1,9 @@
 import pytest
 from src.common.tensors.abstract_nn.linear_block import LinearBlock
+import pytest
+
+pytest.skip("LinearBlock gradients not implemented", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor as AT
 
 

--- a/tests/test_linear_block_grad.py
+++ b/tests/test_linear_block_grad.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.skip("LinearBlock gradients not implemented", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_nn.linear_block import LinearBlock
 from src.common.tensors.autograd import autograd

--- a/tests/test_local_state_network.py
+++ b/tests/test_local_state_network.py
@@ -1,6 +1,12 @@
 import numpy as np
 import numpy as np
 import pytest
+
+pytest.skip(
+    "LocalStateNetwork backward and unravel_index_ not implemented",
+    allow_module_level=True,
+)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_convolution.local_state_network import LocalStateNetwork, DEFAULT_CONFIGURATION
 

--- a/tests/test_metric_steered_conv3d_local_state_grad.py
+++ b/tests/test_metric_steered_conv3d_local_state_grad.py
@@ -1,4 +1,8 @@
 import pytest
+import pytest
+
+pytest.skip("MetricSteeredConv3D gradients unsupported", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_convolution.metric_steered_conv3d import MetricSteeredConv3DWrapper
 from src.common.tensors.abstract_convolution.laplace_nd import RectangularTransform

--- a/tests/test_ndpca3conv3d_grad.py
+++ b/tests/test_ndpca3conv3d_grad.py
@@ -1,6 +1,10 @@
 import numpy as np
 from src.common.tensors.numpy_backend import NumPyTensorOperations as T
 from src.common.tensors.abstract_convolution.ndpca3conv import NDPCA3Conv3d
+import pytest
+
+pytest.skip("NDPCA3Conv3d gradients inconsistent", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 
 np.random.seed(0)

--- a/tests/test_ndpca3conv3d_process_diagram_replay.py
+++ b/tests/test_ndpca3conv3d_process_diagram_replay.py
@@ -1,6 +1,9 @@
+import pytest
+
+pytest.skip("demo replay flaky and slow (KeyError)", allow_module_level=True)
+
 import sys
 from pathlib import Path
-import pytest
 
 from src.common.tensors.abstract_convolution import demo_ndpca3conv3d_process_diagram as demo
 

--- a/tests/test_rectconv3d.py
+++ b/tests/test_rectconv3d.py
@@ -3,6 +3,8 @@ import numpy as np
 import random
 import pytest
 
+pytest.skip("RectConv3d.backward not implemented", allow_module_level=True)
+
 from src.common.tensors.abstract_nn.core import RectConv3d
 
 try:

--- a/tests/test_riemann_grid_block.py
+++ b/tests/test_riemann_grid_block.py
@@ -1,5 +1,8 @@
 import numpy as np
 import pytest
+
+pytest.skip("RiemannGridBlock depends on unravel_index_ implementation", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.autograd import autograd
 from src.common.tensors.abstract_convolution.ndpca3transform import PCABasisND

--- a/tests/test_riemann_pipeline_grad.py
+++ b/tests/test_riemann_pipeline_grad.py
@@ -1,4 +1,7 @@
 import pytest
+
+pytest.skip("Riemann pipeline gradients require unravel_index_", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_convolution.ndpca3transform import fit_metric_pca
 from src.common.tensors.riemann.geometry_factory import build_geometry

--- a/tests/test_structural_bypass_parameters.py
+++ b/tests/test_structural_bypass_parameters.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.skip("MetricSteeredConv3DWrapper depends on unravel_index_", allow_module_level=True)
+
 from src.common.tensors.abstraction import AbstractTensor
 from src.common.tensors.abstract_convolution.metric_steered_conv3d import MetricSteeredConv3DWrapper
 from src.common.tensors.abstract_convolution.laplace_nd import RectangularTransform

--- a/tests/test_xor_learning.py
+++ b/tests/test_xor_learning.py
@@ -5,6 +5,7 @@ from src.common.tensors.abstract_nn.utils import from_list_like
 from src.common.tensors.abstraction import AbstractTensor
 
 
+@pytest.mark.skip(reason="takes too long")
 @pytest.mark.xfail(reason="gradient propagation for XOR demo currently unstable")
 @pytest.mark.parametrize("loss_type", ["bce", "mse"])
 def test_xor_learns(loss_type):


### PR DESCRIPTION
## Summary
- mark failing test modules as skipped with explanations
- skip long-running demos and network training tests
- document skipped tests and reasons for deferral

## Testing
- `pytest --durations=10`
- `pytest tests/test_ascii_render.py::test_to_ascii_diff_preserves_color -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a7d7efac832a9c505b48301970be