### PR TITLE
Use broadcast-safe ring updates

### DIFF
--- a/src/common/tensors/abstract_nn/demo_fused_conv_text.py
+++ b/src/common/tensors/abstract_nn/demo_fused_conv_text.py
@@ -148,7 +148,7 @@ def run_eager_training_test(model, AT, args):
     last_loss = None
     best_loss = None
     inputs = AT.randn((args.input_len,), requires_grad=True)
-    targets = AT.ones(args.input_len) * 65.0  # ASCII 'A'
+    targets = AT.full((args.input_len,), 65.0)  # ASCII 'A'
 
     for i in range(max_steps):
         tape = autograd.tape

--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -328,9 +328,7 @@ def pump_tick(
     if spec.spectral.enabled:
         for n, val in zip(spec.nodes, psi_next):
             if n.ring is not None:
-                r = AT.get_tensor(n.ring)
-                D = int(r.shape[1]) if r.ndim == 2 else 1
-                n.push_ring(AT.ones(D, dtype=float) * val)
+                n.push_ring(val)
         for e, q_val in zip(spec.edges, q):
             if e.ring is not None:
                 e.push_ring(q_val)


### PR DESCRIPTION
## Summary
- Simplify FluxSpring `pump_tick` ring buffer maintenance by relying on the new `push_ring` helper, avoiding manual tensor duplication
- Replace `AT.ones(...)*val` patterns with `AT.full` or direct tensor forwarding to preserve autograd history

## Testing
- `pytest tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_fluxspring_gradients.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17937f900832ab760fda8fa345239