### PR TITLE
Refactor spectral routing training orchestration

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -42,6 +42,7 @@ from types import SimpleNamespace
 import logging
 import numpy as np
 from typing import Callable, Optional
+from dataclasses import dataclass
 
 
 # Module logger setup (configured in main if not already configured)
@@ -254,8 +255,337 @@ def generate_signals(
     for _ in range(frames):
         noise = AT.tensor(rng.standard_normal((len(bands), win)))
         mix = sinusoid_sum + 0.1 * noise
-        noise_frames.append([mix[i] for i in range(len(bands))])
+    noise_frames.append([mix[i] for i in range(len(bands))])
     return sine_chunks, noise_frames
+
+
+@dataclass
+class RoutingState:
+    spec: FluxSpringSpec
+    harness: RingHarness
+    ledger: LineageLedger
+    params: list[AT.Tensor]
+    log_buf: TensorRingBuffer
+    mix_buf: dict[int, AT.Tensor]
+    hist_buf: dict[int, AT.Tensor]
+    previous_grads: list[AT.Tensor] | None = None
+    patience: int = 10
+
+
+def initialize_signal_state(
+    spec: FluxSpringSpec, spectral_cfg: SpectralCfg
+) -> tuple[AT.Tensor, dict[int, AT.Tensor], int, int]:
+    """Prepare the initial node state and histogram targets."""
+    B = len(spectral_cfg.metrics.bands)
+    psi = AT.zeros(len(spec.nodes), dtype=float)
+    hist_targets: dict[int, AT.Tensor] = {}
+    band_start = len(spec.nodes) - B
+    for j, nid in enumerate(range(band_start, band_start + B)):
+        tvec = AT.zeros(B, dtype=float)
+        tvec[j] = 1.0
+        hist_targets[nid] = tvec
+        logger.debug("hist_target for node %d set as one-hot idx=%d", nid, j)
+    return psi, hist_targets, band_start, B
+
+
+def log_param_gradients(params: list[AT.Tensor]) -> None:
+    """Report gradient status for learnable parameters."""
+    for idx, p in enumerate(params):
+        grad = getattr(p, "grad", None)
+        if grad is None:
+            logger.debug("[Gradients] param %d missing gradient", idx)
+        else:
+            g = AT.get_tensor(grad)
+            if np.allclose(g, 0.0):
+                logger.debug("[Gradients] param %d gradient is zero: %s", idx, g)
+            else:
+                logger.debug("[Gradients] param %d grad: %s", idx, g)
+
+
+def purge_lineage_backlog(ctx: RoutingState, max_pending: int) -> None:
+    """Drop the oldest lineages when backlog exceeds ``max_pending``."""
+    active = ctx.ledger.lineages()
+    if len(active) <= max_pending:
+        return
+    stale = active[:-max_pending]
+    logger.warning(
+        "purge_lineage_backlog: dropping %d stale lineages (keeping %d)",
+        len(stale),
+        max_pending,
+    )
+    for lid in stale:
+        line = (lid,)
+        for key_id in (
+            OUT_FEAT_ID,
+            OUT_TARG_ID,
+            OUT_IDS_ID,
+            HIST_FEAT_ID,
+            HIST_TARG_ID,
+            HIST_IDS_ID,
+        ):
+            ctx.harness.node_rings.pop(ctx.harness._key(key_id, line), None)
+        for n in ctx.spec.nodes:
+            ctx.harness.node_rings.pop(ctx.harness._key(n.id, line), None)
+        for idx in range(len(ctx.spec.edges)):
+            ctx.harness.edge_rings.pop(ctx.harness._key(idx, line), None)
+    ctx.ledger.purge_through_lid(stale[-1])
+
+
+def try_backward(ctx: RoutingState, lin: int) -> None:
+    """Execute the backward pass for a completed lineage."""
+    line = (lin,)
+    rb_out_feat = ctx.harness.get_node_ring(OUT_FEAT_ID, lineage=line)
+    rb_out_targ = ctx.harness.get_node_ring(OUT_TARG_ID, lineage=line)
+    rb_out_ids = ctx.harness.get_node_ring(OUT_IDS_ID, lineage=line)
+    rb_hist_feat = ctx.harness.get_node_ring(HIST_FEAT_ID, lineage=line)
+    rb_hist_targ = ctx.harness.get_node_ring(HIST_TARG_ID, lineage=line)
+    rb_hist_ids = ctx.harness.get_node_ring(HIST_IDS_ID, lineage=line)
+    if None in (
+        rb_out_feat,
+        rb_out_targ,
+        rb_out_ids,
+        rb_hist_feat,
+        rb_hist_targ,
+        rb_hist_ids,
+    ):
+        logger.debug(
+            "try_backward(lin=%d): missing rings — skipping (out_feat=%s out_targ=%s out_ids=%s hist_feat=%s hist_targ=%s hist_ids=%s)",
+            lin,
+            rb_out_feat is not None,
+            rb_out_targ is not None,
+            rb_out_ids is not None,
+            rb_hist_feat is not None,
+            rb_hist_targ is not None,
+            rb_hist_ids is not None,
+        )
+        return
+    out_feat = rb_out_feat.buf[0]
+    out_targ = rb_out_targ.buf[0]
+    hist_ids = rb_hist_ids.buf[0]
+    B = int(out_feat.shape[0])
+    M = int(hist_ids.shape[0])
+    if (
+        int(rb_hist_feat.buf.shape[1]) != M * B
+        or int(rb_hist_targ.buf.shape[1]) != M * B
+    ):
+        logger.debug(
+            "try_backward(lin=%d): histogram shape mismatch M=%d B=%d (feat=%s targ=%s) — skipping",
+            lin,
+            M,
+            B,
+            tuple(rb_hist_feat.buf.shape) if rb_hist_feat is not None else None,
+            tuple(rb_hist_targ.buf.shape) if rb_hist_targ is not None else None,
+        )
+        return
+    hist_feat = rb_hist_feat.buf[0].reshape(M, B)
+    hist_targ = rb_hist_targ.buf[0].reshape(M, B)
+    mix_residual = out_feat - out_targ
+    hist_residual = hist_feat - hist_targ
+    hist_residual_summary = hist_residual.mean(0)
+    hist_loss = (hist_residual ** 2).mean()
+    loss_out = (mix_residual ** 2).mean()
+    losses = {"loss_out": loss_out, "hist_loss": hist_loss}
+    probe_losses(losses, ctx.params)
+    logger.debug(
+        "try_backward(lin=%d): loss_out=%.6f hist_loss=%.6f",
+        lin,
+        float(loss_out.item()),
+        float(hist_loss.item()),
+    )
+    if lin in ctx.mix_buf or lin in ctx.hist_buf:
+        logger.debug("try_backward(lin=%d): replacing stale residuals", lin)
+        ctx.mix_buf.pop(lin, None)
+        ctx.hist_buf.pop(lin, None)
+    ctx.mix_buf[lin] = mix_residual
+    ctx.hist_buf[lin] = hist_residual_summary
+    mix_seed = ctx.mix_buf.pop(lin)
+    hist_seed = ctx.hist_buf.pop(lin)
+    seed_val = float((mix_seed.mean() + hist_seed.mean()).item())
+    logger.debug(
+        "try_backward(lin=%d): batching VJP with seed_val=%.6f params=%d",
+        lin,
+        seed_val,
+        len(ctx.params),
+    )
+    sys = SimpleNamespace(
+        nodes={i: SimpleNamespace(sphere=p) for i, p in enumerate(ctx.params)}
+    )
+    jobs = [
+        SimpleNamespace(job_id=f"p{i}", op="__neg__", src_ids=(i,), residual=seed_val)
+        for i in range(len(ctx.params))
+    ]
+    batch = run_batched_vjp(sys=sys, jobs=jobs)
+    grads: list[AT.Tensor] = []
+    if batch.grads_per_source_tensor is not None:
+        g_tensor = AT.get_tensor(batch.grads_per_source_tensor)
+        for idx, p in enumerate(ctx.params):
+            grad = -g_tensor[idx]
+            grads.append(grad)
+            new_p = p - 0.01 * grad
+            ctx.params[idx] = rebind(f"param[{idx}]", new_p)
+    logger.debug(
+        "try_backward(lin=%d): computed grads for %d params",
+        lin,
+        len(grads),
+    )
+    if ctx.previous_grads is not None:
+        changed = False
+        for idx, (g, pg) in enumerate(zip(grads, ctx.previous_grads)):
+            if g is None and pg is not None:
+                changed = True
+                logger.debug("[Gradients] param %d lost gradient", idx)
+            elif g is not None and pg is None:
+                changed = True
+                logger.debug("[Gradients] param %d gained gradient", idx)
+            if g != pg:
+                changed = True
+                logger.debug("[Gradients] param %d gradient changed", idx)
+        if changed:
+            logger.debug("[Gradients] previous: %s", ctx.previous_grads)
+            logger.debug("[Gradients] current:  %s", grads)
+        else:
+            ctx.patience -= 1
+            if ctx.patience <= 0:
+                logger.debug("[Gradients] no changes in gradients, stopping early")
+                exit(0)
+    else:
+        logger.debug("[Gradients] initial gradients: %s", grads)
+    ctx.previous_grads = grads
+    logger.debug(
+        "loss: %.6f, hist_loss: %.6f",
+        float(loss_out.item()),
+        float(hist_loss.item()),
+    )
+    tick_idx = ctx.ledger.tick_of_lid[lin]
+    log_entry = {
+        "tick": AT.tensor([float(tick_idx)]),
+        "out_feat": out_feat.clone(),
+        "out_targ": out_targ.clone(),
+        "mix_residual": mix_seed.clone(),
+        "hist_residual": hist_seed.clone(),
+        "param_grad": AT.stack(grads) if grads else AT.zeros(len(ctx.params)),
+    }
+    ctx.log_buf.append(log_entry)
+    logger.debug(
+        "try_backward(lin=%d): logged tick=%d keys=%s",
+        lin,
+        int(float(tick_idx)),
+        list(log_entry.keys()),
+    )
+    for key_id in (
+        OUT_FEAT_ID,
+        OUT_TARG_ID,
+        OUT_IDS_ID,
+        HIST_FEAT_ID,
+        HIST_TARG_ID,
+        HIST_IDS_ID,
+    ):
+        k = ctx.harness._key(key_id, line)
+        ctx.harness.node_rings.pop(k, None)
+    logger.debug("try_backward(lin=%d): cleared transient node rings", lin)
+    for n in ctx.spec.nodes:
+        k = ctx.harness._key(n.id, line)
+        ctx.harness.node_rings.pop(k, None)
+    for idx in range(len(ctx.spec.edges)):
+        k = ctx.harness._key(idx, line)
+        ctx.harness.edge_rings.pop(k, None)
+    ctx.ledger.purge_through_lid(lin)
+    logger.debug("try_backward(lin=%d): purged lineage from ledger", lin)
+
+
+def pump_with_loss(
+    ctx: RoutingState,
+    state: AT.Tensor,
+    target_out: AT.Tensor,
+    spectral_cfg: SpectralCfg,
+    hist_targets: dict[int, AT.Tensor],
+    band_start: int,
+    out_start: int,
+    B: int,
+) -> tuple[AT.Tensor, list[int]]:
+    """Advance the system by one tick and stage data for gradients."""
+    lid = ctx.ledger.ingest()
+    logger.debug("pump_with_loss: ingest lid=%d", lid)
+    state, _ = fs_dec.pump_tick(
+        state,
+        ctx.spec,
+        eta=0.1,
+        phi=AT.tanh,
+        norm="all",
+        harness=ctx.harness,
+        lineage_id=lid,
+    )
+    logger.debug(
+        "pump_with_loss: post pump lid=%d state_len=%d",
+        lid,
+        int(state.shape[0]),
+    )
+    out_feat = state[out_start : out_start + B].clone()
+    ctx.harness.push_node(OUT_FEAT_ID, out_feat, lineage=(lid,), size=1)
+    ctx.harness.push_node(OUT_TARG_ID, target_out.clone(), lineage=(lid,), size=1)
+    out_ids = AT.arange(out_start, out_start + B, dtype=float)
+    ctx.harness.push_node(OUT_IDS_ID, out_ids, lineage=(lid,), size=1)
+    logger.debug(
+        "pump_with_loss: pushed OUT_* rings lid=%d out_ids=[%d..%d)",
+        lid,
+        out_start,
+        out_start + B,
+    )
+    pending = [lid]
+
+    mids = list(range(band_start, band_start + B))
+    win_map, kept_map = gather_recent_windows(
+        ctx.spec, mids, spectral_cfg, ctx.harness, ctx.ledger
+    )
+    logger.debug(
+        "pump_with_loss: gather_recent_windows mids=%d returned lineages=%d",
+        len(mids),
+        len(win_map),
+    )
+    for lin, W in win_map.items():
+        complete = True
+        for nid in kept_map[lin]:
+            rb = ctx.harness.get_node_ring(nid, lineage=(lin,))
+            if rb is None or rb.idx < spectral_cfg.win_len:
+                complete = False
+                break
+        if not complete:
+            logger.debug(
+                "pump_with_loss: lineage %d windows incomplete — skipping hist compute",
+                lin,
+            )
+            continue
+        bp = batched_bandpower_from_windows(W, spectral_cfg)
+        bp_map = {nid: bp[row] for row, nid in enumerate(kept_map[lin])}
+        targ_map = {nid: hist_targets[nid] for nid in kept_map[lin]}
+        feat_mat = AT.stack([bp_map[nid] for nid in kept_map[lin]])
+        targ_mat = AT.stack([targ_map[nid] for nid in kept_map[lin]])
+        ctx.harness.push_node(
+            HIST_FEAT_ID,
+            feat_mat.flatten(),
+            lineage=(lin,),
+            size=1,
+        )
+        ctx.harness.push_node(
+            HIST_TARG_ID,
+            targ_mat.flatten(),
+            lineage=(lin,),
+            size=1,
+        )
+        ctx.harness.push_node(
+            HIST_IDS_ID,
+            AT.tensor(kept_map[lin], dtype=float),
+            lineage=(lin,),
+            size=1,
+        )
+        logger.debug(
+            "pump_with_loss: lineage %d pushed HIST_* (rows=%d B=%d)",
+            lin,
+            int(bp.shape[0]),
+            B,
+        )
+        pending.append(lin)
+    return state, pending
 
 
 def train_routing(
@@ -277,21 +607,22 @@ def train_routing(
     lineages grows beyond this threshold, the oldest entries are purged along
     with any cached ring data to avoid unbounded memory use.
     """
-    patience = 10
     wheels = register_param_wheels(spec, slots=1)
     for w in wheels:
         w.rotate(); w.bind_slot()
     params = [w.versions()[0] for w in wheels]
     set_strict_mode(True)
     annotate_params(params)
-    B = len(spectral_cfg.metrics.bands)
-    psi = AT.zeros(len(spec.nodes), dtype=float)
+
+    psi, hist_targets, band_start, B = initialize_signal_state(spec, spectral_cfg)
     routed: list[AT.Tensor] = []
     out_start = 5 * B
     layers = max(1, len(spec.nodes) // B)
     ring_capacity = log_capacity or max(1, layers - 1)
     log_buf = TensorRingBuffer(ring_capacity, flush_hook)
-    harness = RingHarness(default_size=spectral_cfg.win_len if spectral_cfg.enabled else None)
+    harness = RingHarness(
+        default_size=spectral_cfg.win_len if spectral_cfg.enabled else None
+    )
     ledger = LineageLedger()
     logger.debug(
         "train_routing: start B=%d layers=%d out_start=%d ring_capacity=%d",
@@ -301,299 +632,40 @@ def train_routing(
         ring_capacity,
     )
 
-    hist_targets: dict[int, AT.Tensor] = {}
-    band_start = len(spec.nodes) - B
-    for j, nid in enumerate(range(band_start, band_start + B)):
-        tvec = AT.zeros(B, dtype=float)
-        tvec[j] = 1.0
-        hist_targets[nid] = tvec
-        logger.debug("hist_target for node %d set as one-hot idx=%d", nid, j)
-
-    previous_grads = None
-    mix_buf: dict[int, AT.Tensor] = {}
-    hist_buf: dict[int, AT.Tensor] = {}
-
-    def purge_lineage_backlog(max_pending: int) -> None:
-        """Drop the oldest lineages when backlog exceeds ``max_pending``."""
-        active = ledger.lineages()
-        if len(active) <= max_pending:
-            return
-        stale = active[:-max_pending]
-        logger.warning(
-            "purge_lineage_backlog: dropping %d stale lineages (keeping %d)",
-            len(stale),
-            max_pending,
-        )
-        for lid in stale:
-            line = (lid,)
-            for key_id in (
-                OUT_FEAT_ID,
-                OUT_TARG_ID,
-                OUT_IDS_ID,
-                HIST_FEAT_ID,
-                HIST_TARG_ID,
-                HIST_IDS_ID,
-            ):
-                harness.node_rings.pop(harness._key(key_id, line), None)
-            for n in spec.nodes:
-                harness.node_rings.pop(harness._key(n.id, line), None)
-            for idx in range(len(spec.edges)):
-                harness.edge_rings.pop(harness._key(idx, line), None)
-        ledger.purge_through_lid(stale[-1])
-
-    def try_backward(lin: int) -> None:
-        nonlocal previous_grads, patience, log_buf
-        line = (lin,)
-        rb_out_feat = harness.get_node_ring(OUT_FEAT_ID, lineage=line)
-        rb_out_targ = harness.get_node_ring(OUT_TARG_ID, lineage=line)
-        rb_out_ids = harness.get_node_ring(OUT_IDS_ID, lineage=line)
-        rb_hist_feat = harness.get_node_ring(HIST_FEAT_ID, lineage=line)
-        rb_hist_targ = harness.get_node_ring(HIST_TARG_ID, lineage=line)
-        rb_hist_ids = harness.get_node_ring(HIST_IDS_ID, lineage=line)
-        if None in (
-            rb_out_feat,
-            rb_out_targ,
-            rb_out_ids,
-            rb_hist_feat,
-            rb_hist_targ,
-            rb_hist_ids,
-        ):
-            logger.debug(
-                "try_backward(lin=%d): missing rings — skipping (out_feat=%s out_targ=%s out_ids=%s hist_feat=%s hist_targ=%s hist_ids=%s)",
-                lin,
-                rb_out_feat is not None,
-                rb_out_targ is not None,
-                rb_out_ids is not None,
-                rb_hist_feat is not None,
-                rb_hist_targ is not None,
-                rb_hist_ids is not None,
-            )
-            return
-        out_feat = rb_out_feat.buf[0]
-        out_targ = rb_out_targ.buf[0]
-        hist_ids = rb_hist_ids.buf[0]
-        B = int(out_feat.shape[0])
-        M = int(hist_ids.shape[0])
-        if (
-            int(rb_hist_feat.buf.shape[1]) != M * B
-            or int(rb_hist_targ.buf.shape[1]) != M * B
-        ):
-            logger.debug(
-                "try_backward(lin=%d): histogram shape mismatch M=%d B=%d (feat=%s targ=%s) — skipping",
-                lin,
-                M,
-                B,
-                tuple(rb_hist_feat.buf.shape) if rb_hist_feat is not None else None,
-                tuple(rb_hist_targ.buf.shape) if rb_hist_targ is not None else None,
-            )
-            return
-        hist_feat = rb_hist_feat.buf[0].reshape(M, B)
-        hist_targ = rb_hist_targ.buf[0].reshape(M, B)
-        mix_residual = out_feat - out_targ
-        hist_residual = hist_feat - hist_targ
-        hist_residual_summary = hist_residual.mean(0)
-        hist_loss = (hist_residual ** 2).mean()
-        loss_out = (mix_residual ** 2).mean()
-        losses = {"loss_out": loss_out, "hist_loss": hist_loss}
-        probe_losses(losses, params)
-        logger.debug(
-            "try_backward(lin=%d): loss_out=%.6f hist_loss=%.6f",
-            lin,
-            float(loss_out.item()),
-            float(hist_loss.item()),
-        )
-        # Guard against asynchronous updates by clearing any stale entries
-        # before inserting fresh residuals. This ensures subsequent pops are
-        # safe and always retrieve the values from the current tick.
-        if lin in mix_buf or lin in hist_buf:
-            logger.debug("try_backward(lin=%d): replacing stale residuals", lin)
-            mix_buf.pop(lin, None)
-            hist_buf.pop(lin, None)
-        mix_buf[lin] = mix_residual
-        hist_buf[lin] = hist_residual_summary
-        mix_seed = mix_buf.pop(lin)
-        hist_seed = hist_buf.pop(lin)
-        seed_val = float((mix_seed.mean() + hist_seed.mean()).item())
-        logger.debug(
-            "try_backward(lin=%d): batching VJP with seed_val=%.6f params=%d",
-            lin,
-            seed_val,
-            len(params),
-        )
-        sys = SimpleNamespace(
-            nodes={i: SimpleNamespace(sphere=p) for i, p in enumerate(params)}
-        )
-        jobs = [
-            SimpleNamespace(job_id=f"p{i}", op="__neg__", src_ids=(i,), residual=seed_val)
-            for i in range(len(params))
-        ]
-        batch = run_batched_vjp(sys=sys, jobs=jobs)
-        grads = []
-        if batch.grads_per_source_tensor is not None:
-            g_tensor = AT.get_tensor(batch.grads_per_source_tensor)
-            for idx, p in enumerate(params):
-                grad = -g_tensor[idx]
-                grads.append(grad)
-                new_p = p - 0.01 * grad
-                params[idx] = rebind(f"param[{idx}]", new_p)
-        logger.debug(
-            "try_backward(lin=%d): computed grads for %d params",
-            lin,
-            len(grads),
-        )
-        if previous_grads is not None:
-            changed = False
-            for idx, (g, pg) in enumerate(zip(grads, previous_grads)):
-                if g is None and pg is not None:
-                    changed = True
-                    logger.debug("[Gradients] param %d lost gradient", idx)
-                elif g is not None and pg is None:
-                    changed = True
-                    logger.debug("[Gradients] param %d gained gradient", idx)
-                if g != pg:
-                    changed = True
-                    logger.debug("[Gradients] param %d gradient changed", idx)
-            if changed:
-                logger.debug("[Gradients] previous: %s", previous_grads)
-                logger.debug("[Gradients] current:  %s", grads)
-            else:
-                patience -= 1
-                if patience <= 0:
-                    logger.debug("[Gradients] no changes in gradients, stopping early")
-                    exit(0)
-        else:
-            logger.debug("[Gradients] initial gradients: %s", grads)
-        previous_grads = grads
-        logger.debug(
-            "loss: %.6f, hist_loss: %.6f",
-            float(loss_out.item()),
-            float(hist_loss.item()),
-        )
-        tick_idx = ledger.tick_of_lid[lin]
-        log_entry = {
-            "tick": AT.tensor([float(tick_idx)]),
-            "out_feat": out_feat.clone(),
-            "out_targ": out_targ.clone(),
-            "mix_residual": mix_seed.clone(),
-            "hist_residual": hist_seed.clone(),
-            "param_grad": AT.stack(grads) if grads else AT.zeros(len(params)),
-        }
-        log_buf.append(log_entry)
-        logger.debug(
-            "try_backward(lin=%d): logged tick=%d keys=%s",
-            lin,
-            int(float(tick_idx)),
-            list(log_entry.keys()),
-        )
-        for key_id in (
-            OUT_FEAT_ID,
-            OUT_TARG_ID,
-            OUT_IDS_ID,
-            HIST_FEAT_ID,
-            HIST_TARG_ID,
-            HIST_IDS_ID,
-        ):
-            k = harness._key(key_id, line)
-            harness.node_rings.pop(k, None)
-        logger.debug("try_backward(lin=%d): cleared transient node rings", lin)
-        for n in spec.nodes:
-            k = harness._key(n.id, line)
-            harness.node_rings.pop(k, None)
-        for idx in range(len(spec.edges)):
-            k = harness._key(idx, line)
-            harness.edge_rings.pop(k, None)
-        ledger.purge_through_lid(lin)
-        logger.debug("try_backward(lin=%d): purged lineage from ledger", lin)
-
-    def pump_with_loss(state: AT.Tensor, target_out: AT.Tensor) -> AT.Tensor:
-        lid = ledger.ingest()
-        logger.debug("pump_with_loss: ingest lid=%d", lid)
-        state, _ = fs_dec.pump_tick(
-            state,
-            spec,
-            eta=0.1,
-            phi=AT.tanh,
-            norm="all",
-            harness=harness,
-            lineage_id=lid,
-        )
-        logger.debug("pump_with_loss: post pump lid=%d state_len=%d", lid, int(state.shape[0]))
-        out_feat = state[out_start : out_start + B].clone()
-        harness.push_node(OUT_FEAT_ID, out_feat, lineage=(lid,), size=1)
-        harness.push_node(OUT_TARG_ID, target_out.clone(), lineage=(lid,), size=1)
-        out_ids = AT.arange(out_start, out_start + B, dtype=float)
-        harness.push_node(OUT_IDS_ID, out_ids, lineage=(lid,), size=1)
-        logger.debug(
-            "pump_with_loss: pushed OUT_* rings lid=%d out_ids=[%d..%d)",
-            lid,
-            out_start,
-            out_start + B,
-        )
-
-        mids = list(range(band_start, band_start + B))
-        win_map, kept_map = gather_recent_windows(spec, mids, spectral_cfg, harness, ledger)
-        logger.debug(
-            "pump_with_loss: gather_recent_windows mids=%d returned lineages=%d",
-            len(mids),
-            len(win_map),
-        )
-        for lin, W in win_map.items():
-            complete = True
-            for nid in kept_map[lin]:
-                rb = harness.get_node_ring(nid, lineage=(lin,))
-                if rb is None or rb.idx < spectral_cfg.win_len:
-                    complete = False
-                    break
-            if not complete:
-                logger.debug(
-                    "pump_with_loss: lineage %d windows incomplete — skipping hist compute",
-                    lin,
-                )
-                continue
-            bp = batched_bandpower_from_windows(W, spectral_cfg)
-            bp_map = {nid: bp[row] for row, nid in enumerate(kept_map[lin])}
-            targ_map = {nid: hist_targets[nid] for nid in kept_map[lin]}
-            feat_mat = AT.stack([bp_map[nid] for nid in kept_map[lin]])
-            targ_mat = AT.stack([targ_map[nid] for nid in kept_map[lin]])
-            harness.push_node(
-                HIST_FEAT_ID,
-                feat_mat.flatten(),
-                lineage=(lin,),
-                size=1,
-            )
-            harness.push_node(
-                HIST_TARG_ID,
-                targ_mat.flatten(),
-                lineage=(lin,),
-                size=1,
-            )
-            harness.push_node(
-                HIST_IDS_ID,
-                AT.tensor(kept_map[lin], dtype=float),
-                lineage=(lin,),
-                size=1,
-            )
-            logger.debug(
-                "pump_with_loss: lineage %d pushed HIST_* (rows=%d B=%d)",
-                lin,
-                int(bp.shape[0]),
-                B,
-            )
-            try_backward(lin)
-
-        try_backward(lid)
-        purge_lineage_backlog(max_lineage_backlog)
-        return state
+    ctx = RoutingState(
+        spec=spec,
+        harness=harness,
+        ledger=ledger,
+        params=params,
+        log_buf=log_buf,
+        mix_buf={},
+        hist_buf={},
+    )
 
     win = sine_chunks[0].shape[0]
-    B = len(sine_chunks)
     for frame_idx, frame_chunks in enumerate(noise_frames):
-        logger.debug("train_routing: processing frame %d/%d", frame_idx + 1, len(noise_frames))
+        logger.debug(
+            "train_routing: processing frame %d/%d",
+            frame_idx + 1,
+            len(noise_frames),
+        )
         for k in range(win):
             for i in range(B):
                 psi[i] = frame_chunks[i][k]
             target_out = AT.stack([sine_chunks[i][k] for i in range(B)]).flatten()
-            psi = pump_with_loss(psi, target_out)
+            psi, pending = pump_with_loss(
+                ctx,
+                psi,
+                target_out,
+                spectral_cfg,
+                hist_targets,
+                band_start,
+                out_start,
+                B,
+            )
+            for lin in pending:
+                try_backward(ctx, lin)
+            purge_lineage_backlog(ctx, max_lineage_backlog)
 
         win_map, kept_map = gather_recent_windows(
             spec, list(range(B)), spectral_cfg, harness, ledger
@@ -607,29 +679,28 @@ def train_routing(
                 bp = batched_bandpower_from_windows(W, spectral_cfg)
                 for row, nid in enumerate(kept_map[lin]):
                     psi[nid] = bp[row, nid]
-        psi = pump_with_loss(psi, AT.zeros(B, dtype=float))
+        psi, pending = pump_with_loss(
+            ctx,
+            psi,
+            AT.zeros(B, dtype=float),
+            spectral_cfg,
+            hist_targets,
+            band_start,
+            out_start,
+            B,
+        )
+        for lin in pending:
+            try_backward(ctx, lin)
+        purge_lineage_backlog(ctx, max_lineage_backlog)
         out = [psi[out_start + i] for i in range(B)]
         routed.append(AT.stack(out))
         logger.debug("train_routing: appended routed output for frame %d", frame_idx + 1)
 
     for lid in list(ledger.tick_of_lid.keys()):
-        try_backward(lid)
-    purge_lineage_backlog(max_lineage_backlog)
+        try_backward(ctx, lid)
+    purge_lineage_backlog(ctx, max_lineage_backlog)
 
-    # Report gradient status for all learnable parameters once outputs have been
-    # produced.  This helps diagnose dead graphs where ``loss.backward`` fails
-    # to populate ``grad`` fields.
-    for idx, p in enumerate(params):
-        grad = getattr(p, "grad", None)
-        if grad is None:
-            logger.debug("[Gradients] param %d missing gradient", idx)
-        else:
-            g = AT.get_tensor(grad)
-            if np.allclose(g, 0.0):
-                logger.debug("[Gradients] param %d gradient is zero: %s", idx, g)
-            else:
-                logger.debug("[Gradients] param %d grad: %s", idx, g)
-
+    log_param_gradients(params)
     remaining_logs = log_buf.snapshot()
     log_buf.flush_all()
 


### PR DESCRIPTION
## Summary
- modularize lineage cleanup, backward passes, and per-tick pumping into dedicated helpers
- extract signal initialization and gradient logging utilities
- streamline `train_routing` to orchestrate helpers and return results

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py`


------
https://chatgpt.com/codex/tasks/task_e_68c36c50617c832a84894b3017915df5