### PR TITLE
feat: add spectral ring buffer support

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -46,7 +46,8 @@
           },
           "scripted_axes": { "type": "array", "items": { "type": "integer" }, "minItems": 2, "maxItems": 2 },
           "temperature": { "type": "number", "default": 0.0 },
-          "exclusive": { "type": "boolean", "default": false }
+          "exclusive": { "type": "boolean", "default": false },
+          "ring_size": { "type": ["integer", "null"], "minimum": 1 }
         },
         "additionalProperties": false
       }
@@ -102,7 +103,8 @@
             "additionalProperties": false
           },
           "temperature": { "type": "number", "default": 0.0 },
-          "exclusive": { "type": "boolean", "default": false }
+          "exclusive": { "type": "boolean", "default": false },
+          "ring_size": { "type": ["integer", "null"], "minimum": 1 }
         },
         "additionalProperties": false
       }

--- a/src/common/tensors/autoautograd/fluxspring/fs_io.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_io.py
@@ -37,6 +37,7 @@ def _coerce_node(d: Dict) -> NodeSpec:
         scripted_axes=[int(a) for a in d["scripted_axes"]],
         temperature=AT.tensor(float(d.get("temperature", 0.0))),
         exclusive=bool(d.get("exclusive", False)),
+        ring_size=int(d["ring_size"]) if d.get("ring_size") is not None else None,
     )
 
 def _coerce_edge(d: Dict) -> EdgeSpec:
@@ -71,6 +72,7 @@ def _coerce_edge(d: Dict) -> EdgeSpec:
         ),
         temperature=AT.tensor(float(d.get("temperature", 0.0))),
         exclusive=bool(d.get("exclusive", False)),
+        ring_size=int(d["ring_size"]) if d.get("ring_size") is not None else None,
     )
 
 def _coerce_face(d: Dict) -> FaceSpec:
@@ -154,7 +156,11 @@ def load_fluxspring(path: str) -> FluxSpringSpec:
 def save_fluxspring(spec: FluxSpringSpec, path: str, *, indent: int = 2) -> None:
     def _plain(x):
         if is_dataclass(x):
-            return {k: _plain(v) for k, v in asdict(x).items() if v is not None}
+            return {
+                k: _plain(v)
+                for k, v in asdict(x).items()
+                if v is not None and k not in {"ring", "ring_idx"}
+            }
         if isinstance(x, list):
             return [_plain(v) for v in x]
         if isinstance(x, dict):

--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -107,6 +107,7 @@ from .fluxspring.fs_types import (
     EdgeCtrl,
     EdgeTransport,
     EdgeTransportLearn,
+    SpectralCfg,
 )
 V_MAX = 2.0
 STEP_MAX = 10.2
@@ -2408,7 +2409,14 @@ def ascii_targets_for(phrase: str, out_ids: List[int]) -> Dict[int, Callable[[fl
 
 
 
-def build_toy_system(seed=0, *, batch_size: int = 4096, batch_refresh_hz: float = 20.0):
+def build_toy_system(
+    seed=0,
+    *,
+    batch_size: int = 4096,
+    batch_refresh_hz: float = 20.0,
+    spectral: bool = False,
+    ring_size: Optional[int] = None,
+):
     """Build a toy spring–repulsor system where inputs are drawn from a large
     random batch tensor.
 
@@ -2454,6 +2462,7 @@ def build_toy_system(seed=0, *, batch_size: int = 4096, batch_refresh_hz: float 
                 scripted_axes=[0, 2],
                 temperature=AbstractTensor.tensor(0.0),
                 exclusive=False,
+                ring_size=ring_size,
             )
         )
     fs_edges: List[EdgeSpec] = []
@@ -2473,6 +2482,7 @@ def build_toy_system(seed=0, *, batch_size: int = 4096, batch_refresh_hz: float 
                 ctrl=ctrl,
                 temperature=AbstractTensor.tensor(0.0),
                 exclusive=False,
+                ring_size=ring_size,
             )
         )
 
@@ -2491,6 +2501,7 @@ def build_toy_system(seed=0, *, batch_size: int = 4096, batch_refresh_hz: float 
         edges=fs_edges,
         faces=[],
         dec=dec,
+        spectral=SpectralCfg(enabled=spectral),
     )
 
     # Tag roles for visualization


### PR DESCRIPTION
## Summary
- add optional ring buffers to FluxSpring node and edge specs
- allocate buffers when spectral analysis is enabled or a ring size is provided
- expose spectral and ring buffer overrides in spring_async_toy demo

## Testing
- `pytest tests/autoautograd/test_spring_dt_engine_backends.py`

------
https://chatgpt.com/codex/tasks/task_e_68c08f12ae38832abba3304c1c614f4c