### PR TITLE
Return per-source grad tensor

### DIFF
--- a/tests/test_grad_validation.py
+++ b/tests/test_grad_validation.py
@@ -1,88 +1,57 @@
-import threading
 import types
-import sys
 import pytest
 
-
-def _stub_dependencies():
-    stub_bridge = types.ModuleType("bridge_v2")
-    def _dummy(*args, **kwargs):
-        return [], [], []
-    stub_bridge.push_impulses_from_op_v2 = _dummy
-    stub_bridge.push_impulses_from_ops_batched = _dummy
-    pkg = types.ModuleType("integration")
-    pkg.bridge_v2 = stub_bridge
-    sys.modules.setdefault("src.common.tensors.autoautograd.integration", pkg)
-    sys.modules.setdefault(
-        "src.common.tensors.autoautograd.integration.bridge_v2", stub_bridge
-    )
-
-    wbc = types.ModuleType("whiteboard_cache")
-    class WhiteboardCache:
-        pass
-    wbc.WhiteboardCache = WhiteboardCache
-    sys.modules.setdefault(
-        "src.common.tensors.autoautograd.whiteboard_cache", wbc
-    )
-    open_gl = types.ModuleType("OpenGL")
-    open_gl.__path__ = []
-    gl_mod = types.ModuleType("GL")
-    gl_mod.__path__ = []
-    shaders_mod = types.ModuleType("shaders")
-    def _noop(*args, **kwargs):
-        return None
-    shaders_mod.compileProgram = _noop
-    shaders_mod.compileShader = _noop
-    gl_mod.shaders = shaders_mod
-    gl_mod.GL_DYNAMIC_DRAW = 0
-    sys.modules.setdefault("OpenGL", open_gl)
-    sys.modules.setdefault("OpenGL.GL", gl_mod)
-    sys.modules.setdefault("OpenGL.GL.shaders", shaders_mod)
-    open_gl.GL = gl_mod
-    pygame = types.ModuleType("pygame")
-    pygame.__path__ = []
-    locals_mod = types.ModuleType("locals")
-    for name in ["DOUBLEBUF", "OPENGL", "RESIZABLE", "VIDEORESIZE", "QUIT", "KEYDOWN", "K_SPACE"]:
-        setattr(locals_mod, name, 0)
-    pygame.locals = locals_mod
-    pygame.display = types.SimpleNamespace(set_mode=lambda *a, **k: None)
-    pygame.event = types.SimpleNamespace(get=lambda: [])
-    pygame.init = lambda *a, **k: None
-    pygame.quit = lambda *a, **k: None
-    sys.modules.setdefault("pygame", pygame)
-    sys.modules.setdefault("pygame.locals", locals_mod)
-    # matplotlib stubs
-    mpl = types.ModuleType("matplotlib")
-    mpl.__path__ = []
-    mpl.pyplot = types.ModuleType("pyplot")
-    mpl.animation = types.ModuleType("animation")
-    mpl.colors = types.ModuleType("colors")
-    sys.modules.setdefault("matplotlib", mpl)
-    sys.modules.setdefault("matplotlib.pyplot", mpl.pyplot)
-    sys.modules.setdefault("matplotlib.animation", mpl.animation)
-    sys.modules.setdefault("matplotlib.colors", mpl.colors)
-
-
-_stub_dependencies()
-
 from src.common.tensors.abstraction import AbstractTensor
-from src.common.tensors.autoautograd.spring_async_toy import _stack_grads_per_source
+from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp
 
 
-def test_stack_grads_width_mismatch_raises():
-    g1 = AbstractTensor.get_tensor([1.0, 2.0])
-    g2 = AbstractTensor.get_tensor([1.0])
-    with pytest.raises(ValueError) as e:
-        _stack_grads_per_source("add", 3, [1, 2], [g1, g2])
-    msg = str(e.value)
-    assert "add" in msg and "output 3" in msg
-    assert "source index 1" in msg
+class _Node:
+    def __init__(self, val):
+        self.sphere = AbstractTensor.get_tensor(val)
+        self.p = AbstractTensor.zeros(1, float)
+        self.version = 0
 
 
-def test_stack_grads_missing_gradient_raises():
-    g1 = AbstractTensor.get_tensor([1.0, 2.0])
-    with pytest.raises(ValueError) as e:
-        _stack_grads_per_source("mul", 5, [1, 2], [g1])
-    msg = str(e.value)
-    assert "mul" in msg and "output 5" in msg
-    assert "source index 1" in msg
+class _Sys2:
+    def __init__(self):
+        self.nodes = {0: _Node([1.0, 2.0, 3.0]), 1: _Node([4.0, 5.0, 6.0])}
+
+
+class _Sys3:
+    def __init__(self):
+        self.nodes = {
+            0: _Node([1.0, 2.0, 3.0]),
+            1: _Node([4.0, 5.0, 6.0]),
+            2: _Node([7.0, 8.0, 9.0]),
+        }
+
+
+def test_grads_per_source_tensor_matches_reduction():
+    import types
+
+    sys = _Sys2()
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
+    res = run_batched_vjp(sys=sys, jobs=(j0, j1))
+    g = res.grads_per_source_tensor
+    sums = tuple(float(x) for x in g.sum(dim=1))
+    assert sums[0] == res.grads_per_source[0][0]
+    assert sums[1] == res.grads_per_source[1][0]
+
+
+def test_grads_full_consistent_with_stacked_tensor():
+    import types
+
+    sys = _Sys3()
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
+    j2 = types.SimpleNamespace(job_id="j2", op="__neg__", src_ids=(2,), residual=None)
+    res = run_batched_vjp(sys=sys, jobs=(j0, j1, j2))
+    g = res.grads_per_source_tensor
+    g0 = g[0]
+    g1 = g[1]
+    g2 = g[2]
+    assert float((g0 - res.grads_full[0]).sum()) == 0.0
+    assert float((g1 - res.grads_full[1]).sum()) == 0.0
+    assert float((g2 - res.grads_full[2]).sum()) == 0.0
+

--- a/tests/test_spring_async_toy_tensor_glist.py
+++ b/tests/test_spring_async_toy_tensor_glist.py
@@ -1,120 +1,41 @@
-import types
-import sys
-import pytest
-
-
-def _stub_dependencies():
-    stub_bridge = types.ModuleType("bridge_v2")
-
-    def _dummy(*args, **kwargs):
-        return [], [], []
-
-    stub_bridge.push_impulses_from_op_v2 = _dummy
-    stub_bridge.push_impulses_from_ops_batched = _dummy
-    pkg = types.ModuleType("integration")
-    pkg.bridge_v2 = stub_bridge
-    sys.modules.setdefault("src.common.tensors.autoautograd.integration", pkg)
-    sys.modules.setdefault(
-        "src.common.tensors.autoautograd.integration.bridge_v2", stub_bridge
-    )
-
-    wbc = types.ModuleType("whiteboard_cache")
-
-    class WhiteboardCache:
-        pass
-
-    wbc.WhiteboardCache = WhiteboardCache
-    sys.modules.setdefault(
-        "src.common.tensors.autoautograd.whiteboard_cache", wbc
-    )
-
-    open_gl = types.ModuleType("OpenGL")
-    open_gl.__path__ = []
-    gl_mod = types.ModuleType("GL")
-    gl_mod.__path__ = []
-    shaders_mod = types.ModuleType("shaders")
-
-    def _noop(*args, **kwargs):
-        return None
-
-    shaders_mod.compileProgram = _noop
-    shaders_mod.compileShader = _noop
-    gl_mod.shaders = shaders_mod
-    gl_mod.GL_DYNAMIC_DRAW = 0
-    sys.modules.setdefault("OpenGL", open_gl)
-    sys.modules.setdefault("OpenGL.GL", gl_mod)
-    sys.modules.setdefault("OpenGL.GL.shaders", shaders_mod)
-    open_gl.GL = gl_mod
-
-    pygame = types.ModuleType("pygame")
-    pygame.__path__ = []
-    locals_mod = types.ModuleType("locals")
-    for name in [
-        "DOUBLEBUF",
-        "OPENGL",
-        "RESIZABLE",
-        "VIDEORESIZE",
-        "QUIT",
-        "KEYDOWN",
-        "K_SPACE",
-    ]:
-        setattr(locals_mod, name, 0)
-    pygame.locals = locals_mod
-    pygame.display = types.SimpleNamespace(set_mode=lambda *a, **k: None)
-    pygame.event = types.SimpleNamespace(get=lambda: [])
-    pygame.init = lambda *a, **k: None
-    pygame.quit = lambda *a, **k: None
-    sys.modules.setdefault("pygame", pygame)
-    sys.modules.setdefault("pygame.locals", locals_mod)
-
-    mpl = types.ModuleType("matplotlib")
-    mpl.__path__ = []
-    mpl.pyplot = types.ModuleType("pyplot")
-    mpl.animation = types.ModuleType("animation")
-    mpl.colors = types.ModuleType("colors")
-    sys.modules.setdefault("matplotlib", mpl)
-    sys.modules.setdefault("matplotlib.pyplot", mpl.pyplot)
-    sys.modules.setdefault("matplotlib.animation", mpl.animation)
-    sys.modules.setdefault("matplotlib.colors", mpl.colors)
-
-
-_stub_dependencies()
-
 from src.common.tensors.abstraction import AbstractTensor
-from src.common.tensors.autoautograd.spring_async_toy import _stack_grads_per_source
-import importlib
-
-spring_async_toy = importlib.import_module("src.common.tensors.autoautograd.spring_async_toy")
+from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp
 
 
-def test_tensor_glist_no_ambiguous_truthiness():
-    g_tensor = AbstractTensor.get_tensor([[1.0], [2.0]])
-    # Demonstrate that direct truthiness is ambiguous
+class _Node:
+    def __init__(self, val):
+        from src.common.tensors.abstraction import AbstractTensor
+
+        self.sphere = AbstractTensor.get_tensor(val)
+        self.p = AbstractTensor.zeros(1, float)
+        self.version = 0
+
+
+class _Sys:
+    def __init__(self):
+        self.nodes = {0: _Node([1.0, 2.0, 3.0]), 1: _Node([4.0, 5.0, 6.0])}
+
+
+def test_run_batched_vjp_returns_tensor_per_source():
+    import types
+    import pytest
+    from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp
+
+    sys_obj = _Sys()
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
+    res = run_batched_vjp(sys=sys_obj, jobs=(j0, j1))
+    g = res.grads_per_source_tensor
+    assert getattr(g, "shape", None)[0] == 2
     with pytest.raises(ValueError):
-        if g_tensor:
+        if g:
             pass
-    # Should not raise when passed as g_list
-    g_stack, width = _stack_grads_per_source("add", 3, [1, 2], g_tensor)
-    assert g_stack.shape == g_tensor.shape
-    assert width == g_tensor.shape[-1]
 
 
-def test_empty_tensor_glist_skipped(monkeypatch):
-    g_tensor = AbstractTensor.get_tensor([])
-    called = {"count": 0}
+def test_run_batched_vjp_no_jobs_has_none_tensor():
+    from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp
 
-    def _fake_stack(*args, **kwargs):
-        called["count"] += 1
-        return AbstractTensor.zeros(1), 1
+    sys_obj = _Sys()
+    res = run_batched_vjp(sys=sys_obj, jobs=())
+    assert res.grads_per_source_tensor is None
 
-    monkeypatch.setattr(spring_async_toy, "_stack_grads_per_source", _fake_stack)
-    items = {None: types.SimpleNamespace(value=AbstractTensor.get_tensor(0.0), width=1, axis=None)}
-
-    if items is None or g_tensor is None:
-        pass
-    elif isinstance(g_tensor, (list, tuple, AbstractTensor)) and len(g_tensor) == 0:
-        pass
-    else:
-        spring_async_toy._stack_grads_per_source("add", 3, [1, 2], g_tensor)
-
-    assert called["count"] == 0


### PR DESCRIPTION
## Summary
- expose stacked per-source gradients from run_batched_vjp
- consume vectorized grad tensors in spring_async_toy reflection loop
- exercise new gradient path in tests

## Testing
- `pytest tests/test_whiteboard_runtime_none_grads.py tests/test_spring_async_toy_tensor_glist.py tests/test_grad_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68be5509f058832abe646e2cd4298aa5