### PR TITLE
Add spectral configuration block to FluxSpring spec

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -142,6 +142,36 @@
       },
       "additionalProperties": false
     },
+    "spectral": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean", "default": false },
+        "tick_hz": { "type": "number", "minimum": 0.0, "default": 44100.0 },
+        "win_len": { "type": "integer", "minimum": 1, "default": 1024 },
+        "hop_len": { "type": "integer", "minimum": 1, "default": 256 },
+        "window": { "type": "string", "default": "hann" },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "bands": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": { "type": "number" },
+                "minItems": 2,
+                "maxItems": 2
+              },
+              "default": []
+            },
+            "centroid": { "type": "boolean", "default": false }
+          },
+          "additionalProperties": false,
+          "default": {}
+        }
+      },
+      "additionalProperties": false,
+      "default": {}
+    },
     "rho": { "type": "number", "default": 0.0 },
     "beta": { "type": "number", "default": 0.0 },
     "gamma": { "type": "number", "default": 0.0 }

--- a/src/common/tensors/autoautograd/fluxspring/fs_types.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_types.py
@@ -100,6 +100,22 @@ class RegCfg:
     lambda_c: float = 0.0
     lambda_w: float = 0.0
 
+# ----- spectral feature extraction -----
+@dataclass
+class SpectralMetrics:
+    bands: List[List[float]] = field(default_factory=list)  # [ [f_lo, f_hi], ... ]
+    centroid: bool = False
+
+
+@dataclass
+class SpectralCfg:
+    enabled: bool = False
+    tick_hz: float = 44100.0
+    win_len: int = 1024
+    hop_len: int = 256
+    window: str = "hann"
+    metrics: SpectralMetrics = field(default_factory=SpectralMetrics)
+
 # ----- top-level FluxSpring spec -----
 @dataclass
 class FluxSpringSpec:
@@ -111,6 +127,7 @@ class FluxSpringSpec:
     dec: DECSpec
     dirichlet: Optional[DirichletCfg] = None
     regularizers: Optional[RegCfg] = None
+    spectral: SpectralCfg = field(default_factory=SpectralCfg)
     rho: AT = field(default_factory=lambda: AT.tensor(0.0))
     beta: AT = field(default_factory=lambda: AT.tensor(0.0))
     gamma: AT = field(default_factory=lambda: AT.tensor(0.0))


### PR DESCRIPTION
## Summary
- extend `FluxSpringSpec` with a `spectral` configuration block
- describe `spectral` block in `fs.schema.json`
- round-trip spectral settings in loader/saver with validation

## Testing
- `pytest tests/autoautograd` *(fails: ImportError: cannot import name 'Node' from 'src.common.tensors.autoautograd.spring_async_toy')*

------
https://chatgpt.com/codex/tasks/task_e_68c07bcd1bac832abf232afac0893f5d