### PR TITLE
Fix glBufferData byte size handling for AbstractTensor

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -722,7 +722,10 @@ class LiveVizGLPoints:
 
         # positions
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_pos)
-        glBufferData(GL_ARRAY_BUFFER, P.nbytes, P.data, GL_DYNAMIC_DRAW)
+        # ``AbstractTensor.nbytes`` is a method; we must call it to obtain the
+        # byte size.  Passing the bound method directly leads to ctypes type
+        # errors under PyOpenGL.
+        glBufferData(GL_ARRAY_BUFFER, P.nbytes(), P.data, GL_DYNAMIC_DRAW)
 
         # colors
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_col)
@@ -730,7 +733,9 @@ class LiveVizGLPoints:
 
         # sizes
         glBindBuffer(GL_ARRAY_BUFFER, self._vbo_size)
-        glBufferData(GL_ARRAY_BUFFER, S.nbytes, S.data, GL_DYNAMIC_DRAW)
+        # ``S`` is also an ``AbstractTensor``; ensure we pass the computed
+        # integer byte size rather than the bound method object.
+        glBufferData(GL_ARRAY_BUFFER, S.nbytes(), S.data, GL_DYNAMIC_DRAW)
 
         glBindVertexArray(0)
 


### PR DESCRIPTION
## Summary
- call AbstractTensor.nbytes() when uploading vertex data to OpenGL buffers
- document rationale and avoid passing bound methods to glBufferData

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_scheduling_module.py tests/test_bridge_v2_keys.py`
- `python -m src.common.tensors.autoautograd.spring_async_toy` *(fails: Unable to load OpenGL or GL library)*

------
https://chatgpt.com/codex/tasks/task_e_68bbbd0c3a60832a903b1345ee7fa09b