### PR TITLE
Track Φ activation history for spectral binning

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -312,7 +312,8 @@ def pump_tick(
     w_n     = AT.stack([n.ctrl.w     for n in spec.nodes]).reshape(-1)
     b_n     = AT.stack([n.ctrl.b     for n in spec.nodes]).reshape(-1)
     node_raw = s + b_n
-    node_u   = (1.0 - alpha_n) * node_raw + alpha_n * phi(node_raw)
+    node_phi = phi(node_raw)
+    node_u   = (1.0 - alpha_n) * node_raw + alpha_n * node_phi
     delta    = w_n * node_u
 
     denom = None
@@ -345,8 +346,9 @@ def pump_tick(
     if harness is not None:
         if spec.spectral.enabled:
             lin = (lineage_id,) if lineage_id is not None else None
-            for n, val in zip(spec.nodes, psi_next):
+            for n, val, ph in zip(spec.nodes, psi_next, node_phi):
                 harness.push_node(n.id, val, lineage=lin)
+                harness.push_phi(n.id, ph, lineage=lin)
             for idx, q_val in enumerate(q):
                 harness.push_edge(idx, q_val, lineage=lin)
         harness.snapshot_learnables(spec)

--- a/tests/autoautograd/test_phi_ring_histogram_loss.py
+++ b/tests/autoautograd/test_phi_ring_histogram_loss.py
@@ -1,0 +1,54 @@
+from src.common.tensors.autoautograd.fluxspring.fs_types import (
+    FluxSpringSpec,
+    NodeSpec,
+    NodeCtrl,
+    LearnCtrl,
+    EdgeSpec,
+    EdgeCtrl,
+    EdgeTransport,
+    EdgeTransportLearn,
+    DECSpec,
+    SpectralCfg,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_dec import pump_tick
+from src.common.tensors.autoautograd.fluxspring.fs_harness import RingHarness
+from src.common.tensors.autoautograd.fluxspring.spectral_readout import phi_histogram_loss
+from src.common.tensors.abstraction import AbstractTensor as AT
+
+
+def _build_spec():
+    ctrl = NodeCtrl(alpha=AT.tensor(1.0), w=AT.tensor(1.0), b=AT.tensor(0.0), learn=LearnCtrl(True, True, True))
+    n0 = NodeSpec(id=0, p0=AT.zeros(3), v0=AT.zeros(3), mass=AT.tensor(1.0), ctrl=ctrl, scripted_axes=[0, 2])
+    n1 = NodeSpec(id=1, p0=AT.zeros(3), v0=AT.zeros(3), mass=AT.tensor(1.0), ctrl=ctrl, scripted_axes=[0, 2])
+    ectrl = EdgeCtrl(alpha=AT.tensor(1.0), w=AT.tensor(1.0), b=AT.tensor(0.0), learn=LearnCtrl(True, True, True))
+    transport = EdgeTransport(kappa=AT.tensor(1.0), learn=EdgeTransportLearn())
+    edge = EdgeSpec(src=0, dst=1, transport=transport, ctrl=ectrl, temperature=AT.tensor(0.0), exclusive=False)
+    dec = DECSpec(D0=[[-1.0, 1.0]], D1=[])
+    spectral = SpectralCfg(enabled=True, win_len=32, hop_len=32, window="hann")
+    return FluxSpringSpec(
+        version="phi-test",
+        D=3,
+        nodes=[n0, n1],
+        edges=[edge],
+        faces=[],
+        dec=dec,
+        spectral=spectral,
+    )
+
+
+def test_phi_ring_updates_and_hist_loss():
+    spec = _build_spec()
+    psi = AT.zeros(len(spec.nodes), dtype=float)
+    harness = RingHarness(default_size=32)
+    tick_hz = 64.0
+    t = AT.arange(32, dtype=float) / tick_hz
+    signal = (2 * AT.pi() * 8.0 * t).sin()
+    for val in signal:
+        psi, _ = pump_tick(psi, spec, eta=0.0, external={0: val}, harness=harness)
+    rb = harness.get_phi_ring(1)
+    assert rb is not None
+    loss_lo = phi_histogram_loss(rb, band_idx=0, total_bands=2, tick_hz=tick_hz)
+    loss_hi = phi_histogram_loss(rb, band_idx=1, total_bands=2, tick_hz=tick_hz)
+    loss_lo_f = float(AT.get_tensor(loss_lo).item())
+    loss_hi_f = float(AT.get_tensor(loss_hi).item())
+    assert loss_lo_f < loss_hi_f


### PR DESCRIPTION
## Summary
- add PhiRing buffers per node to retain recent Φ activations
- push Φ values each tick and expose phi_histogram_loss for spectral binning
- validate via new test covering ring updates and histogram band loss

## Testing
- `pytest tests/autoautograd/test_phi_ring_histogram_loss.py tests/autoautograd/test_spectral_readout.py tests/autoautograd/test_fluxspring_transport_tick.py tests/test_spectral_fluxspring_grad.py`

------
https://chatgpt.com/codex/tasks/task_e_68c35c852b0c832aab7bc39369397260