### PR TITLE
feat: add data pump and restore energy helpers

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -5,9 +5,18 @@ from .fs_types import (
 )
 from .fs_io import load_fluxspring, save_fluxspring, validate_fluxspring
 from .fs_dec import (
-    incidence_tensors_AT, validate_boundary_of_boundary_AT,
-    edge_vectors_AT, edge_strain_AT, face_flux_AT, curvature_activation_AT,
-    edge_energy_AT, face_energy_from_strain_AT, total_energy_AT, dec_energy_and_gradP_AT,
-    path_edge_energy_AT
+    incidence_tensors_AT,
+    validate_boundary_of_boundary_AT,
+    edge_vectors_AT,
+    edge_strain_AT,
+    face_flux_AT,
+    curvature_activation_AT,
+    edge_energy_AT,
+    face_energy_from_strain_AT,
+    total_energy_AT,
+    dec_energy_and_gradP_AT,
+    path_edge_energy_AT,
+    transport_tick,
+    pump_tick,
 )
 # Torch bridge is optional import to keep AT-only usage clean.


### PR DESCRIPTION
## Summary
- restore DEC energy helpers for FluxSpring graphs
- add transport and data pumps driven by geometry and control params
- provide Node and Edge dataclasses for spring async toy

## Testing
- `pytest tests -k fluxspring -q`
- `pytest tests/test_mass_charge.py::test_mass_conserved_without_pump -q`


------
https://chatgpt.com/codex/tasks/task_e_68c07e637b24832a8760fb04d4b35972