### PR TITLE
Handle vector residuals in autoautograd bridge

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1436,10 +1436,11 @@ class Experiencer(threading.Thread):
                     )
                     sc = 1.0  # default scale
                     for i, g in zip(srcs, g_list):
+                        g_val = g.sum() if hasattr(g, "sum") else g
                         g_host = (
-                            float(getattr(g, "item_", lambda: g)())
-                            if hasattr(g, "item_")
-                            else float(g)
+                            float(getattr(g_val, "item_", lambda: g_val)())
+                            if hasattr(g_val, "item_")
+                            else float(g_val)
                         )
                         self.sys.impulse(int(i), int(out), name, float(sc * g_host * (-r_host)))
                     node = self.sys.nodes[out]


### PR DESCRIPTION
## Summary
- concatenate node position and parameters into a single tensor via `_node_tensor`
- ensure `push_impulses_from_op_v2` and batched variant use `_node_tensor` and process gradients elementwise
- aggregate tensor gradients in `spring_async_toy` before emitting impulses

## Testing
- `pytest tests/test_bridge_v2_keys.py tests/test_dirichlet_neumann_feedback.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc996a5824832a86f21259afecb754