### PR TITLE
Add activation registry and pre-op gating in autoautograd

### DIFF
--- a/src/common/tensors/autoautograd/integration/preop.py
+++ b/src/common/tensors/autoautograd/integration/preop.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+from ...abstraction import AbstractTensor
+from ...abstract_nn.activations import ACTIVATIONS
+
+
+def _sigmoid(x: AbstractTensor) -> AbstractTensor:
+    return 1.0 / (1.0 + (-x).exp())
+
+
+def preactivate_src(sys: Any, nid: int) -> Tuple[AbstractTensor, dict]:
+    """Pre-activation helper for a source node.
+
+    Parameters
+    ----------
+    sys : Any
+        System object exposing ``nodes`` mapping.
+    nid : int
+        Source node id.
+
+    Returns
+    -------
+    y : AbstractTensor
+        Transformed value for the node.
+    meta : dict
+        Metadata containing intermediates for parameter gradient calculations.
+    """
+    n = sys.nodes[nid]
+    x = n.p
+    ecc_raw, w, b = n.param[0], n.param[1], n.param[2]
+    gate = _sigmoid(ecc_raw)
+    z = x * w + b
+    act_name = getattr(n, "activation", "tanh")
+    act_cls = ACTIVATIONS.get(act_name, ACTIVATIONS["tanh"])
+    z_act = act_cls()(z)
+    y = (1.0 - gate) * z + gate * z_act
+    meta = {
+        "x": x,
+        "z": z,
+        "z_act": z_act,
+        "gate": gate,
+        "w": w,
+        "b": b,
+        "ecc_raw": ecc_raw,
+    }
+    return y, meta
+

--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1322,7 +1322,7 @@ class Ops:
     @staticmethod
     def call(sys, op_name: str, src_ids, out_id, *, residual=None, scale=1.0,
              write_out: bool = False, weight: str = "none"):
-        y = push_impulses_from_op_v2(
+        y, _ = push_impulses_from_op_v2(
             sys,
             op_name,
             src_ids,
@@ -1402,7 +1402,7 @@ class Experiencer(threading.Thread):
                 if out in self.outputs:
                     out_specs.append((name, srcs, out, args, kwargs))
             if out_specs:
-                ys, grads = push_impulses_from_ops_batched(
+                ys, grads, _ = push_impulses_from_ops_batched(
                     self.sys, out_specs, weight=None, scale=1.0
                 )
                 # Collect residuals for smoothing


### PR DESCRIPTION
## Summary
- reuse central abstract_nn activation registry in preactivation helper
- drop custom integration-specific activation mapping

## Testing
- `pytest tests/test_bridge_v2_keys.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9f223bcc832abaa429125156830b