### PR TITLE
Add wheel parameter reshape logging

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -52,10 +52,23 @@ FLUX_PARAM_SCHEMA = ("p",)
 
 def _vectorize_wheel_params_to_1d(wheels: Sequence[ParamWheel]) -> None:
     """Ensure each parameter slot is at least 1-D for autograd."""
-    for w in wheels:
-        for i, p in enumerate(w.params):
+    for w_idx, w in enumerate(wheels):
+        for p_idx, p in enumerate(w.params):
             pt = AT.get_tensor(p)
-            w.params[i] = pt.reshape(1) if getattr(pt, "ndim", 0) == 0 else pt.reshape(-1)
+            logger.debug(
+                "vectorize_wheel: wheel=%d param=%d before shape=%s",
+                w_idx,
+                p_idx,
+                getattr(pt, "shape", None),
+            )
+            reshaped = pt.reshape(1) if getattr(pt, "ndim", 0) == 0 else pt.reshape(-1)
+            logger.debug(
+                "vectorize_wheel: wheel=%d param=%d after shape=%s",
+                w_idx,
+                p_idx,
+                getattr(reshaped, "shape", None),
+            )
+            w.params[p_idx] = reshaped
 
 
 class TensorRingBuffer:


### PR DESCRIPTION
## Summary
- log tensor shapes before and after reshaping wheel params in demo_spectral_routing

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py tests/autoautograd/test_output_psi_ring.py tests/autoautograd/test_premix_ring_histogram_loss.py tests/test_spectral_fluxspring_grad.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e3816638832aaba6db47554e0ce8