### PR TITLE
Add lineage ledger and lineage-aware spectral window gathering

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_harness.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_harness.py
@@ -10,6 +10,30 @@ from ...abstraction import AbstractTensor as AT
 
 
 @dataclass
+class LineageLedger:
+    """Ledger mapping tick numbers to lineage identifiers.
+
+    The ledger tracks which lineage was active at a given tick.  This allows
+    callers to later retrieve lineage‑aligned histories from the
+    :class:`RingHarness` rather than relying on the wall‑clock ordering of
+    pushes.  Lineage identifiers are kept abstract and are typically simple
+    integers.
+    """
+
+    tick_to_lineage: Dict[int, int] = field(default_factory=dict)
+
+    def record(self, tick: int, lineage_id: int) -> None:
+        """Associate ``tick`` with ``lineage_id``."""
+
+        self.tick_to_lineage[tick] = lineage_id
+
+    def lineages(self) -> Tuple[int, ...]:
+        """Return the unique lineage identifiers seen so far."""
+
+        return tuple(dict.fromkeys(self.tick_to_lineage.values()))
+
+
+@dataclass
 class RingBuffer:
     """Simple differentiable ring buffer."""
 


### PR DESCRIPTION
## Summary
- add `LineageLedger` to map ticks to lineage ids
- gather spectral windows per-lineage via harness and return lineage-indexed targets
- update demos and tests for lineage-indexed windows

## Testing
- `pytest tests/autoautograd/test_spectral_readout.py::test_gather_recent_windows_wrap_and_pad -q`
- `pytest tests/autoautograd/test_spectral_readout.py::test_batched_bandpower_from_windows -q`
- `pytest tests/autoautograd/test_ring_buffer_gradients.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc3cfe0c832aa46c8fc35b51b3d4