### PR TITLE
Ensure reduction ops return ndarray and preserve autograd

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -531,9 +531,12 @@ class AbstractTensor:
 
     def min(self, dim=None, keepdim: bool = False):
         """Return the minimum of the tensor along the specified dimension(s)."""
+        finalize = AbstractTensor._pre_autograd(
+            "min", [self], params={"axis": dim, "keepdim": keepdim}
+        )
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.min_(dim=dim, keepdim=keepdim)
-        return result
+        return finalize(result)
 
     def argmin(self, dim: Optional[int] = None, keepdim: bool = False):
         """Return the indices of the minimum values along an axis."""

--- a/src/common/tensors/abstraction_methods/reduction.py
+++ b/src/common/tensors/abstraction_methods/reduction.py
@@ -2,17 +2,34 @@ from __future__ import annotations
 
 from typing import Optional
 
+from ..abstraction import AbstractTensor
+
 
 def max(self, dim=None, keepdim: bool = False):
     """Return the maximum of the tensor along the specified dimension(s)."""
-    return self.max_(dim=dim, keepdim=keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "max", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.max_(dim=dim, keepdim=keepdim)
+    return finalize(result)
 
 
 def argmax(self, dim: Optional[int] = None, keepdim: bool = False):
     """Return the indices of the maximum values along an axis."""
-    return self.argmax_(dim, keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "argmax", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.argmax_(dim, keepdim)
+    return finalize(result)
 
 
 def prod(self, dim=None, keepdim: bool = False):
     """Return the product of tensor elements along a dimension."""
-    return self.prod_(dim=dim, keepdim=keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "prod", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.prod_(dim=dim, keepdim=keepdim)
+    return finalize(result)

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -540,6 +540,64 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
         "notes": "Same broadcasting mechanics as `sum`, scaled by 1/N.",
         "tags": ["reduction", "linear"],
     },
+    "prod": {
+        "arity": "unary",
+        "signature": "y = prod(x)",
+        "latex": r"y = \prod_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = prod(x, keepdim=True); gx = expand_to(g * y / x, x.shape)"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.prod(x, keepdim=True); "
+                "return expand_to(g * y / x, x.shape)"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Gradient of product; undefined when x contains zeros.",
+        "tags": ["reduction", "multiplicative"],
+    },
+    "max": {
+        "arity": "unary",
+        "signature": "y = max(x)",
+        "latex": r"y = \max_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = max(x, keepdim=True); m = where(x==y, 1, 0); c = sum(m, keepdim=True); gx = expand_to(g, x.shape) * m / c"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.max(x, keepdim=True); "
+                "m = AbstractTensor.where(x==y, 1, 0); "
+                "c = AbstractTensor.sum(m, keepdim=True); "
+                "return expand_to(g, x.shape) * m / c"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Split gradients equally among maximal elements.",
+        "tags": ["reduction", "nonsmooth"],
+    },
+    "min": {
+        "arity": "unary",
+        "signature": "y = min(x)",
+        "latex": r"y = \min_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = min(x, keepdim=True); m = where(x==y, 1, 0); c = sum(m, keepdim=True); gx = expand_to(g, x.shape) * m / c"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.min(x, keepdim=True); "
+                "m = AbstractTensor.where(x==y, 1, 0); "
+                "c = AbstractTensor.sum(m, keepdim=True); "
+                "return expand_to(g, x.shape) * m / c"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Split gradients equally among minimal elements.",
+        "tags": ["reduction", "nonsmooth"],
+    },
     "matmul": {
         "arity": "binary",
         "signature": "Y = matmul(A, B)  # ... x m x k  @  ... x k x n",

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -432,7 +432,7 @@ class NumPyTensorOperations(AbstractTensor):
 
     def max_(self, tensor=None, dim=None, keepdim=False):
         data = self._AbstractTensor__unwrap(tensor if tensor is not None else self.data)
-        return np.max(data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.max(data, axis=dim, keepdims=keepdim))
 
     def long_cast_(self, tensor):
         return self._AbstractTensor__unwrap(tensor).astype(np.int64)
@@ -700,18 +700,18 @@ class NumPyTensorOperations(AbstractTensor):
         return self.data.size
 
     def mean_(self, dim=None, keepdim=False):
-        return np.mean(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.mean(self.data, axis=dim, keepdims=keepdim))
 
     def sum_(self, dim=None, keepdim=False):
-        return np.sum(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.sum(self.data, axis=dim, keepdims=keepdim))
 
     def prod_(self, dim=None, keepdim=False):
         """Return the product of tensor elements along a dimension."""
         import numpy as np
-        return np.prod(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.prod(self.data, axis=dim, keepdims=keepdim))
 
     def min_(self, dim=None, keepdim=False):
-        return np.min(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.min(self.data, axis=dim, keepdims=keepdim))
 
     def pow_(self, exponent: float):
         return np.power(self.data, exponent)

--- a/tests/autoautograd/test_reduction_autograd.py
+++ b/tests/autoautograd/test_reduction_autograd.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
+
+@pytest.mark.parametrize(
+    "op,expected",
+    [
+        ("sum", np.array([1.0, 1.0, 1.0])),
+        ("mean", np.array([1.0 / 3] * 3)),
+        ("prod", np.array([6.0, 3.0, 2.0])),
+        ("max", np.array([0.0, 0.0, 1.0])),
+        ("min", np.array([1.0, 0.0, 0.0])),
+    ],
+)
+def test_reduction_gradients_no_scalar_leak(op, expected):
+    x = T.tensor([1.0, 2.0, 3.0])
+    x.requires_grad_(True)
+    y = getattr(x, op)()
+    assert isinstance(y.data, np.ndarray)
+    assert y.numel() == 1
+    y.backward()
+    assert x.grad is not None
+    np.testing.assert_allclose(x.grad.data, expected)


### PR DESCRIPTION
## Summary
- Wrap NumPy reduction outputs so max, mean, sum, prod, and min always return `np.ndarray`
- Route `max`, `prod`, and `argmax` through AbstractTensor wrappers and add autograd tracking for `min`
- Register backward formulas for reduction `prod`, `max`, and `min`
- Add regression tests exercising reduction gradients to prevent scalar leakage
- Wrap reduction helpers with autograd pre/post hooks so operations are recorded

## Testing
- `pytest tests/autoautograd/test_reduction_autograd.py tests/test_tensor_grad.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6079a965c832aa2fa8ddefdbf595a