### PR TITLE
Add ring buffer gradient test

### DIFF
--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -710,6 +710,21 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
         "notes": "Scatter assignment; gradient flows from selected region to the value.",
         "tags": ["indexing"],
     },
+    "clone": {
+        "arity": "unary",
+        "signature": "y = x.clone()",
+        "latex": r"y = \mathrm{clone}(x),\quad \frac{\partial y}{\partial x} = 1",
+        "backward": {
+            "x": "gx = g.clone()"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": "return g.clone() if hasattr(g, 'clone') else g",
+        },
+        "domain": "Any real",
+        "notes": "Identity operation; gradient passes through unchanged.",
+        "tags": ["identity"],
+    },
     "gather": {
         "arity": "binary",
         "signature": "y = gather(x, index, dim)",
@@ -734,8 +749,8 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
             "src": "gsrc = g[index]"
         },
         "python": {
-            "parameters": ["g", "x", "src", "index"],
-            "body": "gx=g.clone(); gsrc=g[index]; return gx, gsrc"
+            "parameters": ["g", "x", "index", "src"],
+            "body": "gx=g.clone(); gsrc=g[index]; return gx, None, gsrc"
         },
         "domain": "Any real; index valid.",
         "notes": "Backward of scatter: pass gradient through x; gather gradient for src at index positions.",

--- a/tests/autoautograd/test_ring_buffer_gradients.py
+++ b/tests/autoautograd/test_ring_buffer_gradients.py
@@ -1,0 +1,35 @@
+import pytest
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autograd import autograd
+from src.common.tensors.autoautograd.fluxspring.fs_types import NodeSpec, NodeCtrl
+
+
+def test_ring_buffer_propagates_gradients():
+    """Ring buffers on ``NodeSpec`` should participate in autograd.
+
+    Values pushed through :meth:`NodeSpec.push_ring` are stored via tensor
+    operations (`AT.scatter_row`) rather than Python list mutation. This keeps
+    the autograd graph intact, so losses computed from the ring should backprop
+    to the original parameter.
+    """
+
+    param = AT.tensor(1.0)
+    param.requires_grad_(True)
+
+    node = NodeSpec(
+        id=0,
+        p0=AT.get_tensor([0.0]),
+        v0=AT.get_tensor([0.0]),
+        mass=AT.tensor(1.0),
+        ctrl=NodeCtrl(),
+        scripted_axes=[0],
+        ring_size=3,
+    )
+
+    for i in range(6):
+        node.push_ring(param * AT.tensor(float(i + 1)))
+
+    loss = node.ring.sum()
+    grad = autograd.grad(loss, [param])[0]
+    assert grad is not None
+    assert float(AT.get_tensor(grad)) != 0.0


### PR DESCRIPTION
## Summary
- use `NodeSpec.push_ring` to confirm ring buffer gradients connect to parameters
- fix autograd's `clone` and `scatter_row` to preserve gradient paths
- register missing `clone` backward rule and correct `scatter` backward signature

## Testing
- `pytest tests/autoautograd/test_ring_buffer_gradients.py -q`
- `pytest tests/autoautograd -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1804cc1b0832a8df33422216932b2