### PR TITLE
feat(fluxspring): track lineage IDs across ticks

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -237,6 +237,7 @@ def pump_tick(
     saturate: Callable[[AT.Tensor], AT.Tensor] | None = None,
     lorentz_c: float | None = None,
     harness: RingHarness | None = None,
+    lineage_id: int | None = None,
 ) -> Tuple[AT.Tensor, Dict[str, AT.Tensor]]:
     """Advance node potentials via data-path control parameters.
 
@@ -272,6 +273,10 @@ def pump_tick(
     harness : :class:`RingHarness`, optional
         When provided and ``spec.spectral.enabled`` is ``True``, ring buffers
         for nodes and edges are updated via this harness.
+    lineage_id : int, optional
+        Lineage identifier passed through to the harness so node and edge
+        histories can be keyed by input lineage.  ``None`` preserves the
+        previous behaviour where all pushes share the same buffers.
     """
 
     # Inject fresh external inputs before computing edge potentials. ``ids`` is
@@ -334,9 +339,10 @@ def pump_tick(
 
     # Maintain ring buffers for spectral analysis.
     if harness is not None and spec.spectral.enabled:
+        lin = (lineage_id,) if lineage_id is not None else None
         for n, val in zip(spec.nodes, psi_next):
-            harness.push_node(n.id, val)
+            harness.push_node(n.id, val, lineage=lin)
         for idx, q_val in enumerate(q):
-            harness.push_edge(idx, q_val)
+            harness.push_edge(idx, q_val, lineage=lin)
 
     return psi_next, stats


### PR DESCRIPTION
## Summary
- extend `LineageLedger` with bidirectional lineage↔tick mappings and `ingest`
- let `fs_dec.pump_tick` tag ring buffer writes with a lineage ID
- call `ledger.ingest` in demo routing and forward lineage to `pump_tick`

## Testing
- `pytest tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_fluxspring_gradients.py tests/autoautograd/test_fluxspring_transport_tick.py tests/autoautograd/test_fluxspring_params_grad.py tests/autoautograd/test_ring_buffer_gradients.py tests/autoautograd/test_spectral_readout.py tests/test_spectral_fluxspring_grad.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2012db19c832a9771747b4034533b