### PR TITLE
Add parameter tensor gradients to batched VJP

### DIFF
--- a/tests/test_scheduling_module.py
+++ b/tests/test_scheduling_module.py
@@ -49,7 +49,14 @@ def _stub_batched_vjp(*, sys, jobs, op_args=(), op_kwargs=None, backend=None) ->
     ys = tuple(f"y:{j.job_id}" for j in jobs)
     grads_per_source = tuple(tuple(float(i) for i in range(len(j.src_ids))) for j in jobs)
     slices = BatchSlices(index_of={j.job_id: i for i, j in enumerate(jobs)}, job_ids=tuple(j.job_id for j in jobs))
-    return BatchVJPResult(slices=slices, ys=ys, grads_full=tuple(None for _ in jobs), grads_per_source=grads_per_source)
+    return BatchVJPResult(
+        slices=slices,
+        ys=ys,
+        grads_full=tuple(None for _ in jobs),
+        grads_per_source=grads_per_source,
+        param_grads_full=tuple(None for _ in jobs),
+        param_grads_tensor=None,
+    )
 
 
 def test_runner_cache_probe_and_update(monkeypatch):

--- a/tests/test_whiteboard_runtime_none_grads.py
+++ b/tests/test_whiteboard_runtime_none_grads.py
@@ -25,6 +25,8 @@ def test_run_op_and_grads_cached_none_grads(monkeypatch):
             ys=(AbstractTensor.zeros(3, float),),
             grads_full=(None,),
             grads_per_source=((0.0,),),
+            param_grads_full=(None,),
+            param_grads_tensor=None,
         )
 
     import src.common.tensors.autoautograd.whiteboard_runtime as wr


### PR DESCRIPTION
## Summary
- compute gradients for both source tensors and parameter tensors in batched VJP
- propagate new parameter gradients through run_op_and_grads_cached
- update tests for new BatchVJPResult structure

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_whiteboard_runtime_none_grads.py tests/test_scheduling_module.py tests/test_whiteboard_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6267a3cc832ab86891bd1221f39a