### PR TITLE
Refactor FluxSpring ring buffers into external harness

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -21,6 +21,7 @@ from .fs_dec import (
 )
 # Spectral utilities
 from .spectral_readout import compute_metrics
+from .fs_harness import RingHarness
 # Torch bridge is optional import to keep AT-only usage clean.
 
 from ...abstraction import AbstractTensor as AT

--- a/src/common/tensors/autoautograd/fluxspring/fs.schema.json
+++ b/src/common/tensors/autoautograd/fluxspring/fs.schema.json
@@ -46,8 +46,7 @@
           },
           "scripted_axes": { "type": "array", "items": { "type": "integer" }, "minItems": 2, "maxItems": 2 },
           "temperature": { "type": "number", "default": 0.0 },
-          "exclusive": { "type": "boolean", "default": false },
-          "ring_size": { "type": ["integer", "null"], "minimum": 1 }
+          "exclusive": { "type": "boolean", "default": false }
         },
         "additionalProperties": false
       }
@@ -103,8 +102,7 @@
             "additionalProperties": false
           },
           "temperature": { "type": "number", "default": 0.0 },
-          "exclusive": { "type": "boolean", "default": false },
-          "ring_size": { "type": ["integer", "null"], "minimum": 1 }
+          "exclusive": { "type": "boolean", "default": false }
         },
         "additionalProperties": false
       }

--- a/src/common/tensors/autoautograd/fluxspring/fs_harness.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_harness.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Auxiliary harness managing ring buffers for FluxSpring graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+from ...abstraction import AbstractTensor as AT
+
+
+@dataclass
+class RingBuffer:
+    """Simple differentiable ring buffer."""
+
+    buf: AT
+    idx: int = 0
+
+    def push(self, val: AT) -> AT:
+        i = self.idx % int(len(self.buf))
+        self.buf = AT.scatter_row(self.buf.clone(), i, val, dim=0)
+        self.idx = i + 1
+        return self.buf
+
+
+@dataclass
+class RingHarness:
+    """Own per-node and per-edge ring buffers keyed by lineage."""
+
+    default_size: Optional[int] = None
+    node_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
+    edge_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
+
+    def _key(self, obj_id: int, lineage: Tuple[int, ...] | None) -> Tuple[int, ...]:
+        return (obj_id,) if lineage is None else (obj_id, *lineage)
+
+    def _ensure_node_ring(
+        self, key: Tuple[int, ...], D: int, size: Optional[int]
+    ) -> Optional[RingBuffer]:
+        size = size or self.default_size
+        if size is None:
+            return None
+        if key not in self.node_rings:
+            buf = AT.zeros((size, D), dtype=float)
+            self.node_rings[key] = RingBuffer(buf)
+        return self.node_rings[key]
+
+    def _ensure_edge_ring(
+        self, key: Tuple[int, ...], size: Optional[int]
+    ) -> Optional[RingBuffer]:
+        size = size or self.default_size
+        if size is None:
+            return None
+        if key not in self.edge_rings:
+            buf = AT.zeros(size, dtype=float)
+            self.edge_rings[key] = RingBuffer(buf)
+        return self.edge_rings[key]
+
+    def push_node(
+        self,
+        node_id: int,
+        val: AT,
+        *,
+        lineage: Tuple[int, ...] | None = None,
+        size: Optional[int] = None,
+    ) -> AT | None:
+        key = self._key(node_id, lineage)
+        t = AT.get_tensor(val)
+        D = int(t.shape[0]) if getattr(t, "ndim", 0) > 0 else 1
+        rb = self._ensure_node_ring(key, D, size)
+        if rb is None:
+            return None
+        return rb.push(val)
+
+    def push_edge(
+        self,
+        edge_idx: int,
+        val: AT,
+        *,
+        lineage: Tuple[int, ...] | None = None,
+        size: Optional[int] = None,
+    ) -> AT | None:
+        key = self._key(edge_idx, lineage)
+        rb = self._ensure_edge_ring(key, size)
+        if rb is None:
+            return None
+        return rb.push(val)
+
+    def get_node_ring(
+        self, node_id: int, *, lineage: Tuple[int, ...] | None = None
+    ) -> Optional[RingBuffer]:
+        return self.node_rings.get(self._key(node_id, lineage))
+
+    def get_edge_ring(
+        self, edge_idx: int, *, lineage: Tuple[int, ...] | None = None
+    ) -> Optional[RingBuffer]:
+        return self.edge_rings.get(self._key(edge_idx, lineage))
+

--- a/src/common/tensors/autoautograd/fluxspring/fs_io.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_io.py
@@ -37,7 +37,6 @@ def _coerce_node(d: Dict) -> NodeSpec:
         scripted_axes=[int(a) for a in d["scripted_axes"]],
         temperature=AT.tensor(float(d.get("temperature", 0.0))),
         exclusive=bool(d.get("exclusive", False)),
-        ring_size=int(d["ring_size"]) if d.get("ring_size") is not None else None,
     )
 
 def _coerce_edge(d: Dict) -> EdgeSpec:
@@ -72,7 +71,6 @@ def _coerce_edge(d: Dict) -> EdgeSpec:
         ),
         temperature=AT.tensor(float(d.get("temperature", 0.0))),
         exclusive=bool(d.get("exclusive", False)),
-        ring_size=int(d["ring_size"]) if d.get("ring_size") is not None else None,
     )
 
 def _coerce_face(d: Dict) -> FaceSpec:
@@ -161,7 +159,7 @@ def save_fluxspring(spec: FluxSpringSpec, path: str, *, indent: int = 2) -> None
             return {
                 k: _plain(v)
                 for k, v in asdict(x).items()
-                if v is not None and k not in {"ring", "ring_idx"}
+                if v is not None
             }
         if isinstance(x, list):
             return [_plain(v) for v in x]

--- a/src/common/tensors/autoautograd/fluxspring/fs_types.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_types.py
@@ -61,34 +61,6 @@ class NodeSpec:
     scripted_axes: List[int]   # exactly 2 axes (Dirichlet/scripted)
     temperature: AT = field(default_factory=lambda: AT.tensor(0.0))  # placeholder for thermal models
     exclusive: bool = False  # True if node occupies exclusive geometry
-    ring_size: Optional[int] = None
-    ring: Optional[AT] = None
-    ring_idx: int = 0
-
-    def __post_init__(self) -> None:
-        self.ensure_ring_buffer()
-
-    def ensure_ring_buffer(self) -> None:
-        """Allocate the ring buffer if a size is set."""
-        if self.ring_size and self.ring_size > 0 and self.ring is None:
-            D = int(AT.get_tensor(self.p0).shape[0])
-            self.ring = AT.zeros((self.ring_size, D), dtype=float)
-            self.ring_idx = 0
-
-    def push_ring(self, val: AT) -> AT:
-        """Insert ``val`` into the ring buffer and return the updated buffer.
-
-        Uses :func:`AT.scatter_row` so the operation participates in the
-        autograd tape instead of an in-place Python assignment.  The returned
-        tensor remains connected to the computation graph.
-        """
-        if self.ring is None:
-            raise RuntimeError("ring buffer not allocated")
-
-        i = self.ring_idx % int(len(self.ring))
-        self.ring = AT.scatter_row(self.ring.clone(), i, val, dim=0)
-        self.ring_idx = i + 1
-        return self.ring
 
 @dataclass
 class EdgeSpec:
@@ -98,33 +70,6 @@ class EdgeSpec:
     ctrl: EdgeCtrl
     temperature: AT = field(default_factory=lambda: AT.tensor(0.0))  # placeholder for thermal models
     exclusive: bool = False  # True if edge occupies exclusive geometry
-    ring_size: Optional[int] = None
-    ring: Optional[AT] = None
-    ring_idx: int = 0
-
-    def __post_init__(self) -> None:
-        self.ensure_ring_buffer()
-
-    def ensure_ring_buffer(self) -> None:
-        """Allocate the ring buffer if a size is set."""
-        if self.ring_size and self.ring_size > 0 and self.ring is None:
-            self.ring = AT.zeros(self.ring_size, dtype=float)
-            self.ring_idx = 0
-
-    def push_ring(self, val: AT) -> AT:
-        """Insert ``val`` into the ring buffer and return the updated buffer.
-
-        ``AT.scatter_row`` performs the update using differentiable tensor
-        operations so gradients flow back to ``val`` when the ring is involved
-        in later computations.
-        """
-        if self.ring is None:
-            raise RuntimeError("ring buffer not allocated")
-
-        i = self.ring_idx % int(len(self.ring))
-        self.ring = AT.scatter_row(self.ring.clone(), i, val, dim=0)
-        self.ring_idx = i + 1
-        return self.ring
 
 @dataclass
 class FaceLearn:
@@ -192,14 +137,3 @@ class FluxSpringSpec:
     rho: AT = field(default_factory=lambda: AT.tensor(0.0))
     beta: AT = field(default_factory=lambda: AT.tensor(0.0))
     gamma: AT = field(default_factory=lambda: AT.tensor(0.0))
-
-    def __post_init__(self) -> None:
-        default_size = self.spectral.win_len if self.spectral.enabled else None
-        for n in self.nodes:
-            if n.ring_size is None:
-                n.ring_size = default_size
-            n.ensure_ring_buffer()
-        for e in self.edges:
-            if e.ring_size is None:
-                e.ring_size = default_size
-            e.ensure_ring_buffer()

--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -2415,7 +2415,6 @@ def build_toy_system(
     batch_size: int = 4096,
     batch_refresh_hz: float = 20.0,
     spectral: bool = False,
-    ring_size: Optional[int] = None,
 ):
     """Build a toy spring–repulsor system where inputs are drawn from a large
     random batch tensor.
@@ -2462,7 +2461,6 @@ def build_toy_system(
                 scripted_axes=[0, 2],
                 temperature=AbstractTensor.tensor(0.0),
                 exclusive=False,
-                ring_size=ring_size,
             )
         )
     fs_edges: List[EdgeSpec] = []
@@ -2482,7 +2480,6 @@ def build_toy_system(
                 ctrl=ctrl,
                 temperature=AbstractTensor.tensor(0.0),
                 exclusive=False,
-                ring_size=ring_size,
             )
         )
 

--- a/tests/autoautograd/test_ring_buffer_gradients.py
+++ b/tests/autoautograd/test_ring_buffer_gradients.py
@@ -1,16 +1,22 @@
 import pytest
 from src.common.tensors.abstraction import AbstractTensor as AT
 from src.common.tensors.autograd import autograd
-from src.common.tensors.autoautograd.fluxspring.fs_types import NodeSpec, NodeCtrl
+from src.common.tensors.autoautograd.fluxspring.fs_types import (
+    NodeSpec,
+    NodeCtrl,
+    FluxSpringSpec,
+    DECSpec,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_harness import RingHarness
 
 
 def test_ring_buffer_propagates_gradients():
-    """Ring buffers on ``NodeSpec`` should participate in autograd.
+    """Ring buffers managed by the harness should participate in autograd.
 
-    Values pushed through :meth:`NodeSpec.push_ring` are stored via tensor
-    operations (`AT.scatter_row`) rather than Python list mutation. This keeps
-    the autograd graph intact, so losses computed from the ring should backprop
-    to the original parameter.
+    Values pushed through :class:`RingHarness` are stored via tensor operations
+    (`AT.scatter_row`) rather than Python list mutation. This keeps the autograd
+    graph intact, so losses computed from the ring should backprop to the
+    original parameter.
     """
 
     param = AT.tensor(1.0)
@@ -23,13 +29,23 @@ def test_ring_buffer_propagates_gradients():
         mass=AT.tensor(1.0),
         ctrl=NodeCtrl(),
         scripted_axes=[0],
-        ring_size=3,
     )
+    spec = FluxSpringSpec(
+        version="t",
+        D=1,
+        nodes=[node],
+        edges=[],
+        faces=[],
+        dec=DECSpec(D0=[], D1=[]),
+    )
+    harness = RingHarness(default_size=3)
 
     for i in range(6):
-        node.push_ring(param * AT.tensor(float(i + 1)))
+        harness.push_node(node.id, param * AT.tensor(float(i + 1)))
 
-    loss = node.ring.sum()
+    rb = harness.get_node_ring(node.id)
+    assert rb is not None
+    loss = rb.buf.sum()
     grad = autograd.grad(loss, [param])[0]
     assert grad is not None
     assert float(AT.get_tensor(grad)) != 0.0


### PR DESCRIPTION
## Summary
- Remove node/edge ring storage from FluxSpring spec types
- Introduce `RingHarness` managing lineage-keyed node/edge ring buffers
- Update pump tick and spectral readout to use harness-managed rings

## Testing
- `pytest tests/autoautograd/test_ring_buffer_gradients.py tests/autoautograd/test_spectral_readout.py tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_fluxspring_gradients.py tests/test_spectral_fluxspring_grad.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1d9df8ab4832aa8cc3192c9021e50