### PR TITLE
Add Poisson smoothing with optional feedback edges

### DIFF
--- a/tests/test_dirichlet_neumann_feedback.py
+++ b/tests/test_dirichlet_neumann_feedback.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+try:
+    from src.common.tensors.autoautograd.spring_async_toy import (
+        SpringRepulsorSystem,
+        Node,
+        build_dirichlet_neumann_pipeline,
+    )
+except Exception:
+    pytest.skip("spring_async_toy optional deps missing", allow_module_level=True)
+
+from src.common.tensors import AbstractTensor
+
+
+def _make_sys(n_nodes: int) -> SpringRepulsorSystem:
+    AT = AbstractTensor
+    nodes = [
+        Node(id=i, theta=0.0, p=AT.zeros(2, dtype=float), v=AT.zeros(2, dtype=float))
+        for i in range(n_nodes)
+    ]
+    return SpringRepulsorSystem(nodes, [])
+
+
+def test_feedback_topologies():
+    AT = AbstractTensor
+    X = AT.zeros((1, 2), dtype=float)
+    y = AT.zeros((1, 2), dtype=float)
+
+    sys_paired = _make_sys(2)
+    build_dirichlet_neumann_pipeline(sys_paired, X, y, [0, 1], layers=0, feedback="paired")
+    assert len(sys_paired.feedback_edges) == 2
+
+    sys_full = _make_sys(2)
+    build_dirichlet_neumann_pipeline(sys_full, X, y, [0, 1], layers=0, feedback="full")
+    assert len(sys_full.feedback_edges) == 4

--- a/tests/test_poisson_residual_smoothing.py
+++ b/tests/test_poisson_residual_smoothing.py
@@ -1,0 +1,11 @@
+from src.common.tensors import AbstractTensor
+from src.common.tensors.filtered_poisson import filtered_poisson
+
+
+def test_residual_poisson_smoothing_reduces_peak():
+    rhs = AbstractTensor.get_tensor([0.0, 2.0, 0.0])
+    adjacency = AbstractTensor.get_tensor(
+        [[0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0]], like=rhs
+    )
+    smoothed = filtered_poisson(rhs, iterations=20, adjacency=adjacency)
+    assert float(smoothed[0]) > 0.0 and float(smoothed[2]) > 0.0


### PR DESCRIPTION
## Summary
- Smooth residual vectors via `filtered_poisson` before emitting impulses in the async spring toy
- Allow Dirichlet-Neumann pipeline to create paired or fully-connected feedback edges
- Cover Poisson diffusion and feedback wiring with new tests

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_scheduling_module.py tests/test_bridge_v2_keys.py tests/test_dirichlet_neumann_feedback.py tests/test_poisson_residual_smoothing.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbf0746e94832a865076bb6139ca4b