### PR TITLE
Allow positional and keyword args in op chain

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1333,7 +1333,7 @@ class LinearBlockFactory:
             args = {
                 "indices": srcs,
                 "dim": 0,
-                "fn": _op_apply_factory(["__add__", "__mul__"]),
+                "fn": _op_apply_factory(["__add__", "__mul__"], [(0,), (1,)]),
             }
             ops.append(("gather_and", srcs, r_id, None, args))
 
@@ -1346,7 +1346,7 @@ class LinearBlockFactory:
             args = {
                 "indices": srcs,
                 "dim": 0,
-                "fn": _op_apply_factory(["__add__", "__mul__"]),
+                "fn": _op_apply_factory(["__add__", "__mul__"], [(0,), (1,)]),
             }
             ops.append(("gather_and", srcs, oj, None, args))
 


### PR DESCRIPTION
## Summary
- Support per-op positional and keyword arguments in `_op_apply_factory`
- Update spring async toy to supply operands for `__add__` and `__mul__`

## Testing
- `pytest tests/test_bridge_v2_keys.py -q`
- `pytest tests/test_autograd_process.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafe94dae0832a8db4c904a2646d75