### PR TITLE
Allow configurable node attributes for VJP

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -47,6 +47,8 @@ from dataclasses import dataclass
 # Module logger setup (configured in main if not already configured)
 logger = logging.getLogger(__name__)
 
+FLUX_PARAM_SCHEMA = ("p",)
+
 
 class TensorRingBuffer:
     """AbstractTensor-based ring buffer for per-tick logs."""
@@ -478,9 +480,9 @@ def train_routing(
             if mature_tick >= 0:
                 mature_slot = mature_tick % ctx.bp_queue.slots
                 sys = SimpleNamespace(
-                    nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
+                    nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
                 )
-                res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+                res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
                 if res is not None:
                     ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
             tick += 1
@@ -510,9 +512,9 @@ def train_routing(
         if mature_tick >= 0:
             mature_slot = mature_tick % ctx.bp_queue.slots
             sys = SimpleNamespace(
-                nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
+                nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
             if res is not None:
                 ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1
@@ -525,9 +527,9 @@ def train_routing(
         if mature_tick >= 0:
             mature_slot = mature_tick % ctx.bp_queue.slots
             sys = SimpleNamespace(
-                nodes={i: SimpleNamespace(sphere=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
+                nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
             if res is not None:
                 ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1

--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -127,6 +127,7 @@ class SlotBackpropQueue:
         sys: Any,
         lr: float = 0.01,
         run_vjp=run_batched_vjp,
+        node_attrs: Sequence[str] | str = "sphere",
     ) -> BatchVJPResult | None:
         """Drain and process jobs for ``slot`` applying gradients.
 
@@ -175,7 +176,7 @@ class SlotBackpropQueue:
             )
             jobs.append(_WBJob(j.job_id, j.op, j.src_ids, res, j.param_lens, j.fn))
 
-        batch = run_vjp(sys=sys, jobs=jobs)
+        batch = run_vjp(sys=sys, jobs=jobs, node_attrs=node_attrs)
         g_tensor = batch.grads_per_source_tensor
         if g_tensor is not None:
             g_tensor = AT.get_tensor(g_tensor)

--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -337,6 +337,7 @@ def run_batched_vjp(
     op_args: Tuple[Any, ...] = (),
     op_kwargs: Optional[Dict[str, Any]] = None,
     backend: Any | None = None,
+    node_attrs: Sequence[str] | str = "sphere",
 ) -> BatchVJPResult:
     """
     One tape, one VJP over the whole bin.
@@ -410,7 +411,7 @@ def run_batched_vjp(
     scope = scope_cm() if callable(scope_cm) else nullcontext()
 
     with scope, _tape():
-        view = NodeAttrView(sys.nodes, "sphere", indices=union_ids).build()
+        view = NodeAttrView(sys.nodes, node_attrs, indices=union_ids).build()
         x_all = view.tensor
         if hasattr(x_all, "requires_grad_"):
             x_all = x_all.requires_grad_()


### PR DESCRIPTION
## Summary
- let NodeAttrView gather and scatter multiple attributes per node
- add `node_attrs` option through SlotBackpropQueue and whiteboard runtime
- demo_spectral_routing now passes a FluxSpring parameter schema

## Testing
- `pytest tests/test_spring_async_toy_tensor_glist.py tests/autoautograd/test_slot_backprop_queue.py`
- `pytest tests/autoautograd/test_fluxspring_gradients.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4bd357914832a8460606a03e166c7