### PR TITLE
Enable iterative spectral routing demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -235,4 +235,16 @@ def pump_tick(
         "edge_in": edge_in,
         "node_in": node_in,
     }
+
+    # Maintain ring buffers for spectral analysis.
+    if spec.spectral.enabled:
+        for n, val in zip(spec.nodes, psi_next):
+            if n.ring is not None:
+                r = AT.get_tensor(n.ring)
+                D = int(r.shape[1]) if r.ndim == 2 else 1
+                n.push_ring(AT.ones(D, dtype=float) * val)
+        for e, q_val in zip(spec.edges, q):
+            if e.ring is not None:
+                e.push_ring(q_val)
+
     return psi_next, stats


### PR DESCRIPTION
## Summary
- maintain node and edge ring buffers during FluxSpring pump ticks
- add ring-buffer spectral metrics helper and stream spectral routing demo

## Testing
- `pytest tests/autoautograd/test_spectral_readout.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0a3a4d2f8832a99312bf1d73c05cb