### PR TITLE
Ensure FluxSpring schema enforces rho bounds

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -172,7 +172,12 @@
       "additionalProperties": false,
       "default": {}
     },
-    "rho": { "type": "number", "default": 0.0 },
+    "rho": {
+      "type": "number",
+      "exclusiveMinimum": -1.0,
+      "exclusiveMaximum": 1.0,
+      "default": 0.0
+    },
     "beta": { "type": "number", "default": 0.0 },
     "gamma": { "type": "number", "default": 0.0 }
   },

--- a/src/common/tensors/autoautograd/fluxspring/fs_io.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_io.py
@@ -175,6 +175,9 @@ def validate_fluxspring(spec: FluxSpringSpec, *, tol: float = 1e-8) -> None:
     N = len(spec.nodes); E = len(spec.edges); F = len(spec.faces)
     if spec.D < 2:
         raise ValueError("D must be ≥ 2")
+    rho_val = float(AT.get_tensor(spec.rho))
+    if not (-1.0 < rho_val < 1.0):
+        raise ValueError("rho must satisfy |rho| < 1")
     ids = [n.id for n in spec.nodes]
     if len(set(ids)) != N:
         raise ValueError("duplicate node ids")


### PR DESCRIPTION
## Summary
- Enforce |rho| < 1 in FluxSpring schema and validation
- Add JSON Schema constraints for rho

## Testing
- `pytest tests/autoautograd/test_spring_dt_engine_backends.py tests/autoautograd/test_spring_dt_thread.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c087b95d38832ab6ca6d2cd10db342