### PR TITLE
Log missing gradient tensor in slot backprop

### DIFF
--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -218,6 +218,12 @@ class SlotBackpropQueue:
                     before,
                     after,
                 )
+        else:
+            logger.debug(
+                "process_slot: slot=%d no g_tensor queued_jobs=%d",
+                slot,
+                len(jobs),
+            )
         self.jobs[slot] = []
         self.spectral_jobs[slot] = []
         self.main_residuals[slot] = None


### PR DESCRIPTION
## Summary
- log when a slot produces no gradient tensor, including slot index and queued job count

## Testing
- `pytest tests/autoautograd/test_slot_backprop_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e75c9b88832ab2d9baed46e8bf29