### PR TITLE
Log node parameters before VJP in slot backprop

### DIFF
--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -196,6 +196,21 @@ class SlotBackpropQueue:
             )
             jobs.append(_WBJob(j.job_id, j.op, j.src_ids, res, j.param_lens, j.fn))
 
+        if sys is not None and getattr(sys, "nodes", None) is not None:
+            for nid, node in (
+                sys.nodes.items() if isinstance(sys.nodes, dict) else enumerate(sys.nodes)
+            ):
+                p = getattr(node, "p", None)
+                if p is None:
+                    continue
+                logger.debug(
+                    "process_slot: node_id=%s param_id=%s requires_grad=%s value=%s",
+                    nid,
+                    id(p),
+                    getattr(p, "requires_grad", False),
+                    p,
+                )
+
         batch = run_vjp(sys=sys, jobs=jobs, node_attrs=node_attrs)
         g_tensor = batch.grads_per_source_tensor
         if g_tensor is not None:

--- a/tests/autoautograd/test_dec_energy_gradp.py
+++ b/tests/autoautograd/test_dec_energy_gradp.py
@@ -94,5 +94,5 @@ def test_vectorized_grad_matches_loop():
     P = AT.get_tensor([[0.0], [1.5]])
     E_vec, grad_vec = dec_energy_and_gradP_AT(P, spec)
     E_loop, grad_loop = dec_energy_and_gradP_loop(P, spec)
-    assert float(AT.get_tensor(E_vec)) == pytest.approx(float(AT.get_tensor(E_loop)))
+    assert float(E_vec) == pytest.approx(float(E_loop))
     assert AT.allclose(grad_vec, grad_loop)

--- a/tests/autoautograd/test_fluxspring_gradients.py
+++ b/tests/autoautograd/test_fluxspring_gradients.py
@@ -96,12 +96,12 @@ def test_fluxspring_gradients_match_fd_and_accumulate():
 
     psi_tick, loss = _forward(spec)
     g_edge, g_node = autograd.grad(loss, [edge_w, node_w])
-    exp_psi1_val = -0.1 * float(AT.get_tensor(edge_w)) * float(AT.get_tensor(node_w))
-    assert float(AT.get_tensor(psi_tick)[1]) == pytest.approx(exp_psi1_val)
+    exp_psi1_val = -0.1 * float(edge_w) * float(node_w)
+    assert float(psi_tick[1]) == pytest.approx(exp_psi1_val)
     assert g_edge is not None
     assert g_node is not None
-    g_edge_val = float(AT.get_tensor(g_edge))
-    g_node_val = float(AT.get_tensor(g_node))
+    g_edge_val = float(g_edge)
+    g_node_val = float(g_node)
 
     eps = 1e-4
 
@@ -109,9 +109,9 @@ def test_fluxspring_gradients_match_fd_and_accumulate():
         orig = float(param.data[0])
         with autograd.no_grad():
             param.data[0] = orig + eps
-            lp = float(AT.get_tensor(_compute_loss(spec)))
+            lp = float(_compute_loss(spec))
             param.data[0] = orig - eps
-            lm = float(AT.get_tensor(_compute_loss(spec)))
+            lm = float(_compute_loss(spec))
             param.data[0] = orig
         return (lp - lm) / (2 * eps)
 
@@ -122,8 +122,8 @@ def test_fluxspring_gradients_match_fd_and_accumulate():
 
     loss2 = _compute_loss(spec)
     autograd.grad(loss2, [edge_w, node_w])
-    g_edge_acc = float(AT.get_tensor(edge_w.grad))
-    g_node_acc = float(AT.get_tensor(node_w.grad))
+    g_edge_acc = float(edge_w.grad)
+    g_node_acc = float(node_w.grad)
     assert g_edge_acc == pytest.approx(2 * g_edge_val, rel=1e-6, abs=1e-6)
     assert g_node_acc == pytest.approx(2 * g_node_val, rel=1e-6, abs=1e-6)
 
@@ -135,8 +135,8 @@ def test_fluxspring_gradients_match_fd_and_accumulate():
     spec.nodes[1].ctrl.w = node_w
     loss3 = _compute_loss(spec)
     autograd.grad(loss3, [edge_w, node_w])
-    g_edge_new = float(AT.get_tensor(edge_w.grad))
-    g_node_new = float(AT.get_tensor(node_w.grad))
+    g_edge_new = float(edge_w.grad)
+    g_node_new = float(node_w.grad)
     assert g_edge_new == pytest.approx(g_edge_val, rel=1e-6, abs=1e-6)
     assert g_node_new == pytest.approx(g_node_val, rel=1e-6, abs=1e-6)
 

--- a/tests/autoautograd/test_fluxspring_params_grad.py
+++ b/tests/autoautograd/test_fluxspring_params_grad.py
@@ -91,4 +91,4 @@ def test_edge_face_params_gradients_and_dtype():
     grads = autograd.grad(loss, params)
     assert all(g is not None for g in grads)
     for g in grads:
-        assert float(AT.get_tensor(g)) == pytest.approx(2.0)
+        assert float(g) == pytest.approx(2.0)

--- a/tests/autoautograd/test_fluxspring_pump_tick.py
+++ b/tests/autoautograd/test_fluxspring_pump_tick.py
@@ -60,16 +60,15 @@ def test_pump_tick_injection_leak0():
     psi = AT.zeros(2)
     psi_next, _ = pump_tick(psi, spec, eta=0.0, external={0: AT.tensor(1.0)}, leak=0.0)
     assert psi_next.shape[0] == 2
-    assert float(AT.get_tensor(psi_next)[0]) == pytest.approx(1.0)
+    assert float(psi_next[0]) == pytest.approx(1.0)
 
 
 def test_pump_tick_leak_decay():
     spec = _make_spec()
     psi = AT.get_tensor([1.0, -1.0])
     psi_next, _ = pump_tick(psi, spec, eta=0.0, leak=0.2)
-    vals = AT.get_tensor(psi_next)
-    assert float(vals[0]) == pytest.approx(0.8)
-    assert float(vals[1]) == pytest.approx(-0.8)
+    assert float(psi_next[0]) == pytest.approx(0.8)
+    assert float(psi_next[1]) == pytest.approx(-0.8)
 
 
 def test_pump_tick_saturate():
@@ -77,9 +76,8 @@ def test_pump_tick_saturate():
     psi = AT.get_tensor([2.0, -2.0])
     sat = lambda x: AT.clip(x, -1.0, 1.0)
     psi_next, _ = pump_tick(psi, spec, eta=0.0, leak=0.0, saturate=sat)
-    vals = AT.get_tensor(psi_next)
-    assert float(vals[0]) == pytest.approx(1.0)
-    assert float(vals[1]) == pytest.approx(-1.0)
+    assert float(psi_next[0]) == pytest.approx(1.0)
+    assert float(psi_next[1]) == pytest.approx(-1.0)
 
 
 def test_pump_tick_lorentz():
@@ -90,10 +88,8 @@ def test_pump_tick_lorentz():
     psi_next, stats = pump_tick(psi, spec, eta=eta, lorentz_c=c)
     delta = stats["delta"]
     expected = psi + eta * (delta / AT.sqrt(1.0 - (psi / c) ** 2))
-    vals = AT.get_tensor(psi_next)
-    exp_vals = AT.get_tensor(expected)
-    assert float(vals[0]) == pytest.approx(float(exp_vals[0]))
-    assert float(vals[1]) == pytest.approx(float(exp_vals[1]))
+    assert float(psi_next[0]) == pytest.approx(float(expected[0]))
+    assert float(psi_next[1]) == pytest.approx(float(expected[1]))
 
 
 def test_pump_tick_norm_node():
@@ -102,10 +98,10 @@ def test_pump_tick_norm_node():
     eta = 1.0
     _, stats_off = pump_tick(psi, spec, eta=eta)
     _, stats_norm = pump_tick(psi, spec, eta=eta, norm="node")
-    delta_off = AT.get_tensor(stats_off["delta"])
-    delta_norm = AT.get_tensor(stats_norm["delta"])
-    q_off = AT.get_tensor(stats_off["q"])
-    q_norm = AT.get_tensor(stats_norm["q"])
+    delta_off = stats_off["delta"]
+    delta_norm = stats_norm["delta"]
+    q_off = stats_off["q"]
+    q_norm = stats_norm["q"]
     assert float(delta_norm[0]) == pytest.approx(float(delta_off[0]) / 2)
     assert float(delta_norm[1]) == pytest.approx(float(delta_off[1]) / 2)
     assert float(q_norm[0]) == pytest.approx(float(q_off[0]) / 2)

--- a/tests/autoautograd/test_param_version_rings.py
+++ b/tests/autoautograd/test_param_version_rings.py
@@ -67,7 +67,7 @@ def test_param_version_ring_snapshots():
 
     mat = harness.get_params_for_lineages(lids, ledger)
     assert mat.shape == (3, 1)
-    assert float(AT.get_tensor(mat[0, 0])) == pytest.approx(1.0)
+    assert float(mat[0, 0]) == pytest.approx(1.0)
 
     assert ledger.lineages() == tuple(lids)
     ledger.purge_through_lid(lids[1])
@@ -130,7 +130,7 @@ def test_param_version_ring_respects_stage_depth():
 
     mat = harness.get_params_for_lineages(lids[:2], ledger)
     idx = harness.param_labels.index("node[1].ctrl.w")
-    vals = AT.get_tensor(mat)[:, idx]
+    vals = mat[:, idx]
     assert float(vals[0]) == pytest.approx(1.0)
     assert float(vals[1]) == pytest.approx(2.0)
 

--- a/tests/autoautograd/test_premix_ring_histogram_loss.py
+++ b/tests/autoautograd/test_premix_ring_histogram_loss.py
@@ -49,6 +49,6 @@ def test_premix_ring_updates_and_hist_loss():
     assert rb is not None
     loss_lo = premix_histogram_loss(rb, band_idx=0, total_bands=2, tick_hz=tick_hz)
     loss_hi = premix_histogram_loss(rb, band_idx=1, total_bands=2, tick_hz=tick_hz)
-    loss_lo_f = float(AT.get_tensor(loss_lo).item())
-    loss_hi_f = float(AT.get_tensor(loss_hi).item())
+    loss_lo_f = float(loss_lo)
+    loss_hi_f = float(loss_hi)
     assert loss_lo_f < loss_hi_f

--- a/tests/autoautograd/test_ring_buffer_gradients.py
+++ b/tests/autoautograd/test_ring_buffer_gradients.py
@@ -48,4 +48,4 @@ def test_ring_buffer_propagates_gradients():
     loss = rb.buf.sum()
     grad = autograd.grad(loss, [param])[0]
     assert grad is not None
-    assert float(AT.get_tensor(grad)) != 0.0
+    assert float(grad) != 0.0

--- a/tests/autoautograd/test_spring_dt_thread.py
+++ b/tests/autoautograd/test_spring_dt_thread.py
@@ -79,14 +79,14 @@ def test_meta_loop_runner_moves_free_node():
     table = StateTable()
     round_node = _build_round(sys, table)
     runner = MetaLoopRunner(state_table=table)
-    x0 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[0])
-    y0 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[1])
-    z0 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[2])
+    x0 = float(sys.nodes[1].p[0])
+    y0 = float(sys.nodes[1].p[1])
+    z0 = float(sys.nodes[1].p[2])
     for _ in range(5):
         runner.run_round(round_node, dt=0.01, state_table=table)
-    x1 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[0])
-    y1 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[1])
-    z1 = float(AbstractTensor.get_tensor(sys.nodes[1].p)[2])
+    x1 = float(sys.nodes[1].p[0])
+    y1 = float(sys.nodes[1].p[1])
+    z1 = float(sys.nodes[1].p[2])
     assert not math.isclose(y0, y1)
     assert math.isclose(x0, x1, rel_tol=1e-6, abs_tol=1e-6)
     assert math.isclose(z0, z1, rel_tol=1e-6, abs_tol=1e-6)
@@ -129,12 +129,12 @@ def test_boundary_targets_clamp_x_and_z():
     table = StateTable()
     round_node = _build_round(sys, table)
     runner = MetaLoopRunner(state_table=table)
-    y0_in = float(AbstractTensor.get_tensor(sys.nodes[0].p)[1])
-    y0_out = float(AbstractTensor.get_tensor(sys.nodes[1].p)[1])
+    y0_in = float(sys.nodes[0].p[1])
+    y0_out = float(sys.nodes[1].p[1])
     for _ in range(5):
         runner.run_round(round_node, dt=0.01, state_table=table)
-    p_in = AbstractTensor.get_tensor(sys.nodes[0].p)
-    p_out = AbstractTensor.get_tensor(sys.nodes[1].p)
+    p_in = sys.nodes[0].p
+    p_out = sys.nodes[1].p
     assert math.isclose(float(p_in[0]), 1.0, rel_tol=1e-6, abs_tol=1e-3)
     assert math.isclose(float(p_out[2]), 2.0, rel_tol=1e-6, abs_tol=1e-3)
     assert math.isclose(float(p_in[1]), y0_in, rel_tol=1e-6, abs_tol=1e-6)
@@ -147,9 +147,9 @@ def test_spectral_inertia_reduces_velocity_norm():
     hist = [AT.tensor([math.sin(dt * i), math.cos(dt * i)]) for i in range(128)]
     resp, _, _ = spectral_inertia(hist, dt)
     v_last = hist[-1] - hist[-2]
-    energy_no = float(AT.get_tensor((v_last * v_last).sum()).item())
+    energy_no = float((v_last * v_last).sum())
     diff = v_last - resp * 1e-4
-    energy_damped = float(AT.get_tensor((diff * diff).sum()).item())
+    energy_damped = float((diff * diff).sum())
     assert energy_damped < energy_no
 
 
@@ -159,8 +159,8 @@ def test_spectral_inertia_passthrough_with_short_history():
     # Fewer samples than the minimum FFT window should yield a zero response
     hist = [AT.tensor([0.0, 0.0]) for _ in range(10)]
     resp, J, bands = spectral_inertia(hist, dt)
-    assert AT.get_tensor(resp).abs().sum().item() == 0.0
-    assert AT.get_tensor(J).abs().sum().item() == 0.0
+    assert resp.abs().sum().item() == 0.0
+    assert J.abs().sum().item() == 0.0
     assert bands == []
 
 
@@ -173,7 +173,7 @@ def test_threaded_engine_steps_independently():
     def capture():
         return {
             "pos": [
-                AbstractTensor.get_tensor(n.p).tolist() for n in sys.nodes.values()
+                n.p.tolist() for n in sys.nodes.values()
             ]
         }
 


### PR DESCRIPTION
## Summary
- Add debug logging of each node's parameter before batched VJP execution in `SlotBackpropQueue.process_slot`
- Simplify logging by removing unnecessary tensor conversion
- Drop redundant `AT.get_tensor` calls from autoautograd tests

## Testing
- `pytest tests/autoautograd -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5db056d04832a868302c6d7df4568