### PR TITLE
Implement slot-based residual and gradient processing queue

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -122,7 +122,8 @@ class ParamWheel:
             return
         new_p = update_fn(p, g)
         p.data = AT.get_tensor(new_p)
-        p.grad = None
+        if hasattr(p, "_grad"):
+            p._grad = None
 
 
 def register_param_wheels(spec: FluxSpringSpec, *, slots: int = 2) -> list[ParamWheel]:

--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Sequence
+
+from ..abstraction import AbstractTensor as AT
+from .whiteboard_runtime import run_batched_vjp, BatchVJPResult
+from .fluxspring import ParamWheel
+
+
+@dataclass
+class SlotBackpropQueue:
+    """Track residuals and VJP jobs per parameter slot.
+
+    Parameters
+    ----------
+    wheels:
+        Sequence of :class:`ParamWheel` objects whose slots will be updated
+        when gradients are applied.
+    """
+
+    wheels: Sequence[ParamWheel]
+    main_residuals: Dict[int, AT | None] = field(init=False)
+    spectral_residuals: Dict[int, AT | None] = field(init=False)
+    jobs: Dict[int, List[Any]] = field(init=False)
+
+    def __post_init__(self) -> None:
+        slots = len(self.wheels[0].params) if self.wheels else 0
+        self.main_residuals = {i: None for i in range(slots)}
+        self.spectral_residuals = {i: None for i in range(slots)}
+        self.jobs = {i: [] for i in range(slots)}
+
+    # ------------------------------------------------------------------
+    def add_residual(self, slot: int, *, main: AT | None = None, spectral: AT | None = None) -> None:
+        """Accumulate residuals for ``slot``.
+
+        Residuals are summed if multiple contributions arrive before the slot is
+        processed.
+        """
+
+        if main is not None:
+            t = AT.get_tensor(main)
+            prev = self.main_residuals.get(slot)
+            self.main_residuals[slot] = t if prev is None else prev + t
+        if spectral is not None:
+            t = AT.get_tensor(spectral)
+            prev = self.spectral_residuals.get(slot)
+            self.spectral_residuals[slot] = t if prev is None else prev + t
+
+    # ------------------------------------------------------------------
+    def queue_job(self, slot: int, job: Any) -> None:
+        """Queue a JVP/VJP job for ``slot``."""
+
+        self.jobs.setdefault(slot, []).append(job)
+
+    # ------------------------------------------------------------------
+    def process_slot(
+        self,
+        slot: int,
+        *,
+        sys: Any,
+        lr: float = 0.01,
+        run_vjp=run_batched_vjp,
+    ) -> BatchVJPResult | None:
+        """Drain and process jobs for ``slot`` applying gradients.
+
+        Parameters
+        ----------
+        slot:
+            Slot index being evicted this tick.
+        sys:
+            System passed through to :func:`run_batched_vjp`.
+        lr:
+            Learning rate used when applying gradients to parameters.
+        run_vjp:
+            Callable compatible with :func:`run_batched_vjp` used to compute
+            gradients.  Primarily for dependency injection in tests.
+        """
+
+        jobs = self.jobs.get(slot, [])
+        if not jobs:
+            self.main_residuals[slot] = None
+            self.spectral_residuals[slot] = None
+            return None
+
+        batch = run_vjp(sys=sys, jobs=jobs)
+        g_tensor = batch.grads_per_source_tensor
+        if g_tensor is not None:
+            g_tensor = AT.get_tensor(g_tensor)
+            for idx, w in enumerate(self.wheels):
+                grad = g_tensor[idx]
+                p = w.params[slot]
+                # Store gradient on the internal attribute expected by the
+                # autograd helpers.  ``grad`` is a read-only property, so we set
+                # ``_grad`` directly.
+                p._grad = AT.get_tensor(grad)  # type: ignore[attr-defined]
+                w.apply_slot(slot, lambda p_, g_=p._grad: p_ - lr * g_)
+        self.jobs[slot] = []
+        self.main_residuals[slot] = None
+        self.spectral_residuals[slot] = None
+        return batch

--- a/tests/autoautograd/test_slot_backprop_queue.py
+++ b/tests/autoautograd/test_slot_backprop_queue.py
@@ -1,0 +1,62 @@
+import types
+
+import pytest
+
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring import ParamWheel
+from src.common.tensors.autoautograd.slot_backprop import SlotBackpropQueue
+from src.common.tensors.autoautograd.whiteboard_runtime import BatchSlices, BatchVJPResult
+
+
+def test_slot_backprop_queue_applies_gradients_per_slot():
+    # Two parameters each with two slots
+    p0 = AT.tensor(1.0)
+    p0.requires_grad_(True)
+    p1 = AT.tensor(2.0)
+    p1.requires_grad_(True)
+
+    w0 = ParamWheel(p0, lambda t: None, slots=2)
+    w1 = ParamWheel(p1, lambda t: None, slots=2)
+    for w in (w0, w1):
+        w.rotate(); w.bind_slot()  # activate slot 0
+
+    mgr = SlotBackpropQueue([w0, w1])
+    # Seed residual buffers for slot 0
+    mgr.add_residual(0, main=AT.tensor(0.5))
+    mgr.add_residual(0, spectral=AT.tensor(0.2))
+
+    # Queue simple jobs for slot 0
+    jobs = [types.SimpleNamespace(job_id=f"p{i}", op="__neg__", src_ids=(i,), residual=1.0) for i in range(2)]
+    for j in jobs:
+        mgr.queue_job(0, j)
+
+    # Stub run_batched_vjp to return deterministic gradients
+    def _stub_vjp(*, sys, jobs, **_kw):
+        g = AT.tensor([2.0, 3.0])
+        return BatchVJPResult(
+            slices=BatchSlices(index_of={j.job_id: i for i, j in enumerate(jobs)}, job_ids=tuple(j.job_id for j in jobs)),
+            ys=tuple(AT.tensor(0.0) for _ in jobs),
+            grads_full=tuple(AT.tensor(0.0) for _ in jobs),
+            grads_per_source=tuple(() for _ in jobs),
+            grads_per_source_tensor=g,
+            param_grads_full=tuple(),
+            param_grads_tensor=None,
+        )
+
+    # Rotate wheels to slot 1, evicting slot 0
+    ev0 = w0.rotate(); w0.bind_slot()
+    ev1 = w1.rotate(); w1.bind_slot()
+    assert ev0 == ev1 == 0
+
+    mgr.process_slot(ev0, sys=None, lr=1.0, run_vjp=_stub_vjp)
+
+    # Slot 0 parameters should have been updated; slot 1 untouched
+    assert float(AT.get_tensor(w0.params[0])) == pytest.approx(-1.0)
+    assert float(AT.get_tensor(w1.params[0])) == pytest.approx(-1.0)
+    assert float(AT.get_tensor(w0.params[1])) == pytest.approx(1.0)
+    assert float(AT.get_tensor(w1.params[1])) == pytest.approx(2.0)
+
+    # Residual buffers and job queue for slot 0 should be cleared
+    assert mgr.main_residuals[0] is None
+    assert mgr.spectral_residuals[0] is None
+    assert mgr.jobs[0] == []


### PR DESCRIPTION
## Summary
- Add `SlotBackpropQueue` to maintain per-slot residual buffers and VJP job queues
- Apply gradients only to the evicted slot by patching `ParamWheel.apply_slot`
- Provide unit test verifying slot-specific gradient application and buffer clearing

## Testing
- `pytest tests/autoautograd/test_slot_backprop_queue.py::test_slot_backprop_queue_applies_gradients_per_slot -q`
- `pytest tests/autoautograd/test_param_version_rings.py::test_param_version_ring_snapshots -q`
- `pytest tests/test_whiteboard_runtime_none_grads.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c35f16ac8c832a81b338822f668e94