### PR TITLE
feat: add grad modes to whiteboard cache

### DIFF
--- a/tests/test_bridge_v2_cache.py
+++ b/tests/test_bridge_v2_cache.py
@@ -17,7 +17,7 @@ class DummySys:
 
 
 def _stub_run_cached(sys, op_name, src_ids, **kwargs):
-    return 0, tuple(0 for _ in src_ids)
+    return 0, tuple(0 for _ in src_ids), {}
 
 
 def test_preactivation_cached(monkeypatch):

--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -13,7 +13,7 @@ class DummySys:
 
 
 def _stub_run_cached(*args, **kwargs):
-    return 1, (0,)
+    return 1, (0,), {}
 
 
 def test_batched_forward_handles_list_kwargs(monkeypatch):

--- a/tests/test_pool_whiteboard_scheduler.py
+++ b/tests/test_pool_whiteboard_scheduler.py
@@ -155,6 +155,7 @@ def test_cache_hits_with_tensor_pool():
             scale=j.scale,
             residual=j.residual,
             backend_tag=j.backend_tag,
+            grad_mode="scalar",
         )
         # Direct dictionary probe (authoritative)
         assert key in runner.cache._store

--- a/tests/test_whiteboard_cache.py
+++ b/tests/test_whiteboard_cache.py
@@ -16,14 +16,14 @@ def test_cache_hit_and_miss():
     nodes = {0: DummyNode(1.0), 1: DummyNode(2.0)}
     sys = DummySys(nodes)
     cache = WhiteboardCache()
-    y1, g1 = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    y1, g1, _ = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
     assert cache.misses == 1
     assert g1 == (1.0, 1.0)
-    y2, g2 = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    y2, g2, _ = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
     assert cache.hits == 1
     assert (y1, g1) == (y2, g2)
     nodes[0].version += 1
-    y3, _ = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
+    y3, _, _ = run_op_and_grads_cached(sys, 'add', [0, 1], cache=cache)
     assert cache.misses == 2
     assert y3 == y1
 
@@ -46,6 +46,6 @@ def test_gradient_alignment_mul():
     nodes = {0: DummyNode(3.0), 1: DummyNode(5.0)}
     sys = DummySys(nodes)
     cache = WhiteboardCache()
-    y, grads = run_op_and_grads_cached(sys, 'mul', [0, 1], cache=cache)
+    y, grads, _ = run_op_and_grads_cached(sys, 'mul', [0, 1], cache=cache)
     assert y == 15.0
     assert grads == (5.0, 3.0)


### PR DESCRIPTION
## Summary
- cache forward packages with grad_mode-aware keys and entries
- compute scalar, param-slice or full grads in whiteboard runtime
- bridge requests per-parameter grads and updates nodes accordingly

## Testing
- `pytest tests/test_whiteboard_cache.py tests/test_bridge_v2_cache.py tests/test_bridge_v2_keys.py tests/test_pool_whiteboard_scheduler.py tests/test_scheduling_module.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcd03bf290832a8d09841d50496be5