### PR TITLE
Report gradient status in spectral routing demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -209,6 +209,20 @@ def train_routing(
         out = [psi[out_start + i] for i in range(B)]
         routed.append(AT.get_tensor(out))
 
+    # Report gradient status for all learnable parameters once outputs have been
+    # produced.  This helps diagnose dead graphs where ``loss.backward`` fails
+    # to populate ``grad`` fields.
+    for idx, p in enumerate(params):
+        grad = getattr(p, "grad", None)
+        if grad is None:
+            print(f"[Gradients] param {idx} missing gradient")
+        else:
+            g = AT.get_tensor(grad)
+            if np.allclose(g, 0.0):
+                print(f"[Gradients] param {idx} gradient is zero: {g}")
+            else:
+                print(f"[Gradients] param {idx} grad: {g}")
+
     return routed
 
 


### PR DESCRIPTION
## Summary
- Add gradient reporting after training in demo_spectral_routing to identify missing or zero gradients

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py::test_demo_spec_has_no_gradients -q`
- `pytest tests/test_spectral_fluxspring_grad.py::test_spectral_fluxspring_grad -q`


------
https://chatgpt.com/codex/tasks/task_e_68c190c43cd8832aa366ea5b7a48512a