### PR TITLE
refactor: vectorized sphere attribute

### DIFF
--- a/src/common/tensors/scheduling/runner.py
+++ b/src/common/tensors/scheduling/runner.py
@@ -133,7 +133,6 @@ class BulkOpRunner:
             jobs=jobs_rt,
             op_args=(),
             op_kwargs=None,
-            get_attr=get_attr,
             backend=backend,
         )
 

--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -4,6 +4,7 @@ from src.common.tensors.autoautograd.integration import bridge_v2
 class DummyNode:
     def __init__(self):
         self.param = 0
+        self.sphere = 0
 
 
 class DummySys:
@@ -11,7 +12,7 @@ class DummySys:
         self.nodes = {0: DummyNode(), 1: DummyNode()}
 
 
-def _stub_batched_vjp(*, sys, jobs, op_args, op_kwargs, get_attr, backend):
+def _stub_batched_vjp(*, sys, jobs, op_args, op_kwargs, backend):
     class _Batch:
         def __init__(self, n):
             self.ys = [1] * n

--- a/tests/test_pool_whiteboard_scheduler.py
+++ b/tests/test_pool_whiteboard_scheduler.py
@@ -47,13 +47,14 @@ class PoolATAdapter:
 @dataclass
 class _Node:
     param: Any
+    sphere: Any
     version: int = 0
 
 
 class _Sys:
     def __init__(self, params: List[Any], versions: List[int] | None = None) -> None:
         versions = versions or [0] * len(params)
-        self.nodes = [_Node(param=t, version=v) for t, v in zip(params, versions)]
+        self.nodes = [_Node(param=t, sphere=t, version=v) for t, v in zip(params, versions)]
 
 
 def _mk_jobs(n: int, *, k: int = 2, residual: float | None = 1.0, op: str = "sum_k", weight: str = "w0") -> List[OpJob]:
@@ -88,7 +89,7 @@ def test_full_pipeline_with_tensor_pool():
     sys = _Sys([t0, t1])
 
     import types
-    get_attr = types.MethodType(lambda self, i: self.nodes[i].param, sys)
+    get_attr = types.MethodType(lambda self, i: self.nodes[i].sphere, sys)
     get_version = types.MethodType(lambda self, i: self.nodes[i].version, sys)
 
     runner = BulkOpRunner()
@@ -127,7 +128,7 @@ def test_cache_hits_with_tensor_pool():
     sys = _Sys([t0, t1])
 
     import types
-    get_attr = types.MethodType(lambda self, i: self.nodes[i].param, sys)
+    get_attr = types.MethodType(lambda self, i: self.nodes[i].sphere, sys)
     get_version = types.MethodType(lambda self, i: self.nodes[i].version, sys)
 
     runner = BulkOpRunner()

--- a/tests/test_whiteboard_cache.py
+++ b/tests/test_whiteboard_cache.py
@@ -2,8 +2,8 @@ from src.common.tensors.autoautograd.whiteboard_cache import WhiteboardCache
 from src.common.tensors.autoautograd.whiteboard_runtime import run_op_and_grads_cached
 
 class DummyNode:
-    def __init__(self, param, version=0):
-        self.param = param
+    def __init__(self, sphere, version=0):
+        self.sphere = sphere
         self.version = version
 
 class DummySys:


### PR DESCRIPTION
## Summary
- read full vectors from each node's `sphere` attribute rather than scalar `theta`
- drop unused `get_attr` argument from `run_batched_vjp`
- update whiteboard cache keys and callers for vectorized nodes

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_bridge_v2_keys.py tests/test_scheduling_module.py tests/test_pool_whiteboard_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d16ff5c832a90d8a00e6dd973de