### PR TITLE
Add parameter version rings and lineage-aligned snapshots

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -342,11 +342,13 @@ def pump_tick(
     }
 
     # Maintain ring buffers for spectral analysis.
-    if harness is not None and spec.spectral.enabled:
-        lin = (lineage_id,) if lineage_id is not None else None
-        for n, val in zip(spec.nodes, psi_next):
-            harness.push_node(n.id, val, lineage=lin)
-        for idx, q_val in enumerate(q):
-            harness.push_edge(idx, q_val, lineage=lin)
+    if harness is not None:
+        if spec.spectral.enabled:
+            lin = (lineage_id,) if lineage_id is not None else None
+            for n, val in zip(spec.nodes, psi_next):
+                harness.push_node(n.id, val, lineage=lin)
+            for idx, q_val in enumerate(q):
+                harness.push_edge(idx, q_val, lineage=lin)
+        harness.snapshot_learnables(spec)
 
     return psi_next, stats

--- a/src/common/tensors/autoautograd/fluxspring/fs_harness.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_harness.py
@@ -4,9 +4,31 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from ...abstraction import AbstractTensor as AT
+from .fs_types import FluxSpringSpec
+
+
+def _tape():
+    """Return the global autograd tape."""
+    try:
+        return AT.autograd.tape
+    except Exception:
+        from ...autograd import autograd as _ag
+        return _ag.tape
+
+
+_LABEL_STAGE_DEPTH: Dict[str, int] = {}
+
+
+def label_stage_depth(label: str) -> int:
+    """Return the pipeline stage depth for ``label``."""
+
+    for prefix, depth in _LABEL_STAGE_DEPTH.items():
+        if label.startswith(prefix):
+            return depth
+    return 0
 
 
 @dataclass
@@ -78,12 +100,37 @@ class RingBuffer:
 
 
 @dataclass
+class ParamRing:
+    """Ring buffer storing parameter snapshots and their ticks."""
+
+    buf: AT
+    ticks: List[int]
+    idx: int = 0
+
+    def push(self, tick: int, val: AT) -> AT:
+        i = self.idx % int(len(self.buf))
+        self.buf = AT.scatter_row(self.buf.clone(), i, val, dim=0)
+        self.ticks[i] = tick
+        self.idx = i + 1
+        return self.buf
+
+    def value_at(self, tick: int) -> AT:
+        for i, t in enumerate(self.ticks):
+            if t == tick:
+                return self.buf[i]
+        raise KeyError(f"tick {tick} not found")
+
+
+@dataclass
 class RingHarness:
     """Own per-node and per-edge ring buffers keyed by lineage."""
 
     default_size: Optional[int] = None
     node_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
     edge_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
+    param_rings: Dict[str, ParamRing] = field(default_factory=dict)
+    param_labels: List[str] = field(default_factory=list)
+    tick: int = 0
 
     def _key(self, obj_id: int, lineage: Tuple[int, ...] | None) -> Tuple[int, ...]:
         return (obj_id,) if lineage is None else (obj_id, *lineage)
@@ -109,6 +156,18 @@ class RingHarness:
             buf = AT.zeros(size, dtype=float)
             self.edge_rings[key] = RingBuffer(buf)
         return self.edge_rings[key]
+
+    def _ensure_param_ring(
+        self, label: str, D: int, size: Optional[int]
+    ) -> Optional[ParamRing]:
+        size = size or self.default_size
+        if size is None:
+            return None
+        if label not in self.param_rings:
+            buf = AT.zeros((size, D), dtype=float)
+            ticks = [0] * size
+            self.param_rings[label] = ParamRing(buf, ticks)
+        return self.param_rings[label]
 
     def push_node(
         self,
@@ -149,4 +208,95 @@ class RingHarness:
         self, edge_idx: int, *, lineage: Tuple[int, ...] | None = None
     ) -> Optional[RingBuffer]:
         return self.edge_rings.get(self._key(edge_idx, lineage))
+
+    # ------------------------------------------------------------------
+    # Parameter versioning
+    # ------------------------------------------------------------------
+    def snapshot_learnables(
+        self, spec: FluxSpringSpec, *, size: Optional[int] = None
+    ) -> None:
+        """Record current learnable parameters with tick index."""
+
+        tape = _tape()
+
+        def _maybe(label: str | None, p: AT | None) -> Iterable[Tuple[str, AT]]:
+            if p is None or not getattr(p, "requires_grad", False):
+                return []
+            if label is None:
+                label = tape.graph.nodes.get(id(p), {}).get("annotations", {}).get("label")
+            if label is None:
+                return []
+            return [(label, p)]
+
+        # Nodes
+        for n in spec.nodes:
+            for attr in ("alpha", "w", "b"):
+                p = getattr(n.ctrl, attr)
+                lbl = tape.graph.nodes.get(id(p), {}).get("annotations", {}).get("label") if p is not None else None
+                for label, param in _maybe(lbl, p):
+                    val = AT.get_tensor(param).reshape(-1)
+                    D = int(val.shape[0])
+                    ring = self._ensure_param_ring(label, D, size)
+                    if ring is not None:
+                        ring.push(self.tick, val)
+                        if label not in self.param_labels:
+                            self.param_labels.append(label)
+
+        # Edges
+        for e in spec.edges:
+            for attr in ("alpha", "w", "b"):
+                p = getattr(e.ctrl, attr)
+                lbl = tape.graph.nodes.get(id(p), {}).get("annotations", {}).get("label") if p is not None else None
+                for label, param in _maybe(lbl, p):
+                    val = AT.get_tensor(param).reshape(-1)
+                    D = int(val.shape[0])
+                    ring = self._ensure_param_ring(label, D, size)
+                    if ring is not None:
+                        ring.push(self.tick, val)
+                        if label not in self.param_labels:
+                            self.param_labels.append(label)
+            for attr in ("kappa", "k", "l0", "lambda_s", "x"):
+                p = getattr(e.transport, attr)
+                lbl = tape.graph.nodes.get(id(p), {}).get("annotations", {}).get("label") if p is not None else None
+                for label, param in _maybe(lbl, p):
+                    val = AT.get_tensor(param).reshape(-1)
+                    D = int(val.shape[0])
+                    ring = self._ensure_param_ring(label, D, size)
+                    if ring is not None:
+                        ring.push(self.tick, val)
+                        if label not in self.param_labels:
+                            self.param_labels.append(label)
+
+        # Faces
+        for f in spec.faces:
+            for attr in ("alpha", "c"):
+                p = getattr(f, attr, None)
+                lbl = tape.graph.nodes.get(id(p), {}).get("annotations", {}).get("label") if p is not None else None
+                for label, param in _maybe(lbl, p):
+                    val = AT.get_tensor(param).reshape(-1)
+                    D = int(val.shape[0])
+                    ring = self._ensure_param_ring(label, D, size)
+                    if ring is not None:
+                        ring.push(self.tick, val)
+                        if label not in self.param_labels:
+                            self.param_labels.append(label)
+
+        self.tick += 1
+
+    def get_params_for_lineages(
+        self, lineage_ids: Iterable[int], ledger: LineageLedger
+    ) -> AT:
+        """Return concatenated parameter snapshots for ``lineage_ids``."""
+
+        rows = []
+        for lid in lineage_ids:
+            base_tick = ledger.tick_of_lid[lid]
+            parts = []
+            for label in self.param_labels:
+                ring = self.param_rings[label]
+                t = base_tick + label_stage_depth(label)
+                val = ring.value_at(t)
+                parts.append(val)
+            rows.append(AT.concat(parts, dim=0))
+        return AT.stack(rows)
 

--- a/tests/autoautograd/test_param_version_rings.py
+++ b/tests/autoautograd/test_param_version_rings.py
@@ -1,0 +1,62 @@
+import pytest
+
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring import (
+    FluxSpringSpec,
+    NodeSpec,
+    NodeCtrl,
+    LearnCtrl,
+    EdgeSpec,
+    EdgeCtrl,
+    EdgeTransport,
+    EdgeTransportLearn,
+    DECSpec,
+    register_learnable_params,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_harness import (
+    LineageLedger,
+    RingHarness,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_dec import pump_tick
+
+
+def test_param_version_ring_snapshots():
+    param = AT.tensor(1.0)
+    param.requires_grad_(True)
+
+    node = NodeSpec(
+        id=0,
+        p0=AT.get_tensor([0.0]),
+        v0=AT.get_tensor([0.0]),
+        mass=AT.tensor(1.0),
+        ctrl=NodeCtrl(w=param, learn=LearnCtrl(alpha=False, w=True, b=False)),
+        scripted_axes=[0],
+    )
+    edge = EdgeSpec(
+        src=0,
+        dst=0,
+        transport=EdgeTransport(learn=EdgeTransportLearn(False, False, False, False, False)),
+        ctrl=EdgeCtrl(learn=LearnCtrl(False, False, False)),
+    )
+    spec = FluxSpringSpec(
+        version="t",
+        D=1,
+        nodes=[node],
+        edges=[edge],
+        faces=[],
+        dec=DECSpec(D0=[[0.0]], D1=[]),
+    )
+    register_learnable_params(spec)
+
+    harness = RingHarness(default_size=5)
+    ledger = LineageLedger()
+    psi = AT.tensor([0.0])
+    lids = []
+    for _ in range(3):
+        lid = ledger.ingest()
+        lids.append(lid)
+        psi, _ = pump_tick(psi, spec, eta=0.0, harness=harness, lineage_id=lid)
+
+    mat = harness.get_params_for_lineages(lids, ledger)
+    assert mat.shape == (3, 1)
+    assert float(AT.get_tensor(mat[0, 0])) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- track learnable parameters in versioned rings keyed by stable labels
- look up lineage-aligned parameter snapshots via `get_params_for_lineages`
- snapshot learnables after each `pump_tick` and cover with tests

## Testing
- `pytest tests/autoautograd/test_param_version_rings.py -q`
- `pytest tests/autoautograd -q`


------
https://chatgpt.com/codex/tasks/task_e_68c205b8d714832ab637bfb184ae43d4