### PR TITLE
Fix noise frame collection in spectral routing demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -268,7 +268,7 @@ def generate_signals(
     for _ in range(frames):
         noise = AT.tensor(rng.standard_normal((len(bands), win)))
         mix = sinusoid_sum + 0.1 * noise
-    noise_frames.append([mix[i] for i in range(len(bands))])
+        noise_frames.append([mix[i] for i in range(len(bands))])
     return sine_chunks, noise_frames
 
 

--- a/tests/autoautograd/test_fluxspring_gradients.py
+++ b/tests/autoautograd/test_fluxspring_gradients.py
@@ -6,6 +6,7 @@ from src.common.tensors.autoautograd.fluxspring.demo_spectral_routing import (
     build_spec,
     SpectralCfg,
     SpectralMetrics,
+    generate_signals,
 )
 from src.common.tensors.autoautograd.fluxspring.fs_types import (
     FluxSpringSpec,
@@ -183,4 +184,13 @@ def test_register_learnable_params_preserves_gradients():
     loss = (w * AT.tensor(2.0)) ** 2
     g = autograd.grad(loss, [w])[0]
     assert g is not None
+
+
+def test_generate_signals_returns_entries_per_frame():
+    bands = [[20, 40], [40, 60]]
+    win = 4
+    tick_hz = 400.0
+    frames = 3
+    _, noise_frames = generate_signals(bands, win, tick_hz, frames)
+    assert len(noise_frames) == frames
 


### PR DESCRIPTION
## Summary
- collect noise frames for each iteration in `generate_signals`
- add regression test ensuring noise frame count matches frames

## Testing
- `pytest tests/autoautograd/test_fluxspring_gradients.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5f2ae1e14832ab2ef4b1294cffcb8