### PR TITLE
Refine gradient list validation in spring async toy autograd

### DIFF
--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1619,9 +1619,11 @@ class Experiencer(threading.Thread):
                     list(zip(specs, grads, ys))
                 ):
                     items = bucket.get(int(out))
-                    if items is None or g_list is None:
-                        continue
-                    if isinstance(g_list, (list, tuple, AbstractTensor)) and len(g_list) == 0:
+                    if (
+                        items is None
+                        or not isinstance(g_list, (list, tuple, AbstractTensor))
+                        or len(g_list) == 0
+                    ):
                         continue
                     g_stack, C = _stack_grads_per_source(name, out, srcs, g_list)
                     if g_stack.shape[0] != len(srcs):


### PR DESCRIPTION
## Summary
- Harden gradient list validation during reverse sweep in `spring_async_toy`

## Testing
- `pytest tests/test_spring_async_toy_tensor_glist.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd9dd1b9f4832a9ddb3622ca77e206