### PR TITLE
Refine whiteboard cache with vector bridge

### DIFF
--- a/src/common/tensors/autoautograd/integration/bridge_v2.py
+++ b/src/common/tensors/autoautograd/integration/bridge_v2.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from typing import Sequence
+
+import numpy as np
+
+from ..whiteboard_runtime import run_op_and_grads_cached
+from ..whiteboard_cache import WhiteboardCache
+
+
+def push_impulses_from_op_v2(
+    sys,
+    op_name: str,
+    src_ids: Sequence[int],
+    out_id: int,
+    *,
+    residual: float | None = None,
+    scale: float = 1.0,
+    weight: str | None = None,
+    cache: WhiteboardCache | None = None,
+) -> float:
+    """Vectorised op call that pushes impulses using NodeAttrView and caching."""
+    if weight == "inv_length":
+        po = sys.nodes[out_id].p
+        ws = [1.0 / max(np.linalg.norm(po - sys.nodes[i].p), 1e-8) for i in src_ids]
+        scale *= float(np.mean(ws)) if ws else 1.0
+    y, grads = run_op_and_grads_cached(
+        sys,
+        op_name,
+        src_ids,
+        scale=scale,
+        residual=residual,
+        weight=weight,
+        cache=cache,
+    )
+    if residual is not None:
+        for i, g in zip(src_ids, grads):
+            sys.impulse(i, out_id, op_name, scale * g * float(-residual))
+    return y

--- a/src/common/tensors/autoautograd/ops/__init__.py
+++ b/src/common/tensors/autoautograd/ops/__init__.py
@@ -1,0 +1,1 @@
+from .registry import registry

--- a/src/common/tensors/autoautograd/ops/registry.py
+++ b/src/common/tensors/autoautograd/ops/registry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+from typing import Callable, Dict, Any
+
+class OpRegistry:
+    def __init__(self) -> None:
+        self._ops: Dict[str, Callable[[Any], Any]] = {}
+    def register(self, name: str, fn: Callable[[Any], Any]) -> None:
+        self._ops[name] = fn
+    def get(self, name: str) -> Callable[[Any], Any]:
+        return self._ops[name]
+
+registry = OpRegistry()
+
+registry.register("add", lambda x: x.sum())
+registry.register("mul", lambda x: x.prod())
+registry.register("sum", lambda x: x.sum())

--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -1,45 +1,58 @@
 from __future__ import annotations
-
 from contextlib import contextmanager
-from typing import Any, Callable, Optional, Sequence, Tuple
+from typing import Sequence, Tuple, Optional
+import numpy as np
 
+from ..autograd import autograd, GradTape
+from .whiteboard_cache import WhiteboardCache, ParamSig
+from .node_tensor import NodeAttrView
+from .ops.registry import registry
 
-class WhiteboardMode:
-    """Single-backward, non-accumulating tape scope."""
-
-    def __init__(self) -> None:  # pragma: no cover - trivial
-        """Prepare any context state."""
-        # TODO: Initialize resources required for whiteboard execution.
-        raise NotImplementedError
-
-    def __enter__(self) -> "WhiteboardMode":  # pragma: no cover - context stub
-        """Enter the whiteboard mode."""
-        # TODO: Establish the environment for a single backward pass.
-        raise NotImplementedError
-
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context stub
-        """Tear down the whiteboard mode."""
-        # TODO: Clean up allocated resources.
-        raise NotImplementedError
-
+@contextmanager
+def WhiteboardMode():
+    """Isolate a fresh autograd tape for a single forward/backward pair."""
+    old = autograd.tape
+    autograd.tape = GradTape()
+    try:
+        yield
+    finally:
+        autograd.tape = old
 
 def run_op_and_grads_cached(
-    *,
-    op: str,
+    sys,
+    op_name: str,
     src_ids: Sequence[int],
-    weight: str,
-    scale: float,
-    residual: float,
-    get_attr: Callable[[int], Any],
-    get_attr_version: Optional[Callable[[int], Optional[int]]] = None,
-    scalarize: Optional[Callable[[Any], Any]] = None,
-) -> Tuple[Any, Any]:
-    """Return forward value and local gradients, using a cache when possible.
-
-    The implementation should consult a ``WhiteboardCache`` instance. On a cache
-    miss, it must perform a single forward and backward pass within a
-    ``WhiteboardMode`` context. The returned gradients align with ``src_ids``.
-    """
-    # TODO: Implement cache lookup and whiteboard execution.
-    raise NotImplementedError
-
+    *,
+    scale: float = 1.0,
+    residual: float | None = None,
+    weight: str | None = None,
+    cache: WhiteboardCache | None = None,
+) -> Tuple[float, Tuple[float, ...]]:
+    cache = cache or WhiteboardCache()
+    sigs = [ParamSig(i, getattr(sys.nodes[i], "version", 0)) for i in src_ids]
+    view = NodeAttrView(sys.nodes, "theta", indices=src_ids).build()
+    tensor = view.tensor
+    key = cache.make_key(
+        op_name,
+        sigs,
+        fan_in=len(src_ids),
+        feat_shape=tensor.shape[1:],
+        scale=scale,
+        residual=residual,
+        weight=weight,
+    )
+    pkg = cache.get(key)
+    if pkg is not None:
+        return pkg
+    with WhiteboardMode():
+        fn = registry.get(op_name)
+        y_val = fn(tensor)
+        if op_name == "add" or op_name == "sum":
+            grads = tuple(1.0 for _ in src_ids)
+        elif op_name == "mul":
+            grads = tuple(float(y_val / v) if v != 0 else 0.0 for v in tensor)
+        else:
+            grads = tuple(0.0 for _ in src_ids)
+        pkg = (float(y_val), grads)
+    cache.put(key, pkg)
+    return pkg

--- a/tests/test_whiteboard_cache.py
+++ b/tests/test_whiteboard_cache.py
@@ -1,0 +1,51 @@
+from src.common.tensors.autoautograd.whiteboard_cache import WhiteboardCache
+from src.common.tensors.autoautograd.whiteboard_runtime import run_op_and_grads_cached
+
+class DummyNode:
+    def __init__(self, theta, version=0):
+        self.theta = theta
+        self.version = version
+
+class DummySys:
+    def __init__(self, nodes):
+        self.nodes = nodes
+    def impulse(self, *args, **kwargs):
+        pass
+
+def test_cache_hit_and_miss():
+    nodes = {0: DummyNode(1.0), 1: DummyNode(2.0)}
+    sys = DummySys(nodes)
+    cache = WhiteboardCache()
+    y1, g1 = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    assert cache.misses == 1
+    assert g1 == (1.0, 1.0)
+    y2, g2 = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    assert cache.hits == 1
+    assert (y1, g1) == (y2, g2)
+    nodes[0].version += 1
+    y3, _ = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    assert cache.misses == 2
+    assert y3 == y1
+
+
+def test_quantised_scale_and_residual():
+    nodes = {0: DummyNode(1.0), 1: DummyNode(2.0)}
+    sys = DummySys(nodes)
+    cache = WhiteboardCache()
+    run_op_and_grads_cached(sys, 'add', [0, 1], scale=1.0, residual=0.1, cache=cache)
+    assert cache.misses == 1
+    run_op_and_grads_cached(sys, 'add', [0, 1], scale=1.0, residual=0.1, cache=cache)
+    assert cache.hits == 1
+    run_op_and_grads_cached(sys, 'add', [0, 1], scale=1.0 + 2e-6, residual=0.1, cache=cache)
+    assert cache.misses == 2
+    run_op_and_grads_cached(sys, 'add', [0, 1], scale=1.0, residual=0.1 + 2e-6, cache=cache)
+    assert cache.misses == 3
+
+
+def test_gradient_alignment_mul():
+    nodes = {0: DummyNode(3.0), 1: DummyNode(5.0)}
+    sys = DummySys(nodes)
+    cache = WhiteboardCache()
+    y, grads = run_op_and_grads_cached(sys, 'mul', [0, 1], cache=cache)
+    assert y == 15.0
+    assert grads == (5.0, 3.0)


### PR DESCRIPTION
## Summary
- expand whiteboard cache keys with fan-in, feature shape, weight and quantised scale/residual
- implement vectorised runtime using NodeAttrView and analytic gradients for add/mul
- support weighted op calls in bridge_v2 and cover cache semantics in tests

## Testing
- `pytest tests/test_whiteboard_cache.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8b2547fe4832a9a70697e694ccbea