### PR TITLE
Flatten target_out in spectral routing demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -423,7 +423,7 @@ def train_routing(
         for k in range(win):
             for i in range(B):
                 psi[i] = frame_chunks[i][k]
-            target_out = AT.stack([sine_chunks[i][k] for i in range(B)])
+            target_out = AT.stack([sine_chunks[i][k] for i in range(B)]).flatten()
             psi = pump_with_loss(psi, target_out)
 
         win_map, kept_map = gather_recent_windows(


### PR DESCRIPTION
## Summary
- ensure `target_out` is built as a 1-D tensor by flattening the stack in `train_routing`

## Testing
- `pytest tests/autoautograd/test_spectral_readout.py::test_gather_recent_windows_wrap_and_pad -q`


------
https://chatgpt.com/codex/tasks/task_e_68c222e38740832aadd3d3b7e3e9d71d