### PR TITLE
Log node parameters before VJP in slot backprop

### DIFF
--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -196,6 +196,21 @@ class SlotBackpropQueue:
             )
             jobs.append(_WBJob(j.job_id, j.op, j.src_ids, res, j.param_lens, j.fn))
 
+        if sys is not None and getattr(sys, "nodes", None) is not None:
+            for nid, node in (
+                sys.nodes.items() if isinstance(sys.nodes, dict) else enumerate(sys.nodes)
+            ):
+                p = getattr(node, "p", None)
+                if p is None:
+                    continue
+                logger.debug(
+                    "process_slot: node_id=%s param_id=%s requires_grad=%s value=%s",
+                    nid,
+                    id(p),
+                    getattr(p, "requires_grad", False),
+                    p,
+                )
+
         batch = run_vjp(sys=sys, jobs=jobs, node_attrs=node_attrs)
         g_tensor = batch.grads_per_source_tensor
         if g_tensor is not None:


### PR DESCRIPTION
## Summary
- Add debug logging of each node's parameter before batched VJP execution in `SlotBackpropQueue.process_slot`
- Simplify logging by removing unnecessary tensor conversion

## Testing
- `pytest tests/autoautograd/test_slot_backprop_queue.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5db056d04832a868302c6d7df4568