### PR TITLE
Fix clamp autograd and preserve parameter tape

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -367,10 +367,11 @@ class AbstractTensor:
 
     # --- Clamping ---
     def clamp(self, min: float | None = None, max: float | None = None) -> "AbstractTensor":
-        """Return ``self`` clamped between ``min`` and ``max``."""
+        """Return ``self`` clamped between ``min`` and ``max`` with autograd support."""
+        finalize = AbstractTensor._pre_autograd("clamp", [self], params={"min": min, "max": max})
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.clamp_(min_val=min, max_val=max)
-        return result
+        return finalize(result)
 
     def clamp_(self, min_val: float | None = None, max_val: float | None = None):
         raise NotImplementedError(f"{self.__class__.__name__} must implement clamp_()")


### PR DESCRIPTION
## Summary
- add autograd recording to `AbstractTensor.clamp`/`clip`
- rebind tensors to the active tape when `zero_grad` is called so parameters keep gradient tracking

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py::test_fluxspring_gradients_match_fd_and_accumulate -q`
- `pytest tests/test_spectral_fluxspring_grad.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19b14c82c832aa00d32c6b8df4beb