### PR TITLE
Remove redundant width check in spring async toy

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1628,11 +1628,6 @@ class Experiencer(threading.Thread):
                         raise ValueError(
                             f"{name}: expected {len(srcs)} gradients, got {g_stack.shape[0]} (output {out})"
                         )
-                    y_width = y.shape[-1] if getattr(y, "ndim", 0) > 0 else 1
-                    if y_width != C:
-                        raise ValueError(
-                            f"{name}: output width {y_width} mismatches grad width {C}"
-                        )
                     for item in list(items.values()):
                         if space is Space.F and item.width != C:
                             raise ValueError(


### PR DESCRIPTION
## Summary
- drop output width comparison from reverse sweep loop in `spring_async_toy`
- retain residual width assertions

## Testing
- `pytest tests/test_grad_validation.py tests/test_spring_async_toy_tensor_glist.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9dc317a0832aaea0a6035af34e70