### PR TITLE
Simplify ring buffer keys

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -313,8 +313,7 @@ def purge_lineage_backlog(ctx: RoutingState, max_pending: int) -> None:
         len(stale),
         max_pending,
     )
-    for lid in stale:
-        line = (lid,)
+    for _ in stale:
         for key_id in (
             OUT_FEAT_ID,
             OUT_TARG_ID,
@@ -323,23 +322,22 @@ def purge_lineage_backlog(ctx: RoutingState, max_pending: int) -> None:
             HIST_TARG_ID,
             HIST_IDS_ID,
         ):
-            ctx.harness.node_rings.pop(ctx.harness._key(key_id, line), None)
+            ctx.harness.node_rings.pop(ctx.harness._key(key_id), None)
         for n in ctx.spec.nodes:
-            ctx.harness.node_rings.pop(ctx.harness._key(n.id, line), None)
+            ctx.harness.node_rings.pop(ctx.harness._key(n.id), None)
         for idx in range(len(ctx.spec.edges)):
-            ctx.harness.edge_rings.pop(ctx.harness._key(idx, line), None)
+            ctx.harness.edge_rings.pop(ctx.harness._key(idx), None)
     ctx.ledger.purge_through_lid(stale[-1])
 
 
 def try_backward(ctx: RoutingState, lin: int) -> None:
     """Execute the backward pass for a completed lineage."""
-    line = (lin,)
-    rb_out_feat = ctx.harness.get_node_ring(OUT_FEAT_ID, lineage=line)
-    rb_out_targ = ctx.harness.get_node_ring(OUT_TARG_ID, lineage=line)
-    rb_out_ids = ctx.harness.get_node_ring(OUT_IDS_ID, lineage=line)
-    rb_hist_feat = ctx.harness.get_node_ring(HIST_FEAT_ID, lineage=line)
-    rb_hist_targ = ctx.harness.get_node_ring(HIST_TARG_ID, lineage=line)
-    rb_hist_ids = ctx.harness.get_node_ring(HIST_IDS_ID, lineage=line)
+    rb_out_feat = ctx.harness.get_node_ring(OUT_FEAT_ID)
+    rb_out_targ = ctx.harness.get_node_ring(OUT_TARG_ID)
+    rb_out_ids = ctx.harness.get_node_ring(OUT_IDS_ID)
+    rb_hist_feat = ctx.harness.get_node_ring(HIST_FEAT_ID)
+    rb_hist_targ = ctx.harness.get_node_ring(HIST_TARG_ID)
+    rb_hist_ids = ctx.harness.get_node_ring(HIST_IDS_ID)
     if None in (
         rb_out_feat,
         rb_out_targ,
@@ -509,14 +507,14 @@ def try_backward(ctx: RoutingState, lin: int) -> None:
         HIST_TARG_ID,
         HIST_IDS_ID,
     ):
-        k = ctx.harness._key(key_id, line)
+        k = ctx.harness._key(key_id)
         ctx.harness.node_rings.pop(k, None)
     logger.debug("try_backward(lin=%d): cleared transient node rings", lin)
     for n in ctx.spec.nodes:
-        k = ctx.harness._key(n.id, line)
+        k = ctx.harness._key(n.id)
         ctx.harness.node_rings.pop(k, None)
     for idx in range(len(ctx.spec.edges)):
-        k = ctx.harness._key(idx, line)
+        k = ctx.harness._key(idx)
         ctx.harness.edge_rings.pop(k, None)
     ctx.ledger.purge_through_lid(lin)
     logger.debug("try_backward(lin=%d): purged lineage from ledger", lin)
@@ -566,20 +564,17 @@ def pump_with_loss(
     ctx.harness.push_node(
         OUT_FEAT_ID,
         out_feat,
-        lineage=(lid,),
         size=spectral_cfg.win_len,
     )
     ctx.harness.push_node(
         OUT_TARG_ID,
         target_out.clone(),
-        lineage=(lid,),
         size=spectral_cfg.win_len,
     )
     out_ids = AT.arange(out_start, out_start + B, dtype=float)
     ctx.harness.push_node(
         OUT_IDS_ID,
         out_ids,
-        lineage=(lid,),
         size=spectral_cfg.win_len,
     )
     logger.debug(
@@ -604,19 +599,16 @@ def pump_with_loss(
         ctx.harness.push_node(
             HIST_FEAT_ID,
             bp.flatten(),
-            lineage=(fft_lid,),
             size=spectral_cfg.win_len,
         )
         ctx.harness.push_node(
             HIST_TARG_ID,
             targ_mat.flatten(),
-            lineage=(fft_lid,),
             size=spectral_cfg.win_len,
         )
         ctx.harness.push_node(
             HIST_IDS_ID,
             AT.tensor(kept, dtype=float),
-            lineage=(fft_lid,),
             size=spectral_cfg.win_len,
         )
         logger.debug(

--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -373,15 +373,14 @@ def _pump_tick(
 
     # Maintain ring buffers for spectral analysis.
     if harness is not None:
-        lin = (lineage_id,) if lineage_id is not None else None
         if spec.spectral.enabled:
             evicted: Dict[int, AT] = {}
             for n, val in zip(spec.nodes, psi_next):
-                ev = harness.push_node(n.id, val, lineage=lin)
+                ev = harness.push_node(n.id, val)
                 if ev is not None:
                     evicted[n.id] = ev
             for idx, q_val in enumerate(q):
-                harness.push_edge(idx, q_val, lineage=lin)
+                harness.push_edge(idx, q_val)
             if evicted:
                 stats["evicted_psi"] = evicted
         # Always record raw inputs so premix history is available even when

--- a/src/common/tensors/autoautograd/fluxspring/fs_harness.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_harness.py
@@ -201,21 +201,21 @@ class ParamRing:
 
 @dataclass
 class RingHarness:
-    """Own per-node and per-edge ring buffers keyed by lineage."""
+    """Own per-node and per-edge ring buffers keyed by object ID."""
 
     default_size: Optional[int] = None
-    node_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
-    edge_rings: Dict[Tuple[int, ...], RingBuffer] = field(default_factory=dict)
-    premix_rings: Dict[Tuple[int, ...], PremixRing] = field(default_factory=dict)
+    node_rings: Dict[Tuple[int], RingBuffer] = field(default_factory=dict)
+    edge_rings: Dict[Tuple[int], RingBuffer] = field(default_factory=dict)
+    premix_rings: Dict[Tuple[int], PremixRing] = field(default_factory=dict)
     param_rings: Dict[str, ParamRing] = field(default_factory=dict)
     param_labels: List[str] = field(default_factory=list)
     tick: int = 0
 
-    def _key(self, obj_id: int, lineage: Tuple[int, ...] | None) -> Tuple[int, ...]:
-        return (obj_id,) if lineage is None else (obj_id, *lineage)
+    def _key(self, obj_id: int) -> Tuple[int]:
+        return (obj_id,)
 
     def _ensure_node_ring(
-        self, key: Tuple[int, ...], D: int, size: Optional[int]
+        self, key: Tuple[int], D: int, size: Optional[int]
     ) -> Optional[RingBuffer]:
         size = size or self.default_size
         if size is None:
@@ -232,7 +232,7 @@ class RingHarness:
         return self.node_rings[key]
 
     def _ensure_edge_ring(
-        self, key: Tuple[int, ...], size: Optional[int]
+        self, key: Tuple[int], size: Optional[int]
     ) -> Optional[RingBuffer]:
         size = size or self.default_size
         if size is None:
@@ -270,10 +270,9 @@ class RingHarness:
         node_id: int,
         val: AT,
         *,
-        lineage: Tuple[int, ...] | None = None,
         size: Optional[int] = None,
     ) -> AT | None:
-        key = self._key(node_id, lineage)
+        key = self._key(node_id)
         t = AT.get_tensor(val)
         D = int(t.shape[0]) if getattr(t, "ndim", 0) > 0 else 1
         rb = self._ensure_node_ring(key, D, size)
@@ -282,7 +281,7 @@ class RingHarness:
         return rb.push(val)
 
     def _ensure_premix_ring(
-        self, key: Tuple[int, ...], D: int, size: Optional[int]
+        self, key: Tuple[int], D: int, size: Optional[int]
     ) -> Optional[PremixRing]:
         size = size or self.default_size
         if size is None:
@@ -297,10 +296,9 @@ class RingHarness:
         node_id: int,
         val: AT,
         *,
-        lineage: Tuple[int, ...] | None = None,
         size: Optional[int] = None,
     ) -> AT | None:
-        key = self._key(node_id, lineage)
+        key = self._key(node_id)
         t = AT.get_tensor(val)
         D = int(t.shape[0]) if getattr(t, "ndim", 0) > 0 else 1
         rb = self._ensure_premix_ring(key, D, size)
@@ -309,33 +307,32 @@ class RingHarness:
         return rb.push(val.reshape(-1))
 
     def get_premix_ring(
-        self, node_id: int, *, lineage: Tuple[int, ...] | None = None
+        self, node_id: int
     ) -> Optional[PremixRing]:
-        return self.premix_rings.get(self._key(node_id, lineage))
+        return self.premix_rings.get(self._key(node_id))
 
     def push_edge(
         self,
         edge_idx: int,
         val: AT,
         *,
-        lineage: Tuple[int, ...] | None = None,
         size: Optional[int] = None,
     ) -> AT | None:
-        key = self._key(edge_idx, lineage)
+        key = self._key(edge_idx)
         rb = self._ensure_edge_ring(key, size)
         if rb is None:
             return None
         return rb.push(val)
 
     def get_node_ring(
-        self, node_id: int, *, lineage: Tuple[int, ...] | None = None
+        self, node_id: int
     ) -> Optional[RingBuffer]:
-        return self.node_rings.get(self._key(node_id, lineage))
+        return self.node_rings.get(self._key(node_id))
 
     def get_edge_ring(
-        self, edge_idx: int, *, lineage: Tuple[int, ...] | None = None
+        self, edge_idx: int
     ) -> Optional[RingBuffer]:
-        return self.edge_rings.get(self._key(edge_idx, lineage))
+        return self.edge_rings.get(self._key(edge_idx))
 
     # ------------------------------------------------------------------
     # Parameter versioning


### PR DESCRIPTION
## Summary
- Simplify ring buffer keying in `RingHarness` to only use `(obj_id,)`
- Drop obsolete `lineage` argument from ring buffer helpers and demos

## Testing
- `pytest tests/autoautograd/test_ring_buffer_gradients.py tests/autoautograd/test_output_psi_ring.py tests/autoautograd/test_premix_ring_histogram_loss.py tests/autoautograd/test_spectral_readout.py`


------
https://chatgpt.com/codex/tasks/task_e_68c440dd4c34832a92c2e76389f949cd