### PR TITLE
Use sequential indices in gather_and ops

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1899,7 +1899,7 @@ class LinearBlockFactory:
                     srcs,
                     tgt,
                     None,
-                    {"indices": srcs, "dim": 0, "fn": agg_fn},
+                    {"indices": list(range(len(srcs))), "dim": 0, "fn": agg_fn},
                 ))
 
         # --- connect: row r -> row r+1 (fully connected between consecutive rows) ---
@@ -1915,7 +1915,7 @@ class LinearBlockFactory:
                     srcs,
                     tgt,
                     None,
-                    {"indices": srcs, "dim": 0, "fn": agg_fn},
+                    {"indices": list(range(len(srcs))), "dim": 0, "fn": agg_fn},
                 ))
 
         # --- connect: last row -> outputs (+ bias per output) ---
@@ -1929,7 +1929,7 @@ class LinearBlockFactory:
                 srcs,
                 oj,
                 None,
-                {"indices": srcs, "dim": 0, "fn": agg_fn},
+                {"indices": list(range(len(srcs))), "dim": 0, "fn": agg_fn},
             ))
 
         return LinearBlock(


### PR DESCRIPTION
## Summary
- use range-based indices when wiring gather_and ops in `spring_async_toy`

## Testing
- `pytest src/common/tensors/autoautograd`

------
https://chatgpt.com/codex/tasks/task_e_68bd9dbdc508832aaed03269d9729df1