### PR TITLE
Handle gather_and parameter slice broadcasting

### DIFF
--- a/tests/test_gather_and_broadcast.py
+++ b/tests/test_gather_and_broadcast.py
@@ -1,0 +1,27 @@
+import importlib.util
+import numpy as np
+import pytest
+
+try:
+    from src.common.tensors.numpy_backend import NumPyTensorOperations
+except Exception:  # pragma: no cover - optional dependency
+    NumPyTensorOperations = None
+
+BACKENDS = []
+if NumPyTensorOperations is not None:
+    BACKENDS.append(("NumPy", NumPyTensorOperations))
+
+
+@pytest.mark.parametrize("backend_name,Backend", BACKENDS)
+def test_gather_and_mul_add_broadcast(backend_name, Backend):
+    batch, n, features = 2, 3, 4
+    base = Backend.tensor(np.ones((n, features)))
+    indices = Backend.tensor(np.tile(np.arange(n), (batch, 1)))
+    params = Backend.tensor(np.vstack([np.arange(n), np.arange(n) + 10]))
+    fn_specs = [(Backend.__mul__, 0), (Backend.__add__, 1)]
+    out = base.gather_and(0, indices, fn_specs, params)
+    expected = (
+        np.ones((batch, n, features)) * np.arange(n).reshape(1, n, 1)
+        + (np.arange(n) + 10).reshape(1, n, 1)
+    )
+    assert np.allclose(out.data, expected)


### PR DESCRIPTION
## Summary
- Reshape `gather_and` parameter slices to insert leading and trailing singleton dimensions for proper broadcasting.
- Add regression test ensuring `gather_and` handles `(batch, n, features)` with `(n,)` parameter slices when multiplying and adding.

## Testing
- `pytest tests/test_gather_and_broadcast.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be509fe2f0832a90cad863b4060a0f