### PR TITLE
Use modern colormap API

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -34,9 +34,10 @@ import threading
 from collections import deque, defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, Tuple, List, Optional, Callable
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
-from matplotlib import cm, colors as mcolors
+from matplotlib import colors as mcolors
 from ..abstraction import AbstractTensor
 
 L_MIN = 0.05
@@ -543,7 +544,7 @@ class LiveVizGLPoints:
                  boundary_scale: float = 1.8,
                  bg_color: Tuple[float, float, float] = (0.04, 0.04, 0.06)):
         self.sys = sys
-        self.node_cmap = cm.get_cmap(node_cmap)
+        self.node_cmap = matplotlib.colormaps.get_cmap(node_cmap)
         self.base_point_size = float(base_point_size)
         self.boundary_scale = float(boundary_scale)
         self.bg_color = bg_color


### PR DESCRIPTION
## Summary
- replace deprecated `cm.get_cmap` usage with `matplotlib.colormaps.get_cmap`
- import `matplotlib` and adjust imports accordingly

## Testing
- `pytest tests/test_autograd_process.py::test_autograd_process_training_and_tables -q`
- `pytest tests/test_tensor_basic_ops.py::test_basic_add_and_zeros -q`


------
https://chatgpt.com/codex/tasks/task_e_68bad86117f8832aa44829a7762f7769