### PR TITLE
Canonicalize batched op keys for hashing

### DIFF
--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -1,0 +1,27 @@
+from src.common.tensors.autoautograd.integration import bridge_v2
+
+
+class DummyNode:
+    def __init__(self):
+        self.theta = 0
+
+
+class DummySys:
+    def __init__(self):
+        self.nodes = {0: DummyNode(), 1: DummyNode()}
+
+
+def _stub_batched_vjp(*, sys, jobs, op_args, op_kwargs, get_attr, backend):
+    class _Batch:
+        def __init__(self, n):
+            self.ys = [1] * n
+            self.grads_per_source = [[0]] * n
+
+    return _Batch(len(jobs))
+
+
+def test_batched_forward_handles_list_kwargs(monkeypatch):
+    monkeypatch.setattr(bridge_v2, "run_batched_vjp", _stub_batched_vjp)
+    sys = DummySys()
+    specs = [("noop", [0], 1, None, {"foo": [1, 2]})]
+    assert bridge_v2.batched_forward_v2(sys, specs) == [1]


### PR DESCRIPTION
## Summary
- Recursively freeze lists and dicts before hashing batched op specs
- Use frozen keys in `batched_forward_v2` and `push_impulses_from_ops_batched` to prevent list-based kwargs from crashing
- Add regression test covering list-valued kwargs

## Testing
- `pytest tests/test_bridge_v2_keys.py tests/test_scheduling_module.py`
- Failed: `python -m src.common.tensors.autoautograd.spring_async_toy` (missing OpenGL/GL library)


------
https://chatgpt.com/codex/tasks/task_e_68baf9211704832a81ab4900001fb53b