### PR TITLE
Refactor spring toy Node parameter handling

### DIFF
--- a/src/common/tensors/autoautograd/adapters_autograd_bridge.py
+++ b/src/common/tensors/autoautograd/adapters_autograd_bridge.py
@@ -77,7 +77,7 @@ def push_impulses_from_op(
     residual: if you already have (y - target) locally, pass it; otherwise None.
     """
     # gather current scalar parameters from nodes
-    vals = [AbstractTensor.array(sys.nodes[i].theta, dtype=float) for i in src_ids]
+    vals = [AbstractTensor.array(sys.nodes[i].param, dtype=float) for i in src_ids]
 
     y_at, grads_at = run_op_and_grads(op_name, *vals)  # grads in same order as src_ids
 

--- a/src/common/tensors/autoautograd/integration/bridge_v2.py
+++ b/src/common/tensors/autoautograd/integration/bridge_v2.py
@@ -132,7 +132,7 @@ def push_impulses_from_op_v2(
     )
 
     def get_attr(i: int):
-        return sys.nodes[i].theta
+        return sys.nodes[i].param
 
     batch = run_batched_vjp(
         sys=sys,
@@ -179,7 +179,7 @@ def batched_forward_v2(
         )
 
     def get_attr(i: int):
-        return sys.nodes[i].theta
+        return sys.nodes[i].param
 
     ys_buffer: Dict[int, Any] = {}
     for (op_name, _key_args, _key_kwargs), items in by_op.items():
@@ -256,7 +256,7 @@ def push_impulses_from_ops_batched(
         )
 
     def get_attr(i: int):
-        return sys.nodes[i].theta
+        return sys.nodes[i].param
 
     for (op_name, _key_args, _key_kwargs), items in by_op.items():
         op_args = items[0][3] or ()

--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -3,7 +3,7 @@ from src.common.tensors.autoautograd.integration import bridge_v2
 
 class DummyNode:
     def __init__(self):
-        self.theta = 0
+        self.param = 0
 
 
 class DummySys:

--- a/tests/test_dirichlet_neumann_feedback.py
+++ b/tests/test_dirichlet_neumann_feedback.py
@@ -17,10 +17,19 @@ from src.common.tensors import AbstractTensor
 
 def _make_sys(n_nodes: int) -> SpringRepulsorSystem:
     AT = AbstractTensor
-    nodes = [
-        Node(id=i, theta=0.0, p=AT.zeros(2, dtype=float), v=AT.zeros(2, dtype=float))
-        for i in range(n_nodes)
-    ]
+    nodes = []
+    for i in range(n_nodes):
+        p = AT.zeros(2, dtype=float)
+        param = AT.zeros(1, dtype=float)
+        nodes.append(
+            Node(
+                id=i,
+                param=param,
+                p=p,
+                v=AT.zeros(2, dtype=float),
+                sphere=AbstractTensor.concat([p, param], dim=0),
+            )
+        )
     return SpringRepulsorSystem(nodes, [])
 
 

--- a/tests/test_scheduling_module.py
+++ b/tests/test_scheduling_module.py
@@ -15,14 +15,14 @@ from src.common.tensors.autoautograd.whiteboard_runtime import BatchVJPResult, B
 
 @dataclass
 class _Node:
-    theta: Any
+    param: Any
     version: int = 0
 
 
 class _Sys:
-    def __init__(self, thetas: List[Any], versions: List[int] | None = None) -> None:
-        versions = versions or [0] * len(thetas)
-        self.nodes = [_Node(theta=t, version=v) for t, v in zip(thetas, versions)]
+    def __init__(self, params: List[Any], versions: List[int] | None = None) -> None:
+        versions = versions or [0] * len(params)
+        self.nodes = [_Node(param=t, version=v) for t, v in zip(params, versions)]
 
 
 def _mk_jobs(n: int, *, k: int = 2, op: str = "sum_k", weight: str = "w0", tag: Any = None) -> List[OpJob]:
@@ -55,7 +55,7 @@ def test_runner_cache_probe_and_update(monkeypatch):
     # Arrange a tiny system with scalar features (shape ())
     sys = _Sys([type("_S", (), {"shape": ()})(), type("_S", (), {"shape": ()})()])
     def get_attr(i: int):
-        return sys.nodes[i].theta
+        return sys.nodes[i].param
     def get_version(i: int) -> int:
         return sys.nodes[i].version
 
@@ -86,7 +86,7 @@ def test_triage_bins_and_backend_scoping(monkeypatch):
     # System with vector features (shape (F,)) for F=3; triage infers F from shape
     sys = _Sys([type("_S", (), {"shape": (3,)})(), type("_S", (), {"shape": (3,)})()])
     def get_attr(i: int):
-        return sys.nodes[i].theta
+        return sys.nodes[i].param
     def get_version(i: int) -> int:
         return sys.nodes[i].version
 

--- a/tests/test_whiteboard_cache.py
+++ b/tests/test_whiteboard_cache.py
@@ -2,8 +2,8 @@ from src.common.tensors.autoautograd.whiteboard_cache import WhiteboardCache
 from src.common.tensors.autoautograd.whiteboard_runtime import run_op_and_grads_cached
 
 class DummyNode:
-    def __init__(self, theta, version=0):
-        self.theta = theta
+    def __init__(self, param, version=0):
+        self.param = param
         self.version = version
 
 class DummySys:


### PR DESCRIPTION
## Summary
- extend spring_async_toy Node with tensor `param` and `sphere`
- revise commit path and node constructors to track param residuals
- swap `theta` usage for `param` across integration and runtime layers

## Testing
- `pytest tests/test_dirichlet_neumann_feedback.py tests/test_pool_whiteboard_scheduler.py tests/test_scheduling_module.py tests/test_bridge_v2_keys.py tests/test_whiteboard_cache.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc956e87ac832abf600804a569d76d