### PR TITLE
Ensure SlotBackpropQueue aligns with spectral window length

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -391,6 +391,11 @@ def train_routing(
     mix_buf = RingBuffer(AT.zeros((spec.spectral.win_len, B), dtype=float))
     hist_buf = RingBuffer(AT.zeros((spec.spectral.win_len, B), dtype=float))
     bp_queue = SlotBackpropQueue(wheels)
+    if bp_queue.slots != spectral_cfg.win_len:
+        raise ValueError(
+            "train_routing: bp_queue.slots %d does not match spectral_cfg.win_len %d"
+            % (bp_queue.slots, spectral_cfg.win_len)
+        )
     ctx = RoutingState(
         spec=spec,
         harness=harness,


### PR DESCRIPTION
## Summary
- validate that `SlotBackpropQueue` slots match `SpectralCfg.win_len` in `train_routing`

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c476696130832abb60816915aaa73f