### PR TITLE
Ensure gather_and param gradients with positional dim

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -1131,6 +1131,14 @@ class AbstractTensor:
         Gather from `base` (=other or self) along `dim` with `indices`,
         then run a function chain with per-fn params sliced from `param_tensor`.
 
+        Call Signatures
+        ---------------
+        ``gather_and(dim, indices, fn_specs, param_tensor, *, other=None)``
+            Standard form with ``dim`` as the first positional argument.
+        ``gather_and(indices, fn_specs, param_tensor, *, dim, other=None)``
+            ``dim`` may also be supplied via keyword, in which case the other
+            arguments remain positional.
+
         Parameters
         ----------
         dim : int

--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -280,11 +280,14 @@ def run_batched_vjp(
     op_kwargs = op_kwargs or {}
     op_name = jobs[0].op if jobs else ""
 
-    param_tensor = None
-    if "param_tensor" in op_kwargs:
-        param_tensor = op_kwargs["param_tensor"]
-    elif op_name == "gather_and" and len(op_args) >= 3 and not isinstance(op_args[0], int):
-        param_tensor = op_args[2]
+    param_tensor = op_kwargs.get("param_tensor")
+    if param_tensor is None and op_name == "gather_and":
+        if len(op_args) >= 4 and isinstance(op_args[0], int):
+            # dim is the first positional argument
+            param_tensor = op_args[3]
+        elif len(op_args) >= 3:
+            # dim is provided via keyword or omitted from position 0
+            param_tensor = op_args[2]
 
     if not jobs:
         return BatchVJPResult(

--- a/tests/test_gather_and_param_grads.py
+++ b/tests/test_gather_and_param_grads.py
@@ -42,3 +42,26 @@ def test_gather_and_param_grads():
     )
     g = AbstractTensor.get_tensor(g_param)
     assert getattr(g, "shape", None) == (2, 3)
+
+
+def test_gather_and_dim_first_param_grads():
+    sys = _Sys()
+    indices = list(range(2))
+    fn_specs = [
+        (AbstractTensor.__mul__, slice(1, None, 3)),
+        (AbstractTensor.__add__, slice(2, None, 3)),
+    ]
+    params_vec = AbstractTensor.concat(
+        [sys.nodes[0].param.flatten(), sys.nodes[1].param.flatten()], dim=0
+    ).flatten()
+    param_lens = [len(sys.nodes[0].param.flatten()), len(sys.nodes[1].param.flatten())]
+    _, g_param, _ = run_op_and_grads_cached(
+        sys,
+        "gather_and",
+        [0, 1],
+        op_args=(0, indices, fn_specs, params_vec),
+        grad_mode="param",
+        param_lens=param_lens,
+    )
+    g = AbstractTensor.get_tensor(g_param)
+    assert getattr(g, "shape", None) == (2, 3)


### PR DESCRIPTION
## Summary
- allow `run_batched_vjp` to find `param_tensor` whether `dim` is positional or keyword
- document `gather_and` call signatures
- cover `gather_and` param gradients when `dim` is first positional argument

## Testing
- `pytest tests/test_gather_and_param_grads.py tests/test_gather_and_broadcast.py tests/test_grad_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68bed9c1aad4832aa8f7bab0a175ac01