### PR TITLE
Replace NumPy ops in spring_async_toy with AbstractTensor and add backend parity test

### DIFF
--- a/src/common/tensors/pure_backend.py
+++ b/src/common/tensors/pure_backend.py
@@ -492,7 +492,8 @@ class PurePythonTensorOperations(AbstractTensor):
             return self.get_dtype_(tensor[0])
         return type(tensor)
 
-    def item_(self, tensor: Any) -> Any:
+    def item_(self) -> Any:
+        tensor = self.data
         if isinstance(tensor, list) and len(tensor) == 1:
             return tensor[0]
         return tensor
@@ -1194,10 +1195,10 @@ class PurePythonTensorOperations(AbstractTensor):
             return [self.pow_(item, exponent) for item in tensor]
         return tensor**exponent
 
-    def sqrt_(self, tensor: Any) -> Any:
-        tensor = self._AbstractTensor__unwrap(tensor)
+    def sqrt_(self) -> Any:
+        tensor = self.data
         if isinstance(tensor, list):
-            return [self.sqrt_(item) for item in tensor]
+            return [math.sqrt(item) for item in tensor]
         return math.sqrt(tensor)
 
     def tensor_from_list_(self, data: list, dtype: Any, device: Any) -> Any:

--- a/tests/autoautograd/test_spring_dt_engine_backends.py
+++ b/tests/autoautograd/test_spring_dt_engine_backends.py
@@ -1,0 +1,42 @@
+from pytest import approx
+
+from src.common.tensors.abstraction import AbstractTensor, BACKEND_REGISTRY
+from src.common.tensors.numpy_backend import NumPyTensorOperations  # noqa: F401
+from src.common.tensors.pure_backend import PurePythonTensorOperations  # noqa: F401
+from src.common.tensors.autoautograd.spring_async_toy import (
+    Node,
+    Edge,
+    SpringRepulsorSystem,
+    SpringDtEngine,
+)
+
+
+def _run_system():
+    n0 = Node(id=0, p=AbstractTensor.get_tensor([0.0, 0.0, 0.0]))
+    n1 = Node(id=1, p=AbstractTensor.get_tensor([1.0, 0.0, 0.0]))
+    n0.hist_p.append(n0.p.clone())
+    n1.hist_p.append(n1.p.clone())
+    e = Edge(key=(0, 1, "spring"), i=0, j=1, op_id="spring",
+             l0=AbstractTensor.tensor(1.0), k=AbstractTensor.tensor(1.0))
+    sys = SpringRepulsorSystem([n0, n1], [e], eta=0.0, gamma=1.0, dt=0.1)
+    engine = SpringDtEngine(sys)
+    engine.step(0.1)
+    return [sys.nodes[0].p.tolist(), sys.nodes[1].p.tolist()]
+
+
+def _run_backend(name, backend_cls):
+    orig = BACKEND_REGISTRY.copy()
+    try:
+        BACKEND_REGISTRY.clear()
+        BACKEND_REGISTRY[name] = backend_cls
+        return _run_system()
+    finally:
+        BACKEND_REGISTRY.clear()
+        BACKEND_REGISTRY.update(orig)
+
+
+def test_spring_dt_engine_numpy_vs_pure_python():
+    numpy_pos = _run_backend("numpy", NumPyTensorOperations)
+    pure_pos = _run_backend("pure_python", PurePythonTensorOperations)
+    for np_p, py_p in zip(numpy_pos, pure_pos):
+        assert np_p == approx(py_p)


### PR DESCRIPTION
## Summary
- remove direct NumPy usage in spring_async_toy and build geometry tensors via AbstractTensor
- implement missing sqrt_/item_ in PurePythonTensorOperations
- add regression test ensuring SpringDtEngine matches on numpy and pure_python backends

## Testing
- `pytest tests/autoautograd/test_spring_dt_engine_backends.py -q`
- `pytest tests/test_spring_async_toy_tensor_glist.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf3c1e0918832ab138de5c5feb98e8