### PR TITLE
Fix gather_recent_windows lineage handling

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/__init__.py
+++ b/src/common/tensors/autoautograd/fluxspring/__init__.py
@@ -1,7 +1,7 @@
 from .fs_types import (
     LearnCtrl, NodeCtrl, EdgeTransportLearn, EdgeTransport, EdgeCtrl,
     NodeSpec, EdgeSpec, FaceLearn, FaceSpec,
-    DirichletCfg, DECSpec, RegCfg, FluxSpringSpec
+    DirichletCfg, DECSpec, RegCfg, FluxSpringSpec, SpectralCfg
 )
 from .fs_io import load_fluxspring, save_fluxspring, validate_fluxspring
 from .fs_dec import (
@@ -208,8 +208,19 @@ class ParamWheel:
             p._grad = None
 
 
-def register_param_wheels(spec: FluxSpringSpec, *, slots: int = 2) -> list[ParamWheel]:
-    """Instantiate :class:`ParamWheel` objects for all learnable parameters."""
+def register_param_wheels(
+    spec: FluxSpringSpec, *, slots: int | None = None
+) -> list[ParamWheel]:
+    """Instantiate :class:`ParamWheel` objects for all learnable parameters.
+
+    When ``spec.spectral.enabled`` is ``True`` and ``slots`` is not provided,
+    the number of slots defaults to the FFT window length so that every
+    parameter wheel maintains a full window of versions.  Otherwise two slots
+    are used as a minimal ring.
+    """
+
+    if slots is None:
+        slots = spec.spectral.win_len if spec.spectral.enabled else 2
 
     wheels: list[ParamWheel] = []
     tmp: list[AT] = []

--- a/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
+++ b/src/common/tensors/autoautograd/fluxspring/spectral_readout.py
@@ -147,26 +147,24 @@ def gather_ring_metrics(
 
 
 def gather_recent_windows(
-    spec: FluxSpringSpec,
     node_ids: List[int],
     cfg: SpectralCfg,
     harness: RingHarness,
     ledger: LineageLedger,
-) -> Dict[int, AT]:
-    """Return band powers computed from each node's pre-mix ring.
+) -> Tuple[Dict[int, AT], Dict[int, List[int]]]:
+    """Return recent raw windows for specified node IDs grouped by lineage.
 
-    ``node_ids`` identifies which nodes correspond to FFT binning wheels.  For
-    each node, the raw pre-mix history is retrieved from the harness and ordered
-    so that the most recent ``cfg.win_len`` samples form the analysis window.
-    The window is transformed into band powers according to ``cfg.metrics``.
-
-    The returned mapping associates ``node_id`` with its band‑power tensor.  The
-    caller is responsible for comparing these values against any target bands
-    and accounting losses to the appropriate lineage.  Lineage tagging is left
-    as a TODO once per-node targets are formalised.
+    For each lineage tracked in ``ledger`` this function attempts to retrieve
+    the pre‑mix ring buffer for every node in ``node_ids``.  When a ring
+    contains at least ``cfg.win_len`` samples the most recent ``win_len`` values
+    are stacked into a window.  The returned ``win_map`` associates each
+    lineage identifier with a tensor of shape ``(M, win_len)`` where ``M`` is the
+    number of nodes that produced a valid window.  ``kept_map`` stores the node
+    identifiers corresponding to each row in the window tensor.
     """
 
     win_map: Dict[int, AT] = {}
+    kept_map: Dict[int, List[int]] = {}
 
     def _ordered(rb: RingBuffer) -> AT:
         buf = rb.buf
@@ -179,20 +177,23 @@ def gather_recent_windows(
             return buf
         return AT.cat([buf[start:], buf[:start]], dim=0)
 
-    for nid in node_ids:
-        rb = harness.get_premix_ring(nid)
-        if rb is None:
-            continue
-        ordered = _ordered(rb)
-        if int(ordered.shape[0]) < cfg.win_len:
-            continue
-        win = ordered[-cfg.win_len :]
-        metrics = compute_metrics(win, cfg, return_tensor=True)
-        band = metrics.get("bandpower")
-        if band is not None:
-            win_map[nid] = band
+    for lin in ledger.lineages():
+        windows: List[AT] = []
+        kept: List[int] = []
+        for nid in node_ids:
+            rb = harness.get_premix_ring(nid, lineage=(lin,))
+            if rb is None:
+                continue
+            ordered = _ordered(rb)
+            if int(ordered.shape[0]) < cfg.win_len:
+                continue
+            windows.append(ordered[-cfg.win_len :].reshape(-1))
+            kept.append(nid)
+        if windows:
+            win_map[lin] = AT.stack(windows)
+            kept_map[lin] = kept
 
-    return win_map
+    return win_map, kept_map
 
 
 def quantile_band_targets(


### PR DESCRIPTION
## Summary
- return raw windows grouped by lineage in `gather_recent_windows`
- adjust spectral routing demo to new API
- add unit test verifying lineage-aware window gathering
- size spectral routing ring buffers and parameter wheels to FFT window length

## Testing
- `pytest tests/autoautograd/test_param_version_rings.py tests/autoautograd/test_spectral_readout.py tests/autoautograd/test_fluxspring_params_grad.py tests/autoautograd/test_fluxspring_gradients.py tests/test_spectral_fluxspring_grad.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c419139aa0832ab89d50d1dd845417