### PR TITLE
Optimize NodeAttrView resolution

### DIFF
--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -149,9 +149,17 @@ def run_batched_vjp(
     scope_cm = getattr(backend, "scope", None)
     scope = scope_cm() if callable(scope_cm) else nullcontext()
 
+    hooks = NodeAttrView(sys.nodes, "sphere").resolve()
+
     with scope, _tape():
         for j in jobs:
-            x_j = NodeAttrView(sys.nodes, "sphere", indices=j.src_ids).build().tensor
+            x_j = NodeAttrView(
+                sys.nodes,
+                "sphere",
+                indices=j.src_ids,
+                hooks=hooks,
+                check_shapes=False,
+            ).build().tensor
             if hasattr(x_j, "requires_grad_"):
                 x_j = x_j.requires_grad_()
             xs.append(x_j)


### PR DESCRIPTION
## Summary
- Cache NodeAttrView hook resolution per instance and expose `resolve()` for reuse
- Allow callers to supply pre-resolved hooks and skip homogeneity checks
- Pre-resolve hooks in whiteboard runtime batched VJP to avoid redundant work

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_scheduling_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcb64b0634832ab9c54c57d5196a59