### PR TITLE
Add complex component extraction to AbstractTensor and fix OpenGL buffer uploads

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -396,6 +396,30 @@ class AbstractTensor:
     def log_(self):
         raise NotImplementedError(f"{self.__class__.__name__} must implement log_()")
 
+    @staticmethod
+    def real(x) -> "AbstractTensor":
+        """Return the real part of a complex tensor."""
+        if not isinstance(x, AbstractTensor):
+            x = AbstractTensor.tensor(x)
+        result = type(x)(track_time=x.track_time, tape=getattr(x, "_tape", None))
+        result.data = x.real_()
+        return result
+
+    def real_(self):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement real_()")
+
+    @staticmethod
+    def imag(x) -> "AbstractTensor":
+        """Return the imaginary part of a complex tensor."""
+        if not isinstance(x, AbstractTensor):
+            x = AbstractTensor.tensor(x)
+        result = type(x)(track_time=x.track_time, tape=getattr(x, "_tape", None))
+        result.data = x.imag_()
+        return result
+
+    def imag_(self):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement imag_()")
+
     # --- Softmax utilities ---
     def softmax(self, dim: int = -1) -> "AbstractTensor":
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))

--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -722,7 +722,7 @@ class LiveVizGLPoints:
 
         # positions
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_pos)
-        glBufferData(GL_ARRAY_BUFFER, P.nbytes, P, GL_DYNAMIC_DRAW)
+        glBufferData(GL_ARRAY_BUFFER, P.nbytes, P.data, GL_DYNAMIC_DRAW)
 
         # colors
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_col)
@@ -730,7 +730,7 @@ class LiveVizGLPoints:
 
         # sizes
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_size)
-        glBufferData(GL_ARRAY_BUFFER, S.nbytes, S, GL_DYNAMIC_DRAW)
+        glBufferData(GL_ARRAY_BUFFER, S.nbytes, S.data, GL_DYNAMIC_DRAW)
 
         glBindVertexArray(0)
 

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -205,6 +205,14 @@ class NumPyTensorOperations(AbstractTensor):
         import numpy as np
         return np.log(self.data)
 
+    def real_(self):
+        import numpy as np
+        return np.real(self.data)
+
+    def imag_(self):
+        import numpy as np
+        return np.imag(self.data)
+
     def neg_(self):
         return -self.data
 


### PR DESCRIPTION
## Summary
- add `real` and `imag` helpers to `AbstractTensor` and NumPy backend
- upload NumPy data buffers in `spring_async_toy` rather than AbstractTensor wrappers

## Testing
- `pytest tests/test_tensor_from_nested.py tests/test_tensor_int_cast.py tests/test_copyto_semantics.py`
- `pytest tests/test_eigh_batch.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbb68ec3dc832aa25c2cb5d15fb533