### PR TITLE
feat: enhance filtered Poisson solver

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1912,8 +1912,12 @@ class AbstractF:
         *,
         iterations: int = 50,
         filter_strength: float = 0.0,
-        mode: str = "manifold",
+        mode: str | None = None,
         adjacency=None,
+        boundary_mask=None,
+        boundary_flux=None,
+        normalization: str = "none",
+        tol: float | None = None,
     ):
         """Solve a Poisson problem with optional RHS smoothing."""
         from .filtered_poisson import (
@@ -1923,12 +1927,20 @@ class AbstractF:
         rhs = AbstractTensor.get_tensor(rhs)
         if adjacency is not None:
             adjacency = AbstractTensor.get_tensor(adjacency, like=rhs)
+        if boundary_mask is not None:
+            boundary_mask = AbstractTensor.get_tensor(boundary_mask, like=rhs)
+        if boundary_flux is not None:
+            boundary_flux = AbstractTensor.get_tensor(boundary_flux, like=rhs)
         return _filtered_poisson(
             rhs,
             iterations=iterations,
             filter_strength=filter_strength,
             mode=mode,
             adjacency=adjacency,
+            boundary_mask=boundary_mask,
+            boundary_flux=boundary_flux,
+            normalization=normalization,
+            tol=tol,
         )
 
 # Attach to AbstractTensor


### PR DESCRIPTION
## Summary
- infer grid vs graph domains automatically
- support boundary masks/flux and normalized Laplacians
- stop Jacobi iteration early with tolerance and cover new code paths with tests

## Testing
- `pytest tests/test_filtered_poisson.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb5b5b2d4c832a9da565774af39bad