### PR TITLE
Add caching hooks to bridge_v2

### DIFF
--- a/tests/test_bridge_v2_cache.py
+++ b/tests/test_bridge_v2_cache.py
@@ -16,17 +16,12 @@ class DummySys:
         pass
 
 
-def _stub_batched_vjp(*, sys, jobs, op_args, op_kwargs, backend):
-    class _Batch:
-        def __init__(self, n):
-            self.ys = [0] * n
-            self.grads_full = [[0] * len(job.src_ids) for job in jobs]
-
-    return _Batch(len(jobs))
+def _stub_run_cached(sys, op_name, src_ids, **kwargs):
+    return 0, tuple(0 for _ in src_ids)
 
 
 def test_preactivation_cached(monkeypatch):
-    monkeypatch.setattr(bridge_v2, "run_batched_vjp", _stub_batched_vjp)
+    monkeypatch.setattr(bridge_v2, "run_op_and_grads_cached", _stub_run_cached)
     calls = []
 
     def _fake_preactivate(sys, nid):

--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -12,17 +12,12 @@ class DummySys:
         self.nodes = {0: DummyNode(), 1: DummyNode()}
 
 
-def _stub_batched_vjp(*, sys, jobs, op_args, op_kwargs, backend):
-    class _Batch:
-        def __init__(self, n):
-            self.ys = [1] * n
-            self.grads_per_source = [[0]] * n
-
-    return _Batch(len(jobs))
+def _stub_run_cached(*args, **kwargs):
+    return 1, (0,)
 
 
 def test_batched_forward_handles_list_kwargs(monkeypatch):
-    monkeypatch.setattr(bridge_v2, "run_batched_vjp", _stub_batched_vjp)
+    monkeypatch.setattr(bridge_v2, "run_op_and_grads_cached", _stub_run_cached)
     sys = DummySys()
     specs = [("noop", [0], 1, None, {"foo": [1, 2]})]
     assert bridge_v2.batched_forward_v2(sys, specs) == [1]


### PR DESCRIPTION
## Summary
- Route bridge v2 operations through `run_op_and_grads_cached` with optional cache parameter
- Expand cached op runner to key by weight, scale, and backend tag
- Update tests for new caching hooks

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_bridge_v2_cache.py tests/test_bridge_v2_keys.py tests/test_scheduling_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcb8815014832abb57b1db58e3af4e