### PR TITLE
Fix autograd param cloning in backend conversion

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -3117,7 +3117,10 @@ def _flatten(data):
 
 def default_to_backend(source_ops, tensor, target_ops):
     if type(source_ops) is type(target_ops):
-        return source_ops.clone()
+        # Preserve the original tensor when no backend conversion is needed.
+        # Cloning here detached parameters from the autograd tape, yielding
+        # ``None`` gradients for FluxSpring weights during training.
+        return tensor
 
     data = tensor.tolist()
     dtype = None

--- a/tests/autoautograd/test_fluxspring_gradients.py
+++ b/tests/autoautograd/test_fluxspring_gradients.py
@@ -159,3 +159,21 @@ def test_demo_spec_has_no_gradients():
     grads = autograd.grad(loss, params, allow_unused=True)
     assert all(g is None for g in grads)
 
+
+def test_register_learnable_params_preserves_gradients():
+    bands = [[20, 40], [40, 60]]
+    cfg = SpectralCfg(
+        enabled=True,
+        tick_hz=400.0,
+        win_len=4,
+        hop_len=4,
+        window="hann",
+        metrics=SpectralMetrics(bands=bands),
+    )
+    spec = build_spec(cfg)
+    params = register_learnable_params(spec)
+    w = params[0]
+    loss = (w * AT.tensor(2.0)) ** 2
+    g = autograd.grad(loss, [w])[0]
+    assert g is not None
+


### PR DESCRIPTION
## Summary
- prevent `default_to_backend` from cloning tensors when no backend change is needed
- add regression test ensuring `register_learnable_params` preserves gradient tracking

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py::test_register_learnable_params_preserves_gradients -q`
- `pytest tests/autoautograd/test_fluxspring_gradients.py::test_fluxspring_gradients_match_fd_and_accumulate -q`
- `pytest tests/test_spectral_fluxspring_grad.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1acb8fefc832a84ab4b0ff8427059