### PR TITLE
Preserve FluxSpring parameter gradients

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -39,9 +39,10 @@ def _rebind_param(param: AT | None, learn: bool, out: list[AT]) -> AT | None:
     if param is None:
         return None
 
-    # Ensure the tensor is registered on the current tape with the desired
-    # gradient flag.  ``requires_grad_(False)`` is a no-op for most backends
-    # but keeps intent explicit.
+    # Reattach the tensor to the current tape as a leaf so gradients populate
+    # ``param.grad``.  ``detach`` drops any prior history while preserving the
+    # object identity once reassigned to the spec.
+    param = param.detach()
     param.requires_grad_(learn)
     if learn:
         out.append(param)

--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -155,14 +155,14 @@ def transport_tick(
     dpsi = D0 @ psi  # (E,)
 
     kappa = (
-        AT.get_tensor([e.transport.kappa for e in spec.edges])
+        AT.stack([e.transport.kappa for e in spec.edges])
         .astype(float)
         .reshape(-1)
     )  # (E,)
 
     if P is not None:
         k = (
-            AT.get_tensor([
+            AT.stack([
                 e.transport.k if e.transport.k is not None else AT.tensor(0.0)
                 for e in spec.edges
             ])
@@ -170,7 +170,7 @@ def transport_tick(
             .reshape(-1)
         )
         l0 = (
-            AT.get_tensor([
+            AT.stack([
                 e.transport.l0 if e.transport.l0 is not None else AT.tensor(0.0)
                 for e in spec.edges
             ])
@@ -178,7 +178,7 @@ def transport_tick(
             .reshape(-1)
         )
         lambda_s = (
-            AT.get_tensor([
+            AT.stack([
                 e.transport.lambda_s
                 if e.transport.lambda_s is not None
                 else AT.tensor(0.0)
@@ -194,7 +194,7 @@ def transport_tick(
         G = AT.zeros_like(kappa)
 
     x = (
-        AT.get_tensor([
+        AT.stack([
             e.transport.x if e.transport.x is not None else AT.tensor(0.0)
             for e in spec.edges
         ])


### PR DESCRIPTION
## Summary
- ensure FluxSpring learnable tensors are detached and reattached to the global tape so gradients populate
- stack transport parameters instead of converting them with `get_tensor` so autograd retains the computation graph

## Testing
- `pytest tests/autoautograd -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1aaa27adc832a8595293c55eca1d8