### PR TITLE
Log matured ticks during spectral routing

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -430,7 +430,9 @@ def train_routing(
                 sys = SimpleNamespace(
                     nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
                 )
-                ctx.bp_queue.process_slot(mature_slot, sys=sys)
+                res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+                if res is not None:
+                    ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
             tick += 1
 
         W, kept = gather_recent_windows(list(range(B)), spectral_cfg, harness)
@@ -460,7 +462,9 @@ def train_routing(
             sys = SimpleNamespace(
                 nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            if res is not None:
+                ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1
         out = [psi[out_start + i] for i in range(B)]
         routed.append(AT.stack(out))
@@ -473,7 +477,9 @@ def train_routing(
             sys = SimpleNamespace(
                 nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            if res is not None:
+                ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1
 
     log_param_gradients([p for w in ctx.wheels for p in w.versions()])


### PR DESCRIPTION
## Summary
- Log mature tick values when `process_slot` completes in training loop
- Capture ticks for matured slots during final draining pass

## Testing
- `pytest tests/test_spectral_fluxspring_grad.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4767af66c832abcd3f9b02a17041b