### PR TITLE
Flatten FluxSpring control tensors to 1D

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -154,21 +154,23 @@ def transport_tick(
     D0, _ = incidence_tensors_AT(spec)
     dpsi = D0 @ psi  # (E,)
 
-    kappa = AT.get_tensor([e.transport.kappa for e in spec.edges]).astype(float)  # (E,)
+    kappa = (
+        AT.get_tensor([e.transport.kappa for e in spec.edges]).astype(float).reshape(-1)
+    )  # (E,)
 
     if P is not None:
         k = AT.get_tensor([
             e.transport.k if e.transport.k is not None else AT.tensor(0.0)
             for e in spec.edges
-        ]).astype(float)
+        ]).astype(float).reshape(-1)
         l0 = AT.get_tensor([
             e.transport.l0 if e.transport.l0 is not None else AT.tensor(0.0)
             for e in spec.edges
-        ]).astype(float)
+        ]).astype(float).reshape(-1)
         lambda_s = AT.get_tensor([
             e.transport.lambda_s if e.transport.lambda_s is not None else AT.tensor(0.0)
             for e in spec.edges
-        ]).astype(float)
+        ]).astype(float).reshape(-1)
         g = edge_strain_AT(P, spec, l0)
         G = lambda_s * k * g
     else:
@@ -177,8 +179,8 @@ def transport_tick(
     x = AT.get_tensor([
         e.transport.x if e.transport.x is not None else AT.tensor(0.0)
         for e in spec.edges
-    ]).astype(float)
-    gamma = AT.get_tensor(spec.gamma).astype(float)
+    ]).astype(float).reshape(-1)
+    gamma = AT.get_tensor(spec.gamma).astype(float).reshape(-1)
     R = gamma * x
 
     delta = dpsi + G + R
@@ -212,17 +214,29 @@ def pump_tick(
     D0, _ = incidence_tensors_AT(spec)
     dpsi = D0 @ psi  # (E,)
 
-    alpha_e = AT.get_tensor([e.ctrl.alpha for e in spec.edges]).astype(float)
-    w_e = AT.get_tensor([e.ctrl.w for e in spec.edges]).astype(float)
-    b_e = AT.get_tensor([e.ctrl.b for e in spec.edges]).astype(float)
+    alpha_e = (
+        AT.get_tensor([e.ctrl.alpha for e in spec.edges]).astype(float).reshape(-1)
+    )
+    w_e = (
+        AT.get_tensor([e.ctrl.w for e in spec.edges]).astype(float).reshape(-1)
+    )
+    b_e = (
+        AT.get_tensor([e.ctrl.b for e in spec.edges]).astype(float).reshape(-1)
+    )
     edge_in = alpha_e * dpsi + b_e
     q = w_e * phi(edge_in)
 
     s = D0.T() @ q  # (N,)
 
-    alpha_n = AT.get_tensor([n.ctrl.alpha for n in spec.nodes]).astype(float)
-    w_n = AT.get_tensor([n.ctrl.w for n in spec.nodes]).astype(float)
-    b_n = AT.get_tensor([n.ctrl.b for n in spec.nodes]).astype(float)
+    alpha_n = (
+        AT.get_tensor([n.ctrl.alpha for n in spec.nodes]).astype(float).reshape(-1)
+    )
+    w_n = (
+        AT.get_tensor([n.ctrl.w for n in spec.nodes]).astype(float).reshape(-1)
+    )
+    b_n = (
+        AT.get_tensor([n.ctrl.b for n in spec.nodes]).astype(float).reshape(-1)
+    )
     node_in = alpha_n * s + b_n
     delta = w_n * phi(node_in)
 


### PR DESCRIPTION
## Summary
- Ensure transport parameters (`kappa`, `k`, `l0`, `lambda_s`, `x`, `gamma`) are flattened to 1‑D in `transport_tick`
- Flatten edge and node control triples (`alpha`, `w`, `b`) to 1‑D in `pump_tick`

## Testing
- `python -m src.common.tensors.autoautograd.fluxspring.demo_spectral_routing` *(fails: AttributeError: 'Autograd' object has no attribute 'zero_grad')*
- `pytest tests/autoautograd/test_spectral_readout.py tests/autoautograd/test_spring_dt_engine_backends.py tests/autoautograd/test_spring_dt_thread.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0c81a1c8c832ab7b44d2dac87dcbc