### PR TITLE
Refactor FluxSpring spec builder to use shared dataclasses

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -44,7 +44,9 @@
             },
             "additionalProperties": false
           },
-          "scripted_axes": { "type": "array", "items": { "type": "integer" }, "minItems": 2, "maxItems": 2 }
+          "scripted_axes": { "type": "array", "items": { "type": "integer" }, "minItems": 2, "maxItems": 2 },
+          "temperature": { "type": "number", "default": 0.0 },
+          "exclusive": { "type": "boolean", "default": false }
         },
         "additionalProperties": false
       }
@@ -98,7 +100,9 @@
               }
             },
             "additionalProperties": false
-          }
+          },
+          "temperature": { "type": "number", "default": 0.0 },
+          "exclusive": { "type": "boolean", "default": false }
         },
         "additionalProperties": false
       }

--- a/src/common/tensors/autoautograd/fluxspring/fs_build_specs.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_build_specs.py
@@ -32,10 +32,12 @@ def _node(idx: int, D: int, scripted_axes=(0, 2)) -> NodeSpec:
     return NodeSpec(
         id=idx,
         p0=p0,
-        v0=v0,
+       v0=v0,
         mass=AT.tensor(1.0),
         ctrl=ctrl,
         scripted_axes=list(scripted_axes),
+        temperature=AT.tensor(0.0),
+        exclusive=False,
     )
 
 def _edge(i: int, j: int) -> EdgeSpec:
@@ -51,7 +53,7 @@ def _edge(i: int, j: int) -> EdgeSpec:
         b=AT.tensor(0.0),
         learn=LearnCtrl(True, True, True),
     )
-    return EdgeSpec(src=i, dst=j, transport=transport, ctrl=ctrl)
+    return EdgeSpec(src=i, dst=j, transport=transport, ctrl=ctrl, temperature=AT.tensor(0.0), exclusive=False)
 
 def make_classifier_spec(
     name: str,

--- a/src/common/tensors/autoautograd/fluxspring/fs_io.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_io.py
@@ -35,6 +35,8 @@ def _coerce_node(d: Dict) -> NodeSpec:
             ),
         ),
         scripted_axes=[int(a) for a in d["scripted_axes"]],
+        temperature=AT.tensor(float(d.get("temperature", 0.0))),
+        exclusive=bool(d.get("exclusive", False)),
     )
 
 def _coerce_edge(d: Dict) -> EdgeSpec:
@@ -69,6 +71,8 @@ def _coerce_edge(d: Dict) -> EdgeSpec:
                 b=bool(cL.get("b", True)),
             ),
         ),
+        temperature=AT.tensor(float(d.get("temperature", 0.0))),
+        exclusive=bool(d.get("exclusive", False)),
     )
 
 def _coerce_face(d: Dict) -> FaceSpec:
@@ -185,6 +189,9 @@ def validate_fluxspring(spec: FluxSpringSpec, *, tol: float = 1e-8) -> None:
             raise ValueError(f"node {n.id}: p0/v0 must be length D")
         if float(AT.get_tensor(n.mass)) <= 0:
             raise ValueError(f"node {n.id}: mass must be > 0")
+        _ = float(AT.get_tensor(n.temperature))
+        if not isinstance(n.exclusive, bool):
+            raise ValueError(f"node {n.id}: exclusive must be bool")
         if len(n.scripted_axes) != 2:
             raise ValueError(f"node {n.id}: scripted_axes must list exactly 2 axes")
         for a in n.scripted_axes:
@@ -202,6 +209,9 @@ def validate_fluxspring(spec: FluxSpringSpec, *, tol: float = 1e-8) -> None:
             raise ValueError(f"edge {k}: l0 must be ≥ 0")
         if e.transport.lambda_s is not None and float(AT.get_tensor(e.transport.lambda_s)) < 0:
             raise ValueError(f"edge {k}: lambda_s must be ≥ 0")
+        _ = float(AT.get_tensor(e.temperature))
+        if not isinstance(e.exclusive, bool):
+            raise ValueError(f"edge {k}: exclusive must be bool")
 
     for fidx, fc in enumerate(spec.faces, start=1):
         for or_idx in fc.edges:

--- a/src/common/tensors/autoautograd/fluxspring/fs_spec_builder.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_spec_builder.py
@@ -1,168 +1,95 @@
-# fluxspring_spec_tensor_min.py
-# Spec-only: AbstractTensor fields, no helpers, no integrator, no faces.
-
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
+
+from .fs_types import (
+    FluxSpringSpec,
+    NodeSpec,
+    EdgeSpec,
+    DECSpec,
+    NodeCtrl,
+    EdgeCtrl,
+    EdgeTransport,
+    EdgeTransportLearn,
+    LearnCtrl,
+)
 from ...abstraction import AbstractTensor as AT
 
-# ----------------------------- Nodes -----------------------------------------
-
-@dataclass
-class NodeSpec:
-    id: int
-    p: AT            # (D,)
-    v: AT            # (D,)
-    phys: AT         # (D,) Dirichlet targets
-    mask: AT         # (D,) geometry mask
-    ctrl: AT         # (P,) data-path scalars (free width)
-    mass: AT         # scalar tensor
-
-    # per-node IO mirrors (scalar tensors)
-    in_value: AT
-    out_value: AT
-    in_target: AT
-    out_target: AT
-
-    role: str = ""   # optional tag
-
-    def sync_io(self) -> None:
-        """Refresh per-node IO mirrors from p/phys (x=0, z=2 if present)."""
-        D = int(getattr(self.p, "shape", (0,))[0]) if hasattr(self.p, "shape") else 0
-        if D > 0:
-            self.in_value  = self.p[0]
-            self.in_target = self.phys[0]
-        if D > 2:
-            self.out_value  = self.p[2]
-            self.out_target = self.phys[2]
-
-# ----------------------------- Edges -----------------------------------------
-
-@dataclass
-class EdgeSpec:
-    # Row-aligned with D0 (E x N)
-    eid_1: int       # 1..E (human-friendly id)
-    row_idx: int     # 0..E-1 (D0 row index)
-    src: int
-    dst: int
-
-    # geometric / control
-    k: AT            # scalar tensor
-    l0: AT           # scalar tensor
-    h1: AT           # scalar tensor (Hodge-1 weight)
-    ctrl: AT         # (Q,) edge data-path scalars (free width)
-
-    # learnable parameters and optional resonance state
-    theta: AT        # raw parameter for kappa
-    kappa: AT        # non-negative spring gain
-    x: Optional[AT] = None  # optional resonance state
-
-    op: str = ""     # optional operator tag
-
-# ----------------------------- DEC -------------------------------------------
-
-@dataclass
-class DECSpec:
-    D0: AT                  # (E, N) edge–node incidence
-    D1: AT                  # (F, E) face–edge incidence
-    H0: AT                  # (N,) Hodge-0 diagonal (node volumes)
-    H1: AT                  # (E,) Hodge-1 diagonal (edge lengths)
-    H2: AT                  # (F,) Hodge-2 diagonal (face areas)
-    S_fe: AT                # (F, E) face→edge stencil (flux region per face over edges)
-    node_rows: List[int]    # node id order matching D0 columns
-
-# ----------------------------- Top-level Spec --------------------------------
-
-@dataclass
-class FluxSpringSpec:
-    D: int
-    nodes: List[NodeSpec]
-    edges: List[EdgeSpec]
-    dec: DECSpec
-
-# ----------------------------- Minimal, non-redundant builder ----------------
 
 def make_classifier_spec(
     name: str,
-    M: int,          # input feature count
-    H: int,          # hidden width
-    C: int,          # output count (classes)
+    M: int,
+    H: int,
+    C: int,
     *,
-    D_geom: int = 3  # e.g., keep x/z scripted, y free
+    D_geom: int = 3,
 ) -> FluxSpringSpec:
+    """Build a minimal FluxSpringSpec for a one-hidden-layer classifier."""
+    version = f"{name}-fs-1.0"
     N = M + H + C
 
-    # Nodes (no helpers; constant-time defaults)
     nodes: List[NodeSpec] = []
     for i in range(N):
-        p    = AT.zeros((D_geom,))
-        v    = AT.zeros((D_geom,))
-        phys = AT.zeros((D_geom,))
-        mask = AT.ones((D_geom,))
-        ctrl = AT.get_tensor([0.0])     # (P,)= (1,) default; free width upstream
-        mass = AT.get_tensor(1.0)       # scalar
-        z    = AT.get_tensor(0.0)       # scalar mirrors init
-        nodes.append(NodeSpec(
-            id=i, p=p, v=v, phys=phys, mask=mask, ctrl=ctrl, mass=mass,
-            in_value=z, out_value=z, in_target=z, out_target=z, role=""
-        ))
+        ctrl = NodeCtrl(
+            alpha=AT.tensor(0.0),
+            w=AT.tensor(1.0),
+            b=AT.tensor(0.0),
+            learn=LearnCtrl(True, True, True),
+        )
+        nodes.append(
+            NodeSpec(
+                id=i,
+                p0=AT.zeros(D_geom),
+                v0=AT.zeros(D_geom),
+                mass=AT.tensor(1.0),
+                ctrl=ctrl,
+                scripted_axes=[0, 2] if D_geom >= 3 else list(range(min(2, D_geom))),
+                temperature=AT.tensor(0.0),
+                exclusive=False,
+            )
+        )
 
-    # Id bands
-    in_ids  = list(range(0, M))
+    def _edge(i: int, j: int) -> EdgeSpec:
+        transport = EdgeTransport(
+            kappa=AT.tensor(1.0),
+            k=AT.tensor(1.0),
+            l0=AT.tensor(1.0),
+            learn=EdgeTransportLearn(kappa=True, k=False, l0=False, lambda_s=False, x=False),
+        )
+        ctrl = EdgeCtrl(
+            alpha=AT.tensor(0.0),
+            w=AT.tensor(1.0),
+            b=AT.tensor(0.0),
+            learn=LearnCtrl(True, True, True),
+        )
+        return EdgeSpec(src=i, dst=j, transport=transport, ctrl=ctrl, temperature=AT.tensor(0.0), exclusive=False)
+
+    edges: List[EdgeSpec] = []
+    in_ids = list(range(0, M))
     hid_ids = list(range(M, M + H))
     out_ids = list(range(M + H, N))
+    for j in hid_ids:
+        for i in in_ids:
+            edges.append(_edge(i, j))
+    for k in out_ids:
+        for j in hid_ids:
+            edges.append(_edge(j, k))
 
-    # Edges (fully connect M→H and H→C; no nested loop boilerplate kept)
-    edges: List[EdgeSpec] = []
-    # M → H
-    for r, (i, j) in enumerate((ii, jj) for jj in hid_ids for ii in in_ids):
-        theta = AT.get_tensor(0.0)
-        kappa = AT.softplus(theta) if hasattr(AT, 'softplus') else (theta.exp() + 1.0).log()
-        edges.append(EdgeSpec(
-            eid_1=r + 1, row_idx=r, src=i, dst=j,
-            k=AT.get_tensor(1.0), l0=AT.get_tensor(1.0),
-            h1=AT.get_tensor(1.0), ctrl=AT.get_tensor([0.0]),
-            theta=theta, kappa=kappa, x=None, op="",
-        ))
-    # H → C
-    base = len(edges)
-    for t, (j, k_) in enumerate((jj, kk) for kk in out_ids for jj in hid_ids):
-        r = base + t
-        theta = AT.get_tensor(0.0)
-        kappa = AT.softplus(theta) if hasattr(AT, 'softplus') else (theta.exp() + 1.0).log()
-        edges.append(EdgeSpec(
-            eid_1=r + 1, row_idx=r, src=j, dst=k_,
-            k=AT.get_tensor(1.0), l0=AT.get_tensor(1.0),
-            h1=AT.get_tensor(1.0), ctrl=AT.get_tensor([0.0]),
-            theta=theta, kappa=kappa, x=None, op="",
-        ))
-
-    # DEC (exactly what was requested; faces not used here → F=0)
     E = len(edges)
-    F = 0  # no faces in this minimal classifier graph
-
-    # D0: (E, N)
-    D0 = AT.zeros((E, N))
+    D0 = [[0.0] * N for _ in range(E)]
     for r, e in enumerate(edges):
-        D0[r, e.src] = -1.0
-        D0[r, e.dst] = +1.0
+        D0[r][e.src] = -1.0
+        D0[r][e.dst] = 1.0
+    D1: List[List[float]] = []
 
-    # D1: (F, E) = (0, E)
-    D1 = AT.zeros((F, E))
+    dec = DECSpec(D0=D0, D1=D1)
 
-    # Hodge stars: (N,), (E,), (F,)
-    H0 = AT.ones((N,))
-    H1 = AT.ones((E,))
-    H2 = AT.ones((F,))  # empty if F==0
-
-    # S_fe: (F, E)
-    S_fe = AT.zeros((F, E))
-
-    dec = DECSpec(
-        D0=D0, D1=D1,
-        H0=H0, H1=H1, H2=H2,
-        S_fe=S_fe,
-        node_rows=[n.id for n in nodes],
+    spec = FluxSpringSpec(
+        version=version,
+        D=D_geom,
+        nodes=nodes,
+        edges=edges,
+        faces=[],
+        dec=dec,
     )
+    return spec
 
-    return FluxSpringSpec(D=D_geom, nodes=nodes, edges=edges, dec=dec)

--- a/src/common/tensors/autoautograd/fluxspring/fs_types.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_types.py
@@ -59,6 +59,8 @@ class NodeSpec:
     mass: AT
     ctrl: NodeCtrl
     scripted_axes: List[int]   # exactly 2 axes (Dirichlet/scripted)
+    temperature: AT = field(default_factory=lambda: AT.tensor(0.0))  # placeholder for thermal models
+    exclusive: bool = False  # True if node occupies exclusive geometry
 
 @dataclass
 class EdgeSpec:
@@ -66,6 +68,8 @@ class EdgeSpec:
     dst: int
     transport: EdgeTransport
     ctrl: EdgeCtrl
+    temperature: AT = field(default_factory=lambda: AT.tensor(0.0))  # placeholder for thermal models
+    exclusive: bool = False  # True if edge occupies exclusive geometry
 
 @dataclass
 class FaceLearn:


### PR DESCRIPTION
## Summary
- Refactor FluxSpring spec builder to reuse dataclasses from `fs_types` and emit versioned specs
- Update spring_async_toy demo to convert nodes/edges into the new spec format
- Add temperature and exclusive-geometry placeholders to FluxSpring nodes and edges with schema and I/O updates

## Testing
- `pytest tests/autoautograd/test_spring_dt_engine_backends.py tests/autoautograd/test_spring_dt_thread.py`

------
https://chatgpt.com/codex/tasks/task_e_68c087e743d8832aa069fdeab59a5613