### PR TITLE
Gracefully handle short histories in spectral inertia

### DIFF
--- a/src/common/dt_system/spectral_dampener.py
+++ b/src/common/dt_system/spectral_dampener.py
@@ -20,6 +20,11 @@ from typing import Iterable, List, Tuple
 
 from ..tensors.abstraction import AbstractTensor
 
+# Minimum number of history samples required before performing any FFT based
+# analysis.  Below this threshold the routine returns a zero response so callers
+# can treat the result as a no-op and simply pass the state through unchanged.
+_MIN_FFT_WINDOW = 32
+
 
 def spectral_inertia(history: Iterable[AbstractTensor], dt: float) -> Tuple[AbstractTensor, AbstractTensor, List[Tuple[float, float, float]]]:
     """Estimate a spectral inertia response from ``history``.
@@ -42,11 +47,8 @@ def spectral_inertia(history: Iterable[AbstractTensor], dt: float) -> Tuple[Abst
     """
     hist = list(history)
     H = len(hist)
-    if H < 32:
-        if H == 0:
-            D = 0
-        else:
-            D = hist[0].shape[0]
+    if H < _MIN_FFT_WINDOW:
+        D = hist[-1].shape[0] if H else 0
         return (
             AbstractTensor.zeros(D, float),
             AbstractTensor.zeros((D, D), float),

--- a/tests/autoautograd/test_spring_dt_thread.py
+++ b/tests/autoautograd/test_spring_dt_thread.py
@@ -99,6 +99,17 @@ def test_spectral_inertia_reduces_velocity_norm():
     assert energy_damped < energy_no
 
 
+def test_spectral_inertia_passthrough_with_short_history():
+    AT = AbstractTensor
+    dt = 0.1
+    # Fewer samples than the minimum FFT window should yield a zero response
+    hist = [AT.tensor([0.0, 0.0]) for _ in range(10)]
+    resp, J, bands = spectral_inertia(hist, dt)
+    assert AT.get_tensor(resp).abs().sum().item() == 0.0
+    assert AT.get_tensor(J).abs().sum().item() == 0.0
+    assert bands == []
+
+
 def test_threaded_engine_steps_independently():
     sys = _build_simple_system()
     table = StateTable()


### PR DESCRIPTION
## Summary
- Skip spectral FFT analysis when history is shorter than a full window
- Add regression test ensuring spectral inertia is a no-op with insufficient samples

## Testing
- `pytest tests/autoautograd/test_spring_dt_thread.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf2a644b88832a8a4da2ab3ff66b4c