### PR TITLE
Refactor FluxSpring types around AbstractTensor transport

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -1,5 +1,5 @@
 from .fs_types import (
-    LearnCtrl, NodeCtrl, EdgeHookeLearn, EdgeHooke, EdgeCtrl,
+    LearnCtrl, NodeCtrl, EdgeTransportLearn, EdgeTransport, EdgeCtrl,
     NodeSpec, EdgeSpec, FaceLearn, FaceSpec,
     DirichletCfg, DECSpec, RegCfg, FluxSpringSpec
 )

--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -53,21 +53,27 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["src", "dst", "hooke", "ctrl"],
+        "required": ["src", "dst", "transport", "ctrl"],
         "properties": {
           "src": { "type": "integer" },
           "dst": { "type": "integer" },
-          "hooke": {
+          "transport": {
             "type": "object",
-            "required": ["k", "l0", "learn"],
+            "required": ["kappa", "learn"],
             "properties": {
+              "kappa": { "type": "number", "minimum": 0.0 },
               "k": { "type": "number", "minimum": 0.0 },
               "l0": { "type": "number", "minimum": 0.0 },
+              "lambda_s": { "type": "number", "minimum": 0.0 },
+              "x": { "type": "number" },
               "learn": {
                 "type": "object",
                 "properties": {
+                  "kappa": { "type": "boolean" },
                   "k": { "type": "boolean" },
-                  "l0": { "type": "boolean" }
+                  "l0": { "type": "boolean" },
+                  "lambda_s": { "type": "boolean" },
+                  "x": { "type": "boolean" }
                 },
                 "additionalProperties": false
               }
@@ -135,7 +141,10 @@
         "lambda_w": { "type": "number", "minimum": 0.0 }
       },
       "additionalProperties": false
-    }
+    },
+    "rho": { "type": "number", "default": 0.0 },
+    "beta": { "type": "number", "default": 0.0 },
+    "gamma": { "type": "number", "default": 0.0 }
   },
   "additionalProperties": false
 }

--- a/src/common/tensors/autoautograd/fluxspring/fs_build_specs.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_build_specs.py
@@ -15,21 +15,43 @@ from dataclasses import replace
 
 from .fs_types import (
     FluxSpringSpec, NodeSpec, EdgeSpec, FaceSpec,
-    NodeCtrl, EdgeCtrl, EdgeHooke, EdgeHookeLearn,
+    NodeCtrl, EdgeCtrl, EdgeTransport, EdgeTransportLearn,
     LearnCtrl, DECSpec, DirichletCfg, RegCfg
 )
+from ...abstraction import AbstractTensor as AT
 
 def _node(idx: int, D: int, scripted_axes=(0, 2)) -> NodeSpec:
-    p0 = [0.0] * D
-    v0 = [0.0] * D
-    ctrl = NodeCtrl(alpha=0.15, w=1.0, b=0.0, learn=LearnCtrl(True, True, True))
-    return NodeSpec(id=idx, p0=p0, v0=v0, mass=1.0, ctrl=ctrl,
-                    scripted_axes=list(scripted_axes))
+    p0 = AT.zeros(D)
+    v0 = AT.zeros(D)
+    ctrl = NodeCtrl(
+        alpha=AT.tensor(0.15),
+        w=AT.tensor(1.0),
+        b=AT.tensor(0.0),
+        learn=LearnCtrl(True, True, True),
+    )
+    return NodeSpec(
+        id=idx,
+        p0=p0,
+        v0=v0,
+        mass=AT.tensor(1.0),
+        ctrl=ctrl,
+        scripted_axes=list(scripted_axes),
+    )
 
 def _edge(i: int, j: int) -> EdgeSpec:
-    hooke = EdgeHooke(k=1.0, l0=1.0, learn=EdgeHookeLearn(k=False, l0=False))
-    ctrl  = EdgeCtrl(alpha=0.15, w=1.0, b=0.0, learn=LearnCtrl(True, True, True))
-    return EdgeSpec(src=i, dst=j, hooke=hooke, ctrl=ctrl)
+    transport = EdgeTransport(
+        kappa=AT.tensor(1.0),
+        k=AT.tensor(1.0),
+        l0=AT.tensor(1.0),
+        learn=EdgeTransportLearn(kappa=True, k=False, l0=False, lambda_s=False, x=False),
+    )
+    ctrl = EdgeCtrl(
+        alpha=AT.tensor(0.15),
+        w=AT.tensor(1.0),
+        b=AT.tensor(0.0),
+        learn=LearnCtrl(True, True, True),
+    )
+    return EdgeSpec(src=i, dst=j, transport=transport, ctrl=ctrl)
 
 def make_classifier_spec(
     name: str,

--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -39,8 +39,14 @@ def edge_vectors_AT(P: AT.Tensor, spec: FluxSpringSpec) -> AT.Tensor:
     return Pj - Pi
 
 def edge_params_AT(spec: FluxSpringSpec):
-    k  = AT.get_tensor([e.hooke.k for e in spec.edges]).astype(float)   # (E,)
-    l0 = AT.get_tensor([e.hooke.l0 for e in spec.edges]).astype(float)  # (E,)
+    k = AT.get_tensor([
+        e.transport.k if e.transport.k is not None else AT.tensor(1.0)
+        for e in spec.edges
+    ]).astype(float)  # (E,)
+    l0 = AT.get_tensor([
+        e.transport.l0 if e.transport.l0 is not None else AT.tensor(1.0)
+        for e in spec.edges
+    ]).astype(float)  # (E,)
     return k, l0
 
 def face_params_AT(spec: FluxSpringSpec):

--- a/src/common/tensors/autoautograd/fluxspring/fs_types.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_types.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+from ...abstraction import AbstractTensor as AT
+
 # ----- learning switches shared by node/edge controls -----
 @dataclass
 class LearnCtrl:
@@ -17,38 +19,44 @@ class LearnCtrl:
 # ----- node control (data path) -----
 @dataclass
 class NodeCtrl:
-    alpha: float = 0.0
-    w: float = 1.0
-    b: float = 0.0
+    alpha: AT = field(default_factory=lambda: AT.tensor(0.0))
+    w: AT = field(default_factory=lambda: AT.tensor(1.0))
+    b: AT = field(default_factory=lambda: AT.tensor(0.0))
     learn: LearnCtrl = field(default_factory=LearnCtrl)
 
-# ----- edge Hooke params + learnability -----
+# ----- edge transport params + learnability -----
 @dataclass
-class EdgeHookeLearn:
+class EdgeTransportLearn:
+    kappa: bool = True
     k: bool = True
     l0: bool = True
+    lambda_s: bool = True
+    x: bool = True
 
 @dataclass
-class EdgeHooke:
-    k: float = 1.0
-    l0: float = 1.0
-    learn: EdgeHookeLearn = field(default_factory=EdgeHookeLearn)
+class EdgeTransport:
+    kappa: AT = field(default_factory=lambda: AT.tensor(1.0))
+    k: Optional[AT] = None
+    l0: Optional[AT] = None
+    lambda_s: Optional[AT] = None
+    x: Optional[AT] = None
+    learn: EdgeTransportLearn = field(default_factory=EdgeTransportLearn)
 
 # ----- edge control (data path) -----
 @dataclass
 class EdgeCtrl:
-    alpha: float = 0.0
-    w: float = 1.0
-    b: float = 0.0
+    alpha: AT = field(default_factory=lambda: AT.tensor(0.0))
+    w: AT = field(default_factory=lambda: AT.tensor(1.0))
+    b: AT = field(default_factory=lambda: AT.tensor(0.0))
     learn: LearnCtrl = field(default_factory=LearnCtrl)
 
 # ----- node/edge/face specs -----
 @dataclass
 class NodeSpec:
     id: int
-    p0: List[float]            # length D
-    v0: List[float]            # length D
-    mass: float
+    p0: AT                    # length D
+    v0: AT                    # length D
+    mass: AT
     ctrl: NodeCtrl
     scripted_axes: List[int]   # exactly 2 axes (Dirichlet/scripted)
 
@@ -56,7 +64,7 @@ class NodeSpec:
 class EdgeSpec:
     src: int
     dst: int
-    hooke: EdgeHooke
+    transport: EdgeTransport
     ctrl: EdgeCtrl
 
 @dataclass
@@ -67,8 +75,8 @@ class FaceLearn:
 @dataclass
 class FaceSpec:
     edges: List[int]           # oriented: 1-based edge indices, negative flips orientation
-    alpha: float               # activation wet/dry (mix)
-    c: float                   # face weight
+    alpha: AT                  # activation wet/dry (mix)
+    c: AT                      # face weight
     learn: FaceLearn = field(default_factory=FaceLearn)
 
 # ----- DEC + BC + regularizers -----
@@ -103,3 +111,6 @@ class FluxSpringSpec:
     dec: DECSpec
     dirichlet: Optional[DirichletCfg] = None
     regularizers: Optional[RegCfg] = None
+    rho: AT = field(default_factory=lambda: AT.tensor(0.0))
+    beta: AT = field(default_factory=lambda: AT.tensor(0.0))
+    gamma: AT = field(default_factory=lambda: AT.tensor(0.0))


### PR DESCRIPTION
## Summary
- use AbstractTensor for node/edge specs and controls
- replace Hooke edge params with transport model
- add reactive scalars (rho, beta, gamma) to FluxSpringSpec

## Testing
- `pytest tests/autoautograd/test_spring_dt_engine_backends.py tests/autoautograd/test_spring_dt_thread.py tests/test_spring_async_toy_tensor_glist.py -q` *(ImportError: cannot import name 'Node')*
- `pytest tests/test_spring_async_toy_tensor_glist.py -q`
- `pytest tests/test_autograd_allow_unused.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0759b0068832aa90c908541e9802c