### PR TITLE
Avoid dtype casting on FluxSpring learnable tensors

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -40,19 +40,19 @@ def edge_vectors_AT(P: AT.Tensor, spec: FluxSpringSpec) -> AT.Tensor:
     return Pj - Pi
 
 def edge_params_AT(spec: FluxSpringSpec):
-    k = AT.get_tensor([
+    k = AT.stack([
         e.transport.k if e.transport.k is not None else AT.tensor(1.0)
         for e in spec.edges
-    ]).astype(float)  # (E,)
-    l0 = AT.get_tensor([
+    ]).reshape(-1)  # (E,)
+    l0 = AT.stack([
         e.transport.l0 if e.transport.l0 is not None else AT.tensor(1.0)
         for e in spec.edges
-    ]).astype(float)  # (E,)
+    ]).reshape(-1)  # (E,)
     return k, l0
 
 def face_params_AT(spec: FluxSpringSpec):
-    alpha = AT.get_tensor([fc.alpha for fc in spec.faces]).astype(float)  # (F,)
-    c     = AT.get_tensor([fc.c     for fc in spec.faces]).astype(float)  # (F,)
+    alpha = AT.stack([fc.alpha for fc in spec.faces]).reshape(-1)  # (F,)
+    c     = AT.stack([fc.c     for fc in spec.faces]).reshape(-1)  # (F,)
     return alpha, c
 
 def edge_strain_AT(P: AT.Tensor, spec: FluxSpringSpec, l0: AT.Tensor) -> AT.Tensor:
@@ -156,9 +156,7 @@ def transport_tick(
     dpsi = D0 @ psi  # (E,)
 
     kappa = (
-        AT.stack([e.transport.kappa for e in spec.edges])
-        .astype(float)
-        .reshape(-1)
+        AT.stack([e.transport.kappa for e in spec.edges]).reshape(-1)
     )  # (E,)
 
     if P is not None:
@@ -166,17 +164,13 @@ def transport_tick(
             AT.stack([
                 e.transport.k if e.transport.k is not None else AT.tensor(0.0)
                 for e in spec.edges
-            ])
-            .astype(float)
-            .reshape(-1)
+            ]).reshape(-1)
         )
         l0 = (
             AT.stack([
                 e.transport.l0 if e.transport.l0 is not None else AT.tensor(0.0)
                 for e in spec.edges
-            ])
-            .astype(float)
-            .reshape(-1)
+            ]).reshape(-1)
         )
         lambda_s = (
             AT.stack([
@@ -184,9 +178,7 @@ def transport_tick(
                 if e.transport.lambda_s is not None
                 else AT.tensor(0.0)
                 for e in spec.edges
-            ])
-            .astype(float)
-            .reshape(-1)
+            ]).reshape(-1)
         )
 
         g = edge_strain_AT(P, spec, l0)
@@ -198,12 +190,10 @@ def transport_tick(
         AT.stack([
             e.transport.x if e.transport.x is not None else AT.tensor(0.0)
             for e in spec.edges
-        ])
-        .astype(float)
-        .reshape(-1)
+        ]).reshape(-1)
     )
 
-    gamma = AT.get_tensor(spec.gamma).astype(float).reshape(-1)
+    gamma = AT.get_tensor(spec.gamma).reshape(-1)
 
     R = gamma * x
 

--- a/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
+++ b/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
@@ -220,7 +220,10 @@ def batched_bandpower_from_windows(window_matrix: AT, cfg: SpectralCfg) -> AT:
 
     freqs = AT.rfftfreq(Nw, d=1.0 / cfg.tick_hz, like=xw)
     mask_FB = AT.stack(
-        [(((freqs >= lo) & (freqs <= hi)).astype(float)) for lo, hi in cfg.metrics.bands]
+        [
+            AT.get_tensor((freqs >= lo) & (freqs <= hi), dtype=float)
+            for lo, hi in cfg.metrics.bands
+        ]
     ).transpose(0, 1)
 
     band_powers = AT.matmul(power, mask_FB)

--- a/src/common/tensors/autoautograd/spring_async_toy.py
+++ b/src/common/tensors/autoautograd/spring_async_toy.py
@@ -1461,7 +1461,7 @@ class LiveVizGLPoints:
             U_vals.append(U)
 
         AT = AbstractTensor
-        P = AT.stack(P_segs).astype(float)
+        P = AT.stack(P_segs)
         if P.shape[1] == 2:
             P = AT.pad(P, (0, 1, 0, 0), value=0.0)
         P = AT.nan_to_num(P, nan=0.0, posinf=0.0, neginf=0.0)

--- a/tests/autoautograd/test_fluxspring_params_grad.py
+++ b/tests/autoautograd/test_fluxspring_params_grad.py
@@ -1,0 +1,91 @@
+import pytest
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autograd import autograd
+from src.common.tensors.autoautograd.fluxspring.fs_types import (
+    FluxSpringSpec,
+    NodeSpec,
+    EdgeSpec,
+    FaceSpec,
+    DECSpec,
+    NodeCtrl,
+    EdgeCtrl,
+    EdgeTransport,
+    EdgeTransportLearn,
+    LearnCtrl,
+    FaceLearn,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_dec import (
+    edge_params_AT,
+    face_params_AT,
+)
+from src.common.tensors.autoautograd.fluxspring import register_learnable_params
+
+
+def _make_spec():
+    nodes = [
+        NodeSpec(
+            id=0,
+            p0=AT.get_tensor([0.0]),
+            v0=AT.get_tensor([0.0]),
+            mass=AT.tensor(1.0),
+            ctrl=NodeCtrl(learn=LearnCtrl(False, False, False)),
+            scripted_axes=[0],
+        ),
+        NodeSpec(
+            id=1,
+            p0=AT.get_tensor([0.0]),
+            v0=AT.get_tensor([0.0]),
+            mass=AT.tensor(1.0),
+            ctrl=NodeCtrl(learn=LearnCtrl(False, False, False)),
+            scripted_axes=[0],
+        ),
+    ]
+    edge = EdgeSpec(
+        src=0,
+        dst=1,
+        transport=EdgeTransport(
+            kappa=AT.tensor(1.0),
+            k=AT.tensor(1.0),
+            l0=AT.tensor(1.0),
+            learn=EdgeTransportLearn(kappa=False, k=True, l0=True, lambda_s=False, x=False),
+        ),
+        ctrl=EdgeCtrl(learn=LearnCtrl(False, False, False)),
+    )
+    face = FaceSpec(
+        edges=[1],
+        alpha=AT.tensor(0.5),
+        c=AT.tensor(1.0),
+        learn=FaceLearn(alpha=True, c=True),
+    )
+    dec = DECSpec(D0=[[-1.0, 1.0]], D1=[[0.0]])
+    spec = FluxSpringSpec(
+        version="test",
+        D=1,
+        nodes=nodes,
+        edges=[edge],
+        faces=[face],
+        dec=dec,
+        gamma=AT.tensor(0.0),
+    )
+    return spec
+
+
+def test_edge_face_params_gradients_and_dtype():
+    spec = _make_spec()
+    params = register_learnable_params(spec)
+    assert len(params) == 4
+
+    k, l0 = edge_params_AT(spec)
+    alpha, c = face_params_AT(spec)
+
+    # dtype preservation
+    assert k.dtype == spec.edges[0].transport.k.dtype
+    assert l0.dtype == spec.edges[0].transport.l0.dtype
+    assert alpha.dtype == spec.faces[0].alpha.dtype
+    assert c.dtype == spec.faces[0].c.dtype
+
+    loss = (k.sum() + l0.sum() + alpha.sum() + c.sum()) * AT.tensor(2.0)
+    grads = autograd.grad(loss, params)
+    assert all(g is not None for g in grads)
+    for g in grads:
+        assert float(AT.get_tensor(g)) == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- Preserve dtype and gradient flow in FluxSpring by removing `.astype(float)` from learnable tensors
- Allow dtype casting only for static DEC matrices `D0` and `D1`
- Add unit test confirming gradients propagate through `edge_params_AT` and `face_params_AT`

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py tests/autoautograd/test_fluxspring_transport_tick.py tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_fluxspring_params_grad.py tests/test_spectral_fluxspring_grad.py`
- `pytest tests/test_dirichlet_neumann_feedback.py tests/test_geometry_residual_no_impulse.py tests/autoautograd/test_spring_dt_thread.py tests/autoautograd/test_spring_dt_engine_backends.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1f9c325cc832a9fe9e3c3ca323c87