### PR TITLE
refactor spectral ring windows

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
+++ b/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
@@ -144,91 +144,53 @@ def gather_ring_metrics(
     return stats
 
 
-_fft_bands_rb: RingBuffer | None = None
-_fft_lids_rb: RingBuffer | None = None
-_fft_count: int = 0
-
-
-def update_fft_window(lineage: int, band: AT, cfg: SpectralCfg) -> None:
-    """Record ``band`` and its ``lineage`` in a global tensor ring.
-
-    The ring buffer stores the most recent ``cfg.win_len`` entries using
-    :class:`RingBuffer` so gradients remain connected without manual tensor
-    slicing.  ``band`` is promoted to a 1‑D row to fit the ring layout.
-    """
-
-    global _fft_bands_rb, _fft_lids_rb, _fft_count
-
-    row = band if getattr(AT.get_tensor(band), "ndim", 0) > 0 else band[None]
-
-    if _fft_bands_rb is None:
-        D = int(row.shape[0])
-        zeros = AT.zeros((int(cfg.win_len), D), dtype=AT.get_tensor(row).dtype)
-        _fft_bands_rb = RingBuffer(zeros)
-        _fft_lids_rb = RingBuffer(AT.zeros(int(cfg.win_len), dtype=float))
-
-    _fft_bands_rb.push(row)
-    _fft_lids_rb.push(AT.tensor(lineage, dtype=float))
-    _fft_count += 1
-
-
-def _ordered_ring(rb: RingBuffer, count: int) -> AT:
-    buf = rb.buf
-    R = int(buf.shape[0])
-    c = count if count < R else R
-    if count < R:
-        return buf[:c]
-    start = count % R
-    if start == 0:
-        return buf
-    return AT.cat([buf[start:], buf[:start]], dim=0)
-
-
-def current_fft_window() -> Tuple[AT, AT]:
-    """Return the stacked bands and their lineage identifiers."""
-
-    if _fft_bands_rb is None or _fft_lids_rb is None or _fft_count == 0:
-        return AT.zeros(0, dtype=float), AT.zeros(0, dtype=float)
-    bands = _ordered_ring(_fft_bands_rb, _fft_count)
-    lids = _ordered_ring(_fft_lids_rb, _fft_count)
-    return bands, lids
-
-
-def reset_fft_windows() -> None:
-    """Clear stored window history for all lineages."""
-
-    global _fft_bands_rb, _fft_lids_rb, _fft_count
-    _fft_bands_rb = None
-    _fft_lids_rb = None
-    _fft_count = 0
-
-
 def gather_recent_windows(
     spec: FluxSpringSpec,
     node_ids: List[int],
     cfg: SpectralCfg,
     harness: RingHarness,
     ledger: LineageLedger,
-) -> Tuple[Dict[int, AT], Dict[int, List[int]]]:
-    """Compatibility shim returning the global FFT window keyed by lineage.
+) -> Dict[int, AT]:
+    """Return band powers computed from each node's pre-mix ring.
 
-    Each lineage present in the window is mapped to its band tensor.  ``node_ids``
-    are echoed back in ``kept_map`` so legacy callers can associate results with
-    originating nodes even though per-lineage history is no longer stored.
+    ``node_ids`` identifies which nodes correspond to FFT binning wheels.  For
+    each node, the raw pre-mix history is retrieved from the harness and ordered
+    so that the most recent ``cfg.win_len`` samples form the analysis window.
+    The window is transformed into band powers according to ``cfg.metrics``.
+
+    The returned mapping associates ``node_id`` with its band‑power tensor.  The
+    caller is responsible for comparing these values against any target bands
+    and accounting losses to the appropriate lineage.  Lineage tagging is left
+    as a TODO once per-node targets are formalised.
     """
 
     win_map: Dict[int, AT] = {}
-    kept_map: Dict[int, List[int]] = {}
 
-    bands, lids = current_fft_window()
-    if int(bands.shape[0]) == 0:
-        return win_map, kept_map
+    def _ordered(rb: RingBuffer) -> AT:
+        buf = rb.buf
+        R = int(buf.shape[0])
+        idx = rb.idx
+        if idx < R:
+            return buf[:idx]
+        start = idx % R
+        if start == 0:
+            return buf
+        return AT.cat([buf[start:], buf[:start]], dim=0)
 
-    lid_list = [int(x) for x in AT.get_tensor(lids).flatten().tolist()]
-    for i, lin in enumerate(lid_list):
-        win_map[lin] = bands[i : i + 1]
-        kept_map[lin] = list(node_ids)
-    return win_map, kept_map
+    for nid in node_ids:
+        rb = harness.get_premix_ring(nid)
+        if rb is None:
+            continue
+        ordered = _ordered(rb)
+        if int(ordered.shape[0]) < cfg.win_len:
+            continue
+        win = ordered[-cfg.win_len :]
+        metrics = compute_metrics(win, cfg, return_tensor=True)
+        band = metrics.get("bandpower")
+        if band is not None:
+            win_map[nid] = band
+
+    return win_map
 
 
 def batched_bandpower_from_windows(window_matrix: AT, cfg: SpectralCfg) -> AT:


### PR DESCRIPTION
## Summary
- always record node pre-mix values in fs_dec's ring harness
- drop global FFT window buffers in spectral_readout and gather windows directly from premix rings
- simplify spectral_readout tests to remove obsolete FFT window helpers

## Testing
- `pytest tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_premix_ring_histogram_loss.py tests/autoautograd/test_output_phi_ring.py tests/autoautograd/test_spectral_readout.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3ac7fbf70832a8242eabe0081611c