### PR TITLE
Remove phi ring buffering and log psi outputs

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -375,17 +375,15 @@ def _pump_tick(
     if harness is not None:
         lin = (lineage_id,) if lineage_id is not None else None
         if spec.spectral.enabled:
-            phi_out = phi(psi_next)
             evicted: Dict[int, AT] = {}
-            for n, val, ph_o in zip(spec.nodes, psi_next, phi_out):
-                harness.push_node(n.id, val, lineage=lin)
-                ev = harness.push_out_phi(n.id, ph_o, lineage=lin)
+            for n, val in zip(spec.nodes, psi_next):
+                ev = harness.push_node(n.id, val, lineage=lin)
                 if ev is not None:
                     evicted[n.id] = ev
             for idx, q_val in enumerate(q):
                 harness.push_edge(idx, q_val, lineage=lin)
             if evicted:
-                stats["evicted_phi"] = evicted
+                stats["evicted_psi"] = evicted
         # Always record raw inputs so premix history is available even when
         # spectral analysis is disabled.
         for n, raw in zip(spec.nodes, node_raw):

--- a/tests/autoautograd/test_output_psi_ring.py
+++ b/tests/autoautograd/test_output_psi_ring.py
@@ -31,7 +31,7 @@ def _build_spec(win_len: int) -> FluxSpringSpec:
     dec = DECSpec(D0=[[0.0]], D1=[])
     spectral = SpectralCfg(enabled=True, win_len=win_len, hop_len=win_len, window="hann")
     return FluxSpringSpec(
-        version="phi-out-test",
+        version="psi-out-test",
         D=1,
         nodes=[node],
         edges=[edge],
@@ -41,7 +41,7 @@ def _build_spec(win_len: int) -> FluxSpringSpec:
     )
 
 
-def test_out_phi_ring_eviction_and_grad():
+def test_out_psi_ring_eviction_and_grad():
     spec = _build_spec(3)
     param = AT.tensor(0.5)
     param.requires_grad_(True)
@@ -51,8 +51,8 @@ def test_out_phi_ring_eviction_and_grad():
     for _ in range(4):
         psi, stats = pump_tick(psi, spec, eta=0.0, external={0: param}, harness=harness)
 
-    evicted = stats.get("evicted_phi", {}).get(0)
+    evicted = stats.get("evicted_psi", {}).get(0)
     assert evicted is not None
-    expected = AT.tanh(param).reshape(-1)
+    expected = param.reshape(-1)
     assert AT.allclose(evicted, expected)
 


### PR DESCRIPTION
## Summary
- Remove phi ring storage and helper methods from the FluxSpring harness
- Record evicted psi values directly during spectral logging
- Update tests to assert psi ring eviction and gradients

## Testing
- `pytest tests/autoautograd -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4175357c4832aaab55975b3d8335b