### PR TITLE
fix: register AbstractTensor for OpenGL

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1662,14 +1662,26 @@ class AbstractTensor:
 
     # inside AbstractTensor
     def __array__(self, dtype=None):
-        out = self.clone()
+        """Return a ``numpy`` view of this tensor's data.
+
+        The conversion only materialises when the current backend is not the
+        NumPy implementation.  In that case we delegate to ``to_backend`` to
+        obtain a NumPy-backed tensor and expose its underlying ``ndarray``.
+        """
+
         from .numpy_backend import NumPyTensorOperations
-        out.to_backend(AbstractTensor.get_tensor(0, cls=NumPyTensorOperations))
-        return out.data if dtype is None else out.data.astype(dtype)
+
+        tensor = self
+        if not isinstance(self, NumPyTensorOperations):
+            tensor = self.to_backend(
+                AbstractTensor.get_tensor(0, cls=NumPyTensorOperations)
+            )
+
+        arr = tensor.data
+        return arr if dtype is None else arr.astype(dtype)
 
     @property
     def __array_interface__(self):
-        import numpy as np
         return self.__array__().__array_interface__
 
 

--- a/src/common/tensors/pyopengl_handler.py
+++ b/src/common/tensors/pyopengl_handler.py
@@ -1,22 +1,46 @@
 # src/common/tensors/pyopengl_handler.py
-from OpenGL.arrays import arraydatatype, numpymodule
-import numpy as np
+"""PyOpenGL array handler for :class:`AbstractTensor`.
 
-# Delegate to NumPy's handler, but force a NumPy view first (via __array__)
-class _AbstractTensorHandler(numpymodule.NumpyHandler):
-    @classmethod
-    def asArray(cls, value, typeCode=None):
-        arr = np.asarray(value, order="C")      # triggers AbstractTensor.__array__
-        print(f"[DBG] PyOpenGL converting AbstractTensor to array: {arr}, typeCode={typeCode}")
-        return super().asArray(arr, typeCode)   # dtype/contiguity handled here
+This module registers a lightweight shim so that instances of
+``AbstractTensor`` (and their NumPy backend) can be passed directly to
+PyOpenGL calls without explicitly converting them to ``numpy`` arrays.
 
-def install_pyopengl_handlers():
-    # Import here to avoid import cycles
+If PyOpenGL or the system GL libraries are unavailable the registration is a
+no-op, keeping the import side-effects minimal in headless environments.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - optional OpenGL dependency
+    from OpenGL.arrays import arraydatatype, numpymodule
+except Exception:  # noqa: BLE001 - tolerate missing GL libraries
+    arraydatatype = None  # type: ignore[assignment]
+    numpymodule = None  # type: ignore[assignment]
+
+
+def install_pyopengl_handlers() -> None:
+    """Install PyOpenGL handlers for ``AbstractTensor`` types.
+
+    The handler delegates to NumPy's implementation but extracts the underlying
+    ``numpy`` ``ndarray`` without forcing an intermediate ``np.asarray``
+    conversion, satisfying the "no explicit numpy conversion" requirement.
+    """
+
+    if arraydatatype is None or numpymodule is None:  # pragma: no cover - optional
+        return
+
+    # Import here to avoid circular dependencies
     from .abstraction import AbstractTensor
     from .numpy_backend import NumPyTensorOperations
+
+    class _AbstractTensorHandler(numpymodule.NumpyHandler):
+        @classmethod
+        def asArray(cls, value, typeCode=None):
+            arr = getattr(value, "data", value)  # direct view of backing array
+            return super().asArray(arr, typeCode)
 
     reg = arraydatatype.ArrayDatatype.getRegistry()
     handler = _AbstractTensorHandler()
 
-    # Register for both wrapper + backend instances (your traceback shows both)
+    # Register for both wrapper + backend instances (traceback showed both)
     reg.register(handler, types=(AbstractTensor, NumPyTensorOperations))


### PR DESCRIPTION
## Summary
- allow AbstractTensor to expose numpy views only when needed
- register a PyOpenGL handler for AbstractTensor without forcing np.asarray

## Testing
- `pytest tests/test_eye_batch_dims.py tests/test_padcat.py tests/test_opengl_matrices.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbd56ddf7c832a8adc1eb837c2c534