### PR TITLE
feat: add spectral metrics readout and demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -19,4 +19,6 @@ from .fs_dec import (
     transport_tick,
     pump_tick,
 )
+# Spectral utilities
+from .spectral_readout import compute_metrics
 # Torch bridge is optional import to keep AT-only usage clean.

--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -1,0 +1,160 @@
+"""FluxSpring spectral routing demonstration.
+
+This script showcases how spectral features extracted from a time
+domain buffer can drive a FluxSpring data graph.  Three sine bands are
+analysed via :func:`compute_metrics` and the resulting band powers are
+fed into a small FluxSpring spec consisting of two identity stacks
+bracketing a mixing layer.  The graph is executed directly using
+AbstractTensor operations to apply the edge weights encoded in the spec.
+"""
+
+from __future__ import annotations
+
+from ...abstraction import AbstractTensor as AT
+from .spectral_readout import compute_metrics
+from .fs_types import (
+    DECSpec,
+    EdgeCtrl,
+    EdgeSpec,
+    EdgeTransport,
+    EdgeTransportLearn,
+    FluxSpringSpec,
+    LearnCtrl,
+    NodeCtrl,
+    NodeSpec,
+    SpectralCfg,
+    SpectralMetrics,
+)
+from .fs_io import validate_fluxspring
+
+
+def _node(idx: int) -> NodeSpec:
+    """Create a frozen linear node."""
+
+    ctrl = NodeCtrl(
+        alpha=AT.tensor(0.0),
+        w=AT.tensor(1.0),
+        b=AT.tensor(0.0),
+        learn=LearnCtrl(False, False, False),
+    )
+    return NodeSpec(
+        id=idx,
+        p0=AT.zeros(3),
+        v0=AT.zeros(3),
+        mass=AT.tensor(1.0),
+        ctrl=ctrl,
+        scripted_axes=[0, 2],
+        temperature=AT.tensor(0.0),
+        exclusive=False,
+    )
+
+
+def _edge(i: int, j: int, w: float) -> EdgeSpec:
+    """Create a frozen linear edge with weight ``w``."""
+
+    ctrl = EdgeCtrl(
+        alpha=AT.tensor(0.0),
+        w=AT.tensor(w),
+        b=AT.tensor(0.0),
+        learn=LearnCtrl(False, False, False),
+    )
+    transport = EdgeTransport(
+        kappa=AT.tensor(1.0),
+        learn=EdgeTransportLearn(kappa=False, k=False, l0=False, lambda_s=False, x=False),
+    )
+    return EdgeSpec(src=i, dst=j, transport=transport, ctrl=ctrl, temperature=AT.tensor(0.0), exclusive=False)
+
+
+def build_spec(spectral: SpectralCfg) -> FluxSpringSpec:
+    """Construct the demo FluxSpringSpec.
+
+    The graph has six layers (input, two pre-mix identity layers, a
+    mixing layer and two post-mix identity layers) with three nodes per
+    layer.  Only the central layer mixes features; all other edges carry
+    identity weights.
+    """
+
+    layers = 6
+    nodes = [_node(i) for i in range(3 * layers)]
+    edges: list[EdgeSpec] = []
+
+    def add_identity(src_start: int, dst_start: int) -> None:
+        for k in range(3):
+            edges.append(_edge(src_start + k, dst_start + k, 1.0))
+
+    # Input → pre-mix stacks
+    add_identity(0, 3)
+    add_identity(3, 6)
+
+    # Mixing layer
+    Wmid = [
+        [1.0, 0.5, 0.0],
+        [0.0, 1.0, 0.5],
+        [0.5, 0.0, 1.0],
+    ]
+    for i in range(3):
+        for j in range(3):
+            edges.append(_edge(6 + i, 9 + j, Wmid[i][j]))
+
+    # Post-mix stacks
+    add_identity(9, 12)
+    add_identity(12, 15)
+
+    E = len(edges)
+    N = len(nodes)
+    D0 = [[0.0] * N for _ in range(E)]
+    for r, e in enumerate(edges):
+        D0[r][e.src] = -1.0
+        D0[r][e.dst] = 1.0
+    dec = DECSpec(D0=D0, D1=[])
+
+    spec = FluxSpringSpec(
+        version="spectral-demo-fs-1.0",
+        D=3,
+        nodes=nodes,
+        edges=edges,
+        faces=[],
+        dec=dec,
+        spectral=spectral,
+    )
+    validate_fluxspring(spec)
+    return spec
+
+
+def main() -> None:
+    tick_hz = 400.0
+    N = 400
+    t = AT.arange(N, dtype=float) / tick_hz
+    freqs = [40.0, 80.0, 160.0]
+    sig = AT.stack([(2 * AT.pi() * f * t).sin() for f in freqs], dim=1)
+
+    spectral_cfg = SpectralCfg(
+        enabled=True,
+        tick_hz=tick_hz,
+        win_len=N,
+        hop_len=N,
+        window="hann",
+        metrics=SpectralMetrics(bands=[[30, 50], [70, 90], [150, 170]]),
+    )
+    metrics = compute_metrics(sig, spectral_cfg)
+    feats = metrics["bandpower"]
+
+    spec = build_spec(spectral_cfg)
+
+    # Run a simple forward pass using the edge weights in the spec.
+    activ = AT.zeros(len(spec.nodes), dtype=float)
+    for i, val in enumerate(feats):
+        activ[i] = AT.tensor(val)
+    for e in spec.edges:
+        w = float(AT.get_tensor(e.ctrl.w).data.item())
+        b = float(AT.get_tensor(e.ctrl.b).data.item())
+        activ[e.dst] = activ[e.dst] + w * activ[e.src] + b
+    out = activ[15:18]
+
+    print("Band powers:", feats)
+    print("Routed output:", [float(AT.get_tensor(o).data.item()) for o in out])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -169,7 +169,9 @@
               },
               "default": []
             },
-            "centroid": { "type": "boolean", "default": false }
+            "centroid": { "type": "boolean", "default": false },
+            "flatness": { "type": "boolean", "default": false },
+            "coherence": { "type": "boolean", "default": false }
           },
           "additionalProperties": false,
           "default": {}

--- a/src/common/tensors/autoautograd/fluxspring/fs_io.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_io.py
@@ -125,6 +125,8 @@ def _coerce_spectral(d: Optional[Dict]) -> SpectralCfg:
         metrics=SpectralMetrics(
             bands=[[float(lo), float(hi)] for lo, hi in m.get("bands", [])],
             centroid=bool(m.get("centroid", False)),
+            flatness=bool(m.get("flatness", False)),
+            coherence=bool(m.get("coherence", False)),
         ),
     )
 
@@ -259,7 +261,6 @@ def validate_fluxspring(spec: FluxSpringSpec, *, tol: float = 1e-8) -> None:
 
     # Optional numeric check with AbstractTensor if available
     try:
-        from ...abstraction import AbstractTensor as AT
         D0_t = AT.get_tensor(D0).astype(float)
         D1_t = AT.get_tensor(D1).astype(float)
         bdry = D1_t @ D0_t

--- a/src/common/tensors/autoautograd/fluxspring/fs_types.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_types.py
@@ -150,6 +150,8 @@ class RegCfg:
 class SpectralMetrics:
     bands: List[List[float]] = field(default_factory=list)  # [ [f_lo, f_hi], ... ]
     centroid: bool = False
+    flatness: bool = False
+    coherence: bool = False
 
 
 @dataclass

--- a/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
+++ b/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
@@ -1,0 +1,106 @@
+"""Spectral metrics utilities for FluxSpring.
+
+This module exposes a ``compute_metrics`` function that operates on
+:class:`~src.common.tensors.abstraction.AbstractTensor` buffers.  It
+computes power spectra using the backend's FFT implementation when
+available and falls back to explicit sine/cosine bases otherwise.  The
+function supports several common spectral metrics that are useful for
+training FluxSpring graphs with frequency‑selective objectives.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from ...abstraction import AbstractTensor as AT
+from .fs_types import SpectralCfg
+
+
+def _rfft_real_imag(x: AT, tick_hz: float) -> Tuple[AT, AT, AT]:
+    """Return real/imag parts of the FFT and the frequency grid.
+
+    Uses the backend FFT when available.  If missing, a direct DFT is
+    computed using sine/cosine bases.  This avoids constructing complex
+    tensors manually and stays within the AbstractTensor API.
+    """
+
+    N = int(x.shape[0])
+    try:
+        C = AT.fft.rfft(x, axis=0)
+        freqs = AT.fft.rfftfreq(N, d=1.0 / tick_hz, like=x)
+        return AT.real(C), AT.imag(C), freqs
+    except Exception:
+        t = AT.arange(N, dtype=float)
+        k = AT.arange(N // 2 + 1, dtype=float)
+        ang = (2.0 * AT.pi() * t[:, None] * k[None, :]) / float(N)
+        cos_b = ang.cos()
+        sin_b = ang.sin()
+        c_real = cos_b.T @ x
+        c_imag = -sin_b.T @ x
+        freqs = k * (tick_hz / float(N))
+        return c_real, c_imag, freqs
+
+
+def _window(name: str, N: int) -> AT:
+    n = name.lower()
+    if n in ("hann", "hanning"):
+        return AT.hanning(N)
+    if n == "hamming":
+        return AT.hamming(N)
+    if n == "zeros":
+        return AT.zeros(N, dtype=float)
+    return AT.ones(N, dtype=float)
+
+
+def compute_metrics(buffer: AT, cfg: SpectralCfg) -> Dict[str, Any]:
+    """Compute spectral metrics for ``buffer`` according to ``cfg``."""
+
+    if buffer.ndim == 1:
+        x = buffer[:, None]
+    else:
+        x = buffer
+
+    N = int(x.shape[0])
+    w = _window(cfg.window, N)
+    xw = w[:, None] * x
+
+    real, imag, freqs = _rfft_real_imag(xw, cfg.tick_hz)
+    power = real**2 + imag**2
+
+    metrics: Dict[str, Any] = {}
+    m = cfg.metrics
+
+    if m.bands:
+        band_vals: List[float] = []
+        for lo, hi in m.bands:
+            mask = (freqs >= lo) & (freqs <= hi)
+            bw = AT.sum(power * mask[:, None])
+            band_vals.append(float(AT.get_tensor(bw).data.item()))
+        metrics["bandpower"] = band_vals
+
+    if m.centroid:
+        total = AT.sum(power) + 1e-12
+        cent = AT.sum(freqs * AT.sum(power, dim=1)) / total
+        metrics["centroid"] = float(AT.get_tensor(cent).data.item())
+
+    if m.flatness:
+        logp = AT.log(power + 1e-12)
+        gm = AT.exp(AT.mean(logp))
+        am = AT.mean(power)
+        metrics["flatness"] = float(AT.get_tensor(gm / (am + 1e-12)).data.item())
+
+    if m.coherence and xw.shape[1] >= 2:
+        r0, i0 = real[:, 0], imag[:, 0]
+        r1, i1 = real[:, 1], imag[:, 1]
+        pxx = r0**2 + i0**2
+        pyy = r1**2 + i1**2
+        pxy_r = r0 * r1 + i0 * i1
+        pxy_i = i0 * r1 - r0 * i1
+        den = pxx * pyy
+        coh = (pxy_r**2 + pxy_i**2) / (den + 1e-12)
+        mask = den > 1e-12
+        coh_masked = AT.where(mask, coh, AT.zeros_like(coh))
+        mean_coh = AT.sum(coh_masked) / (AT.sum(mask) + 1e-12)
+        metrics["coherence"] = float(AT.get_tensor(mean_coh).data.item())
+
+    return metrics

--- a/tests/autoautograd/test_spectral_readout.py
+++ b/tests/autoautograd/test_spectral_readout.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring.spectral_readout import (
+    compute_metrics,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_types import (
+    SpectralCfg,
+    SpectralMetrics,
+)
+
+
+def _sine(freq: float, N: int, tick_hz: float) -> AT:
+    t = AT.arange(N, dtype=float) / tick_hz
+    return (2 * AT.pi() * freq * t).sin()
+
+
+def test_bandpower_centroid_flatness():
+    N = 400
+    tick_hz = 400.0
+    freq = 40.0
+    x = _sine(freq, N, tick_hz)
+    cfg = SpectralCfg(
+        enabled=True,
+        tick_hz=tick_hz,
+        win_len=N,
+        hop_len=N,
+        window="rect",
+        metrics=SpectralMetrics(
+            bands=[[30.0, 50.0], [100.0, 150.0]],
+            centroid=True,
+            flatness=True,
+        ),
+    )
+    m = compute_metrics(x, cfg)
+    assert m["bandpower"][0] > 10 * m["bandpower"][1]
+    assert abs(m["centroid"] - freq) < 2.0
+    assert m["flatness"] < 0.2
+
+
+def test_window_function_applied():
+    N = 128
+    tick_hz = 128.0
+    freq = 20.0
+    x = _sine(freq, N, tick_hz)
+    cfg = SpectralCfg(
+        enabled=True,
+        tick_hz=tick_hz,
+        win_len=N,
+        hop_len=N,
+        window="zeros",
+        metrics=SpectralMetrics(bands=[[10.0, 30.0]]),
+    )
+    m = compute_metrics(x, cfg)
+    assert m["bandpower"][0] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_coherence_identical_signals():
+    N = 256
+    tick_hz = 256.0
+    freq = 30.0
+    s = _sine(freq, N, tick_hz)
+    buf = AT.stack([s, s], dim=1)
+    cfg = SpectralCfg(
+        enabled=True,
+        tick_hz=tick_hz,
+        win_len=N,
+        hop_len=N,
+        window="rect",
+        metrics=SpectralMetrics(coherence=True),
+    )
+    m = compute_metrics(buf, cfg)
+    assert abs(m["coherence"] - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- integrate FluxSpring's SpectralCfg into spectral readout
- enable spectral mode in demo and route band powers through graph
- expand spectral metrics to include flatness and coherence

## Testing
- `python -m src.common.tensors.autoautograd.fluxspring.demo_spectral_routing`
- `pytest tests/autoautograd/test_spectral_readout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c091ffa414832ab73c9ea85260506c