### PR TITLE
Unroll FFT into AbstractTensor methods with gradients

### DIFF
--- a/src/common/dt_system/spectral_dampener.py
+++ b/src/common/dt_system/spectral_dampener.py
@@ -73,8 +73,8 @@ def spectral_inertia(history: Iterable[AbstractTensor], dt: float) -> Tuple[Abst
     w = AbstractTensor.hanning(W) if W > 1 else AbstractTensor.ones(W)
     xw = w[:, None] * xs
 
-    C0 = AbstractTensor.fft.rfft(xw, axis=0)  # (F0, D)
-    w0 = 2.0 * AbstractTensor.pi() * AbstractTensor.fft.rfftfreq(int(W), d=dt, like=xs)
+    C0 = xw.rfft(axis=0)  # (F0, D)
+    w0 = 2.0 * AbstractTensor.pi() * AbstractTensor.rfftfreq(int(W), d=dt, like=xs)
     P0 = AbstractTensor.sum(AbstractTensor.abs(C0) ** 2, dim=1)
     if P0.sum() <= 1e-12 or len(P0) <= 2:
         return (
@@ -111,8 +111,8 @@ def spectral_inertia(history: Iterable[AbstractTensor], dt: float) -> Tuple[Abst
     Z = 8
     Wz = W * Z
     xpad = AbstractTensor.pad(xw, (0, 0, 0, Wz - W))
-    Cz = AbstractTensor.fft.rfft(xpad, axis=0)
-    wz = 2.0 * AbstractTensor.pi() * AbstractTensor.fft.rfftfreq(Wz, d=dt, like=xs)
+    Cz = xpad.rfft(axis=0)
+    wz = 2.0 * AbstractTensor.pi() * AbstractTensor.rfftfreq(Wz, d=dt, like=xs)
 
     def coarse_band_to_w(b_lo, b_hi):
         return w0[b_lo], w0[min(b_hi, len(w0) - 1)]

--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -2663,7 +2663,12 @@ from .abstraction_methods.trigonometry import (
     rad2deg as trig_rad2deg,
 )
 from .abstraction_methods.fourier import (
-    FFTNamespace,
+    fft as fourier_fft,
+    ifft as fourier_ifft,
+    rfft as fourier_rfft,
+    irfft as fourier_irfft,
+    rfftfreq as fourier_rfftfreq,
+    fftfreq as fourier_fftfreq,
 )
 from .abstraction_methods.fold import (
     fold2d as fold2d_ref,
@@ -3052,8 +3057,13 @@ AbstractTensor.inverse = staticmethod(linalg_inv)
 AbstractTensor.eigh  = staticmethod(linalg_eigh)
 AbstractTensor.cholesky = staticmethod(linalg_cholesky)
 
-# --- FFT namespace (numpy-like) --------------------------------------------
-AbstractTensor.fft = FFTNamespace(AbstractTensor)
+# --- FFT methods -----------------------------------------------------------
+AbstractTensor.fft = fourier_fft
+AbstractTensor.ifft = fourier_ifft
+AbstractTensor.rfft = fourier_rfft
+AbstractTensor.irfft = fourier_irfft
+AbstractTensor.rfftfreq = fourier_rfftfreq
+AbstractTensor.fftfreq = fourier_fftfreq
 
 def _cbrt(x):
     import numpy as np

--- a/src/common/tensors/abstraction_methods/fourier.py
+++ b/src/common/tensors/abstraction_methods/fourier.py
@@ -3,75 +3,98 @@ from __future__ import annotations
 from typing import Any, Optional
 
 
-class FFTNamespace:
-    """Namespace for FFT-related functions with backend dispatch.
+def fft(self, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
+    """Return the discrete Fourier transform of ``self``.
 
-    Provides callables that resolve to backend-specific underscore methods
-    (e.g., ``fft_``, ``rfft_``, ``rfftfreq_``). The namespace itself is
-    callable and forwards to ``fft`` so ``AbstractTensor.fft(x)`` works
-    the same as ``AbstractTensor.fft.fft(x)``.
+    Records an autograd node so gradients propagate through the transform
+    using the inverse FFT in the backward pass.
     """
+    from ..abstraction import AbstractTensor
 
-    def __init__(self, tensor_cls: Any):
-        self._cls = tensor_cls
+    finalize = AbstractTensor._pre_autograd(
+        "fft", [self], params={"n": n, "axis": axis, "norm": norm}
+    )
+    out = self.__class__(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    if not hasattr(self, "fft_"):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement fft_()")
+    out.data = self.fft_(n=n, axis=axis, norm=norm)
+    return finalize(out)
 
-    # Allow calling the namespace directly as fft(...)
-    def __call__(self, x: Any, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
-        return self.fft(x, n=n, axis=axis, norm=norm)
 
-    # --- Complex FFTs -----------------------------------------------------
-    def fft(self, x: Any, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
-        t = self._cls.get_tensor(x)
-        finalize = self._cls._pre_autograd("fft", [t], params={"n": n, "axis": axis, "norm": norm})
-        out = t.__class__(track_time=t.track_time, tape=getattr(t, "_tape", None))
-        if not hasattr(t, "fft_"):
-            raise NotImplementedError(f"{t.__class__.__name__} must implement fft_()")
-        out.data = t.fft_(n=n, axis=axis, norm=norm)
-        return finalize(out)
+def ifft(self, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
+    """Return the inverse discrete Fourier transform of ``self``."""
+    from ..abstraction import AbstractTensor
 
-    def ifft(self, x: Any, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
-        t = self._cls.get_tensor(x)
-        finalize = self._cls._pre_autograd("ifft", [t], params={"n": n, "axis": axis, "norm": norm})
-        out = t.__class__(track_time=t.track_time, tape=getattr(t, "_tape", None))
-        if not hasattr(t, "ifft_"):
-            raise NotImplementedError(f"{t.__class__.__name__} must implement ifft_()")
-        out.data = t.ifft_(n=n, axis=axis, norm=norm)
-        return finalize(out)
+    finalize = AbstractTensor._pre_autograd(
+        "ifft", [self], params={"n": n, "axis": axis, "norm": norm}
+    )
+    out = self.__class__(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    if not hasattr(self, "ifft_"):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement ifft_()")
+    out.data = self.ifft_(n=n, axis=axis, norm=norm)
+    return finalize(out)
 
-    # --- Real-input FFTs --------------------------------------------------
-    def rfft(self, x: Any, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
-        t = self._cls.get_tensor(x)
-        finalize = self._cls._pre_autograd("rfft", [t], params={"n": n, "axis": axis, "norm": norm})
-        out = t.__class__(track_time=t.track_time, tape=getattr(t, "_tape", None))
-        if not hasattr(t, "rfft_"):
-            raise NotImplementedError(f"{t.__class__.__name__} must implement rfft_()")
-        out.data = t.rfft_(n=n, axis=axis, norm=norm)
-        return finalize(out)
 
-    def irfft(self, x: Any, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
-        t = self._cls.get_tensor(x)
-        finalize = self._cls._pre_autograd("irfft", [t], params={"n": n, "axis": axis, "norm": norm})
-        out = t.__class__(track_time=t.track_time, tape=getattr(t, "_tape", None))
-        if not hasattr(t, "irfft_"):
-            raise NotImplementedError(f"{t.__class__.__name__} must implement irfft_()")
-        out.data = t.irfft_(n=n, axis=axis, norm=norm)
-        return finalize(out)
+def rfft(self, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
+    """Return the FFT of a real-valued ``self``."""
+    from ..abstraction import AbstractTensor
 
-    # --- Frequency helpers ------------------------------------------------
-    def rfftfreq(self, n: int, d: float = 1.0, *, like: Any | None = None):
-        base = like if isinstance(like, self._cls) else self._cls.get_tensor(0)
-        finalize = self._cls._pre_autograd("rfftfreq", [base] if isinstance(like, self._cls) else [], params={"n": n, "d": d})
-        out = base.__class__(track_time=getattr(base, "track_time", False), tape=getattr(base, "_tape", None))
-        if not hasattr(base, "rfftfreq_"):
-            raise NotImplementedError(f"{base.__class__.__name__} must implement rfftfreq_()")
-        out.data = base.rfftfreq_(n, d=d)
-        return finalize(out)
+    finalize = AbstractTensor._pre_autograd(
+        "rfft", [self], params={"n": n, "axis": axis, "norm": norm}
+    )
+    out = self.__class__(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    if not hasattr(self, "rfft_"):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement rfft_()")
+    out.data = self.rfft_(n=n, axis=axis, norm=norm)
+    return finalize(out)
 
-    def fftfreq(self, n: int, d: float = 1.0, *, like: Any | None = None):
-        base = like if isinstance(like, self._cls) else self._cls.get_tensor(0)
-        finalize = self._cls._pre_autograd("fftfreq", [base] if isinstance(like, self._cls) else [], params={"n": n, "d": d})
-        out = base.__class__(track_time=getattr(base, "track_time", False), tape=getattr(base, "_tape", None))
-        if not hasattr(base, "fftfreq_"):
-            raise NotImplementedError(f"{base.__class__.__name__} must implement fftfreq_()")
-        out.data = base.fftfreq_(n, d=d)
-        return finalize(out)
+
+def irfft(self, n: Optional[int] = None, axis: int = -1, norm: Optional[str] = None):
+    """Return the inverse FFT for a real-input spectrum ``self``."""
+    from ..abstraction import AbstractTensor
+
+    finalize = AbstractTensor._pre_autograd(
+        "irfft", [self], params={"n": n, "axis": axis, "norm": norm}
+    )
+    out = self.__class__(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    if not hasattr(self, "irfft_"):
+        raise NotImplementedError(f"{self.__class__.__name__} must implement irfft_()")
+    out.data = self.irfft_(n=n, axis=axis, norm=norm)
+    return finalize(out)
+
+
+@classmethod
+def rfftfreq(
+    cls, n: int, d: float = 1.0, *, like: Any | None = None
+):
+    """Return the sample frequencies for a real-input FFT."""
+    from ..abstraction import AbstractTensor
+
+    base = like if isinstance(like, cls) else cls.get_tensor(0)
+    finalize = AbstractTensor._pre_autograd(
+        "rfftfreq", [base] if isinstance(like, cls) else [], params={"n": n, "d": d}
+    )
+    out = base.__class__(track_time=getattr(base, "track_time", False), tape=getattr(base, "_tape", None))
+    if not hasattr(base, "rfftfreq_"):
+        raise NotImplementedError(f"{base.__class__.__name__} must implement rfftfreq_()")
+    out.data = base.rfftfreq_(n, d=d)
+    return finalize(out)
+
+
+@classmethod
+def fftfreq(
+    cls, n: int, d: float = 1.0, *, like: Any | None = None
+):
+    """Return the sample frequencies for a complex FFT."""
+    from ..abstraction import AbstractTensor
+
+    base = like if isinstance(like, cls) else cls.get_tensor(0)
+    finalize = AbstractTensor._pre_autograd(
+        "fftfreq", [base] if isinstance(like, cls) else [], params={"n": n, "d": d}
+    )
+    out = base.__class__(track_time=getattr(base, "track_time", False), tape=getattr(base, "_tape", None))
+    if not hasattr(base, "fftfreq_"):
+        raise NotImplementedError(f"{base.__class__.__name__} must implement fftfreq_()")
+    out.data = base.fftfreq_(n, d=d)
+    return finalize(out)
+

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -917,6 +917,70 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
     },
 
     # ----------------------------------------------------------------------
+    # Fourier transforms
+    # ----------------------------------------------------------------------
+    "fft": {
+        "arity": "unary",
+        "signature": "y = fft(x, n=None, axis=-1, norm=None)",
+        "latex": r"y = \mathcal{F}(x),\quad \frac{\partial y}{\partial x} = \mathcal{F}^{-1}(g)",
+        "backward": {
+            "x": "gx = ifft(g, n=n, axis=axis, norm=norm)",
+        },
+        "python": {
+            "parameters": ["g", "x", "n=None", "axis=-1", "norm=None"],
+            "body": "return AbstractTensor.ifft(g, n=n, axis=axis, norm=norm)",
+        },
+        "domain": "x real or complex",
+        "notes": "Gradient is the inverse FFT of the upstream gradient.",
+        "tags": ["fourier", "linear"],
+    },
+    "ifft": {
+        "arity": "unary",
+        "signature": "y = ifft(x, n=None, axis=-1, norm=None)",
+        "latex": r"y = \mathcal{F}^{-1}(x),\quad \frac{\partial y}{\partial x} = \mathcal{F}(g)",
+        "backward": {
+            "x": "gx = fft(g, n=n, axis=axis, norm=norm)",
+        },
+        "python": {
+            "parameters": ["g", "x", "n=None", "axis=-1", "norm=None"],
+            "body": "return AbstractTensor.fft(g, n=n, axis=axis, norm=norm)",
+        },
+        "domain": "x real or complex",
+        "notes": "Gradient is the forward FFT of the upstream gradient.",
+        "tags": ["fourier", "linear"],
+    },
+    "rfft": {
+        "arity": "unary",
+        "signature": "y = rfft(x, n=None, axis=-1, norm=None)",
+        "latex": r"y = \mathcal{F}_r(x),\quad \frac{\partial y}{\partial x} = \mathcal{F}^{-1}_r(g)",
+        "backward": {
+            "x": "gx = irfft(g, n=n, axis=axis, norm=norm)",
+        },
+        "python": {
+            "parameters": ["g", "x", "n=None", "axis=-1", "norm=None"],
+            "body": "return AbstractTensor.irfft(g, n=n, axis=axis, norm=norm)",
+        },
+        "domain": "x real",
+        "notes": "Real-input FFT uses inverse real FFT for gradients.",
+        "tags": ["fourier", "linear"],
+    },
+    "irfft": {
+        "arity": "unary",
+        "signature": "y = irfft(x, n=None, axis=-1, norm=None)",
+        "latex": r"y = \mathcal{F}^{-1}_r(x),\quad \frac{\partial y}{\partial x} = \mathcal{F}_r(g)",
+        "backward": {
+            "x": "gx = rfft(g, n=n, axis=axis, norm=norm)",
+        },
+        "python": {
+            "parameters": ["g", "x", "n=None", "axis=-1", "norm=None"],
+            "body": "return AbstractTensor.rfft(g, n=n, axis=axis, norm=norm)",
+        },
+        "domain": "x spectrum with Hermitian symmetry",
+        "notes": "Inverse real FFT uses forward real FFT for gradients.",
+        "tags": ["fourier", "linear"],
+    },
+
+    # ----------------------------------------------------------------------
     # Softmax family
     # ----------------------------------------------------------------------
     "softmax": {

--- a/tests/test_fft_autograd.py
+++ b/tests/test_fft_autograd.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
+
+
+@pytest.mark.skipif(T is None, reason="NumPy backend required")
+def test_fft_backward_matches_ifft():
+    x = T.arange(8, dtype=np.float32)
+    x.requires_grad_(True)
+
+    y = x.fft().ifft()
+    loss = y.sum()
+    loss.backward()
+
+    expected = T.ones_like(x)
+    assert np.allclose(x.grad.data, expected.data)
+


### PR DESCRIPTION
## Summary
- expose fft/ifft/rfft/irfft as direct AbstractTensor methods
- wire backward rules for Fourier transforms
- cover FFT gradient flow with a dedicated test

## Testing
- `pytest tests/test_fft_autograd.py tests/test_autograd_homemade.py tests/test_backward_registry.py`
- ⚠️ `pytest tests/autoautograd/test_spring_dt_thread.py` (failed: SymPy assumptions recursion/KeyboardInterrupt)


------
https://chatgpt.com/codex/tasks/task_e_68c093985f3c832a88cc9b4355e8dc1a