### PR TITLE
Remove explicit lineage from premix pushes

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -387,7 +387,7 @@ def _pump_tick(
         # Always record raw inputs so premix history is available even when
         # spectral analysis is disabled.
         for n, raw in zip(spec.nodes, node_raw):
-            harness.push_premix(n.id, raw, lineage=lin)
+            harness.push_premix(n.id, raw)
         harness.snapshot_learnables(spec)
 
     return psi_next, stats


### PR DESCRIPTION
## Summary
- drop `lineage` argument when recording node premix values

## Testing
- `pytest tests/autoautograd`
- `python -m src.common.tensors.autoautograd.fluxspring.demo_spectral_routing`


------
https://chatgpt.com/codex/tasks/task_e_68c42a9ee750832a8da086bc2aa59fa5