### PR TITLE
Clarify lineage handling in FluxSpring pump tick

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/fs_dec.py
+++ b/src/common/tensors/autoautograd/fluxspring/fs_dec.py
@@ -307,9 +307,7 @@ def _pump_tick(
         When provided and ``spec.spectral.enabled`` is ``True``, ring buffers
         for nodes and edges are updated via this harness.
     lineage_id : int, optional
-        Lineage identifier passed through to the harness so node and edge
-        histories can be keyed by input lineage.  ``None`` preserves the
-        previous behaviour where all pushes share the same buffers.
+        Reserved for future lineage tracking; currently unused.
     """
 
     # Inject fresh external inputs before computing edge potentials. ``ids`` is


### PR DESCRIPTION
## Summary
- Clarify that `lineage_id` is currently unused in FluxSpring's `_pump_tick`
- Keep harness pushes per tick without lineage arguments for slot order

## Testing
- `pytest tests/autoautograd/test_fluxspring_pump_tick.py tests/autoautograd/test_fluxspring_transport_tick.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4605cccf8832aa8e23bd82b8b9178