### PR TITLE
Log broken op gradient width

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -32,7 +32,7 @@ import time
 import threading
 from collections import deque, defaultdict
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, List, Optional, Callable
+from typing import Dict, Tuple, List, Optional, Callable, Set
 import matplotlib
 
 import matplotlib.pyplot as plt
@@ -1477,6 +1477,7 @@ class Experiencer(threading.Thread):
         self.outputs = outputs
         # If none provided, fall back to the tiny demo. (We’ll pass one in.)
         self.ops_program = ops_program
+        self._broken_ops_logged: Set[Tuple[str, int]] = set()
 
     def _residual_for_out(
         self, out_id: int, y_val: AbstractTensor, t: float
@@ -1485,6 +1486,23 @@ class Experiencer(threading.Thread):
             return None
         target_vec = self.outputs[out_id](t)
         return y_val - target_vec
+
+    def _warn_broken_op(
+        self,
+        name: str,
+        out_id: int,
+        g_stack: AbstractTensor,
+        g_list: List[AbstractTensor],
+    ) -> None:
+        width = g_stack.shape[1] if getattr(g_stack, "ndim", 0) > 1 else 0
+        if width != 0:
+            return
+        key = (name, int(out_id))
+        if key in self._broken_ops_logged:
+            return
+        shapes = [getattr(g, "shape", None) for g in g_list]
+        print(f"[BROKEN-OP] op={name} out={out_id} grad_shapes={shapes}")
+        self._broken_ops_logged.add(key)
 
     def run(self):
         t0 = now_s()
@@ -1536,6 +1554,7 @@ class Experiencer(threading.Thread):
                 if r is None or not g_list:
                     continue
                 g_stack = AbstractTensor.stack(list(g_list), dim=0)
+                self._warn_broken_op(name, out, g_stack, g_list)
                 r_tensor = AbstractTensor.get_tensor(r)
                 prod = g_stack * r_tensor
                 g_scalars = prod.reshape(len(srcs), -1).sum(dim=1)

--- a/tests/test_broken_op_logging.py
+++ b/tests/test_broken_op_logging.py
@@ -1,0 +1,42 @@
+import threading
+import types
+import sys
+
+
+def _stub_dependencies():
+    stub_bridge = types.ModuleType("bridge_v2")
+    def _dummy(*args, **kwargs):
+        return [], [], []
+    stub_bridge.push_impulses_from_op_v2 = _dummy
+    stub_bridge.push_impulses_from_ops_batched = _dummy
+    pkg = types.ModuleType("integration")
+    pkg.bridge_v2 = stub_bridge
+    sys.modules.setdefault("src.common.tensors.autoautograd.integration", pkg)
+    sys.modules.setdefault(
+        "src.common.tensors.autoautograd.integration.bridge_v2", stub_bridge
+    )
+    sys.modules.setdefault(
+        "src.common.tensors.autoautograd.whiteboard_cache", types.ModuleType("whiteboard_cache")
+    )
+    open_gl = types.ModuleType("OpenGL")
+    open_gl.GL = types.ModuleType("GL")
+    sys.modules.setdefault("OpenGL", open_gl)
+    sys.modules.setdefault("OpenGL.GL", open_gl.GL)
+
+
+def test_broken_op_log_emitted_once(capsys):
+    _stub_dependencies()
+    from src.common.tensors.abstraction import AbstractTensor
+    from src.common.tensors.autoautograd.spring_async_toy import Experiencer
+
+    class DummySys:
+        pass
+
+    exp = Experiencer(DummySys(), threading.Event(), {}, ops_program=[])
+    g_list = [AbstractTensor.get_tensor([])]
+    g_stack = AbstractTensor.stack(list(g_list), dim=0)
+    exp._warn_broken_op("noop", 7, g_stack, g_list)
+    exp._warn_broken_op("noop", 7, g_stack, g_list)
+    out = capsys.readouterr().out
+    assert out.count("[BROKEN-OP]") == 1
+    assert "op=noop" in out and "out=7" in out


### PR DESCRIPTION
## Summary
- log `[BROKEN-OP]` once per op when stacked gradients have zero width
- add test harness verifying broken op logging

## Testing
- `pytest tests/test_broken_op_logging.py -q` *(fails: ImportError: Unable to load OpenGL or GL library)*

------
https://chatgpt.com/codex/tasks/task_e_68bd81b20490832ab46b20cc882eecd1