### PR TITLE
Refactor autoautograd demo for new gather_and chain

### DIFF
--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -35,13 +35,14 @@ class BatchVJPResult:
 class SubFnMeta:
     """Description of a post-op function in a composite kernel.
 
-    ``param_refs`` lists indices into the invoking node's ``param`` vector that
-    should be passed as positional operands.  Scalars broadcast according to the
-    backend's normal rules so no extra annotation is required for them.
+    ``param_refs`` lists indices or slices into the invoking node's ``param``
+    vector that should be passed as positional operands.  Scalars broadcast
+    according to the backend's normal rules so no extra annotation is required
+    for them.
     """
 
     name: str
-    param_refs: Tuple[int, ...] = ()
+    param_refs: Tuple[Any, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -85,12 +86,16 @@ BATCHABLE_OPS: Dict[str, OpBatchMeta] = {
     # ``matmul`` is included as an example of a non element-wise operator.
     "matmul": OpBatchMeta(shape="matmul"),
     # ``gather_and`` gathers then applies a tiny op chain such as
-    # ("__mul__", "__add__").  Parameter references mirror how the autoautograd
-    # demo wires weights then biases via ``param[1]`` and ``param[2]``.
+    # ("__mul__", "__add__").  Parameter slices mirror how the autoautograd
+    # demo wires weights then biases via ``slice(1, None, 3)`` and
+    # ``slice(2, None, 3)``.
     "gather_and": OpBatchMeta(
         shape="gather",
         dim_params=("dim",),
-        sub_fns=(SubFnMeta("__mul__", (1,)), SubFnMeta("__add__", (2,))),
+        sub_fns=(
+            SubFnMeta("__mul__", (slice(1, None, 3),)),
+            SubFnMeta("__add__", (slice(2, None, 3),)),
+        ),
     ),
 }
 


### PR DESCRIPTION
## Summary
- update spring_async_toy to drive gather_and via explicit function chain
- allow slice-based param specs and document in whiteboard runtime

## Testing
- `pytest tests/test_scheduling_module.py -vv`
- `pytest tests/test_whiteboard_cache.py -vv`
- `pytest tests/test_whiteboard_runtime_none_grads.py -vv`
- `pytest tests/test_grad_validation.py -vv`
- `pytest tests/test_spring_async_toy_tensor_glist.py -vv`
- `pytest tests/test_residual_store_put.py -vv`
- `pytest tests/test_geometry_residual_no_impulse.py -vv`
- `pytest tests/test_bridge_v2_keys.py -vv`
- `pytest tests/test_bridge_v2_cache.py -vv`
- `pytest tests/test_dirichlet_neumann_feedback.py -vv` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be34cd05e8832a9d68592de68cd103