### PR TITLE
Add tensor finite check and caching runtime

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -2271,6 +2271,7 @@ _bind_and_wrap({
     "isfinite": comp_isfinite,
     "isnan": comp_isnan,
     "isinf": comp_isinf,
+    "isinfinite": comp_isinf,
     "allclose": comp_allclose,
     "argwhere": comp_argwhere,
     "sin": trig_sin,

--- a/src/common/tensors/autoautograd/integration/bridge_v2.py
+++ b/src/common/tensors/autoautograd/integration/bridge_v2.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Sequence, Any, Callable, List, Tuple, Dict
 
-import numpy as np
 
 from ..whiteboard_runtime import run_batched_vjp
 from ..whiteboard_cache import WhiteboardCache
@@ -48,7 +47,7 @@ def _inv_length_scale(sys, out_id: int, src_ids: Sequence[int]) -> float:
         item = getattr(n, "item_", None)
         n_val = float(item()) if callable(item) else float(n)
         ws.append(1.0 / max(n_val, 1e-8))
-    return float(np.mean(ws)) if ws else 1.0
+    return float(AbstractTensor.mean(ws)) if ws else 1.0
 
 
 def push_impulses_from_op_v2(


### PR DESCRIPTION
## Summary
- expose `isinfinite` alias on AbstractTensor
- use AbstractTensor and math finite checks in spring demo
- add cached op runner for autoautograd whiteboard runtime
- replace NumPy calls with AbstractTensor across autoautograd modules

## Testing
- `pytest tests/test_numpy_divide_by_zero.py -q`
- `pytest tests/test_whiteboard_cache.py -q`
- `pytest tests/test_scheduling_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7a6d0f0832a87ce23eae7503995