### PR TITLE
Use vector residuals for feedback loss

### DIFF
--- a/src/common/tensors/autoautograd/integration/bridge_v2.py
+++ b/src/common/tensors/autoautograd/integration/bridge_v2.py
@@ -17,7 +17,7 @@ class _Job:
     src_ids: tuple[int, ...]
     op_args: Optional[Tuple[Any, ...]]
     op_kwargs: Optional[Dict[str, Any]]
-    residual: float | None
+    residual: Any | None
     scale: float | None
     weight: str | None
     backend_tag: Any = None


### PR DESCRIPTION
## Summary
- support vector residuals in `push_impulses_from_op`
- allow `_Job` to carry non-scalar residuals
- aggregate `0.5*(r*r).sum()` before broadcasting feedback loss

## Testing
- `pytest tests/test_bridge_v2_keys.py tests/test_whiteboard_cache.py tests/test_scheduling_module.py tests/test_pool_whiteboard_scheduler.py tests/test_dirichlet_neumann_feedback.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca52b124c832aaebe381badd70b58