### PR TITLE
Handle slice objects in autoautograd key freeze

### DIFF
--- a/src/common/tensors/autoautograd/integration/bridge_v2.py
+++ b/src/common/tensors/autoautograd/integration/bridge_v2.py
@@ -83,6 +83,12 @@ def _op_apply_factory(
 
 def _freeze_for_key(obj: Any) -> Any:
     """Recursively convert lists/dicts to tuples for hashing."""
+    if isinstance(obj, slice):
+        return (
+            _freeze_for_key(obj.start),
+            _freeze_for_key(obj.stop),
+            _freeze_for_key(obj.step),
+        )
     if isinstance(obj, dict):
         return tuple(sorted((str(k), _freeze_for_key(v)) for k, v in obj.items()))
     if isinstance(obj, (list, tuple)):

--- a/tests/test_bridge_v2_keys.py
+++ b/tests/test_bridge_v2_keys.py
@@ -21,3 +21,20 @@ def test_batched_forward_handles_list_kwargs(monkeypatch):
     sys = DummySys()
     specs = [("noop", [0], 1, None, {"foo": [1, 2]})]
     assert bridge_v2.batched_forward_v2(sys, specs) == [1]
+
+
+def test_batched_forward_batches_equivalent_slices(monkeypatch):
+    calls = []
+
+    def _recording_stub(*args, **kwargs):
+        calls.append(1)
+        return 1, (0,), {}
+
+    monkeypatch.setattr(bridge_v2, "run_op_and_grads_cached", _recording_stub)
+    sys = DummySys()
+    specs = [
+        ("noop", [0], 1, None, {"foo": slice(0, 10, 2)}),
+        ("noop", [0], 1, None, {"foo": slice(0, 10, 2)}),
+    ]
+    assert bridge_v2.batched_forward_v2(sys, specs) == [1, 1]
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- Ensure `_freeze_for_key` converts `slice` objects into `(start, stop, step)` tuples so identical slices hash consistently
- Add regression test confirming batched operations deduplicate equivalent slice kwargs

## Testing
- `pytest tests/test_bridge_v2_keys.py tests/test_bridge_v2_cache.py -q` *(fails: sympy import in test configuration caused a long-running process, aborted with KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68be3aea0340832a8c719f77a5b8ecdb