### PR TITLE
Add T alias for tensor transpose

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -2299,6 +2299,22 @@ _bind_and_wrap({
     "ifft": fourier_ifft,
 })
 
+def T(self) -> "AbstractTensor":
+    """Matrix transpose convenience alias.
+
+    Returns ``self`` transposed over its last two dimensions.  Vectors and
+    scalars are promoted to 2D before transposition to match NumPy's
+    ``.T`` semantics.
+    """
+    ndim = getattr(self, "ndim", len(getattr(self, "shape", ())))
+    if ndim < 2:
+        if ndim == 0:
+            base = self.reshape((1, 1))
+        else:
+            base = self.reshape((1, self.shape[0]))
+        return base.transpose(-2, -1)
+    return self.transpose(-2, -1)
+
 AbstractTensor.reshape = _reshape_methods.reshape
 AbstractTensor.flatten = _reshape_methods.flatten
 AbstractTensor.transpose = _reshape_methods.transpose
@@ -2306,6 +2322,8 @@ AbstractTensor.permute = _reshape_methods.permute
 AbstractTensor.unsqueeze = _reshape_methods.unsqueeze
 AbstractTensor.squeeze = _reshape_methods.squeeze
 AbstractTensor.swapaxes = _reshape_methods.swapaxes
+
+AbstractTensor.T = T
 
 AbstractTensor.numel   = prop_numel
 AbstractTensor.item    = prop_item

--- a/tests/test_tensor_basic_ops.py
+++ b/tests/test_tensor_basic_ops.py
@@ -95,6 +95,14 @@ def test_transpose_invalid_indices(backend_name, Backend):
 
 
 @pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_T_is_transpose_alias(backend_name, Backend):
+    t = Backend.tensor([[1, 2, 3], [4, 5, 6]])
+    alias = t.T()
+    transposed = t.transpose(-2, -1)
+    assert alias.tolist() == transposed.tolist()
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
 def test_swapaxes_negative_indices(backend_name, Backend):
     t = Backend.tensor([[1, 2, 3], [4, 5, 6]])
     neg = t.swapaxes(-2, -1)


### PR DESCRIPTION
## Summary
- add `T` helper on `AbstractTensor` that forwards to `transpose` and handles vectors/scalars
- test that `T()` matches explicit transpose

## Testing
- `pytest tests/test_tensor_basic_ops.py::test_T_is_transpose_alias -q`
- `pytest tests/test_tensor_basic_ops.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb3fe3a098832a8097812728a6da6b