### PR TITLE
Truncate union_ids in zero-grad warning

### DIFF
--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -568,9 +568,10 @@ def run_batched_vjp(
         if zero_all or zero_param:
             job_ids = tuple(j.job_id for j in jobs)
             logger.debug(
-                "run_batched_vjp: WARNING zero grads job_ids=%s union_ids=%s",
+                "run_batched_vjp: WARNING zero grads job_ids=%s union_ids_first=%s union_ids_len=%d",
                 job_ids,
-                union_ids,
+                tuple(union_ids[:5]),
+                len(union_ids),
             )
 
     g_stack = g_all

--- a/tests/test_zero_grad_logging.py
+++ b/tests/test_zero_grad_logging.py
@@ -1,0 +1,32 @@
+import logging
+import src.common.tensors.autoautograd.whiteboard_runtime as wr
+from src.common.tensors.abstraction import AbstractTensor
+
+
+class _Node:
+    def __init__(self):
+        self.sphere = AbstractTensor.zeros(1, float)
+        self.version = 0
+
+
+class _Sys:
+    def __init__(self, n):
+        self.nodes = {i: _Node() for i in range(n)}
+
+
+def test_zero_grad_warning_truncates_union_ids(caplog):
+    sys = _Sys(10)
+    job = wr._WBJob(
+        job_id="j",
+        op=None,
+        src_ids=tuple(range(10)),
+        residual=None,
+        fn=lambda x, residual=None, **kw: x,
+    )
+    with caplog.at_level(logging.DEBUG):
+        wr.run_batched_vjp(sys=sys, jobs=(job,))
+    messages = [r.message for r in caplog.records if "WARNING zero grads" in r.message]
+    assert messages, "expected zero-grads warning"
+    msg = messages[0]
+    assert "union_ids_len=10" in msg
+    assert "union_ids_first=(0, 1, 2, 3, 4)" in msg


### PR DESCRIPTION
## Summary
- Log only the first few `union_ids` and the total count for zero-grad warnings
- Add regression test ensuring union ID logging is truncated

## Testing
- `pytest tests/test_whiteboard_runtime_none_grads.py tests/test_spring_async_toy_tensor_glist.py tests/test_grad_validation.py tests/test_scheduling_module.py tests/autoautograd/test_slot_backprop_queue.py tests/test_zero_grad_logging.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5f6cc1990832aa1b0f19ff5bbc6bd