### PR TITLE
refactor tensor conversion to AT-backed view

### DIFF
--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -189,12 +189,12 @@ def run_op_and_grads_cached(
         y = vals[0] + vals[1]
         ones0 = vals[0] * 0 + 1
         ones1 = vals[1] * 0 + 1
-        grads_full = AbstractTensor.stack([ones0, ones1], dim=0)
+        grads_full = AT.stack([ones0, ones1], dim=0)
     elif op_name == "mul" and len(vals) == 2 and not op_args and not op_kwargs:
         y = vals[0] * vals[1]
         g0 = vals[1] * (vals[0] * 0 + 1)
         g1 = vals[0] * (vals[1] * 0 + 1)
-        grads_full = AbstractTensor.stack([g0, g1], dim=0)
+        grads_full = AT.stack([g0, g1], dim=0)
     elif op_name == "route_batch":
         from .fluxspring import fs_dec
 
@@ -318,11 +318,11 @@ def run_op_and_grads_cached(
         if param_grads_full is not None:
             grads = param_grads_full
         elif grads_full is None:
-            grads = AbstractTensor.zeros((len(src_ids), P), float)
+            grads = AT.zeros((len(src_ids), P), float)
         else:
             grads = grads_full[:, D:] if P > 0 else grads_full[:, 0:0]
     else:  # "full"
-        grads = grads_full if grads_full is not None else AbstractTensor.zeros(
+        grads = grads_full if grads_full is not None else AT.zeros(
             (len(src_ids), sphere_len), float
         )
 


### PR DESCRIPTION
## Summary
- replace `asarray` hook with `to_tensor` using `AbstractTensor.get_tensor`
- drop `asarray_fn` plumbing from `NodeAttrView`
- fix whiteboard runtime to use `AT` helpers for stacking and zero creation

## Testing
- `pytest tests/test_whiteboard_runtime_none_grads.py::test_run_op_and_grads_cached_none_grads -q`
- `pytest tests/test_scheduling_module.py::test_runner_cache_probe_and_update -q`
- `pytest tests/test_gather_and_param_grads.py -q` *(fails: IndexError: index 1 is out of bounds for axis 0 with size 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c8a83814832ab0cd8ccab75178ae