### PR TITLE
Ensure reduction ops return ndarray and preserve autograd

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -512,7 +512,10 @@ class AbstractTensor:
         )
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.mean_(dim=dim, keepdim=keepdim)
-        return finalize(result)
+        result = finalize(result)
+        if getattr(result.data, "shape", ()) == ():
+            return AbstractScalar(result)
+        return result
 
     def sum(self, dim=None, keepdim: bool = False):
         """Return the sum of the tensor along the specified dimension(s)."""
@@ -521,7 +524,10 @@ class AbstractTensor:
         )
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.sum_(dim=dim, keepdim=keepdim)
-        return finalize(result)
+        result = finalize(result)
+        if getattr(result.data, "shape", ()) == ():
+            return AbstractScalar(result)
+        return result
 
     def cumsum(self, dim: int = 0) -> "AbstractTensor":
         """Return the cumulative sum of the tensor along a dimension."""
@@ -531,13 +537,15 @@ class AbstractTensor:
 
     def min(self, dim=None, keepdim: bool = False):
         """Return the minimum of the tensor along the specified dimension(s)."""
+        finalize = AbstractTensor._pre_autograd(
+            "min", [self], params={"axis": dim, "keepdim": keepdim}
+        )
         result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
         result.data = self.min_(dim=dim, keepdim=keepdim)
+        result = finalize(result)
+        if getattr(result.data, "shape", ()) == ():
+            return AbstractScalar(result)
         return result
-
-    def argmin(self, dim: Optional[int] = None, keepdim: bool = False):
-        """Return the indices of the minimum values along an axis."""
-        return self.argmin_(dim, keepdim)
     # --- Backend hooks for reductions (must be implemented by backends) ---
     def mean_(self, dim=None, keepdim: bool = False):
         raise NotImplementedError(f"{self.__class__.__name__} must implement mean_() with keepdim.")
@@ -2393,6 +2401,22 @@ class AbstractTensor:
         raise NotImplementedError(f"{self.__class__.__name__} must implement nbytes_()")
 
 
+class AbstractScalar(AbstractTensor):
+    """Marker mixin for zero-dimensional tensors produced by reductions."""
+
+    def __new__(cls, tensor: "AbstractTensor"):
+        if getattr(getattr(tensor, "data", None), "shape", ()) != ():
+            raise ValueError("AbstractScalar requires a zero-dimensional tensor")
+        if not isinstance(tensor, AbstractScalar):
+            scalar_cls = type(
+                f"{tensor.__class__.__name__}Scalar",
+                (tensor.__class__, cls),
+                {},
+            )
+            tensor.__class__ = scalar_cls
+        return tensor
+
+
 class AbstractF:
     """
     Functional API for advanced tensor operations (e.g., interpolation).
@@ -2596,6 +2620,7 @@ from .abstraction_methods.creation import (
 from .abstraction_methods.reduction import (
     max as reduction_max,
     argmax as reduction_argmax,
+    argmin as reduction_argmin,
     prod as reduction_prod,
 )
 from .abstraction_methods.indexing import (
@@ -2926,6 +2951,7 @@ _bind_and_wrap({
     "randint_like": randint_like,
     "max": reduction_max,
     "argmax": reduction_argmax,
+    "argmin": reduction_argmin,
     "prod": reduction_prod,
     "to": type_to,
     "astype": type_astype,

--- a/src/common/tensors/abstraction_methods/reduction.py
+++ b/src/common/tensors/abstraction_methods/reduction.py
@@ -2,17 +2,54 @@ from __future__ import annotations
 
 from typing import Optional
 
+from ..abstraction import AbstractTensor, AbstractScalar
+
+
+def _wrap_scalar(result):
+    if getattr(result.data, "shape", ()) == ():
+        return AbstractScalar(result)
+    return result
+
 
 def max(self, dim=None, keepdim: bool = False):
     """Return the maximum of the tensor along the specified dimension(s)."""
-    return self.max_(dim=dim, keepdim=keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "max", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.max_(dim=dim, keepdim=keepdim)
+    result = finalize(result)
+    return _wrap_scalar(result)
 
 
 def argmax(self, dim: Optional[int] = None, keepdim: bool = False):
     """Return the indices of the maximum values along an axis."""
-    return self.argmax_(dim, keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "argmax", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.argmax_(dim, keepdim)
+    result = finalize(result)
+    return _wrap_scalar(result)
+
+
+def argmin(self, dim: Optional[int] = None, keepdim: bool = False):
+    """Return the indices of the minimum values along an axis."""
+    finalize = AbstractTensor._pre_autograd(
+        "argmin", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.argmin_(dim, keepdim)
+    result = finalize(result)
+    return _wrap_scalar(result)
 
 
 def prod(self, dim=None, keepdim: bool = False):
     """Return the product of tensor elements along a dimension."""
-    return self.prod_(dim=dim, keepdim=keepdim)
+    finalize = AbstractTensor._pre_autograd(
+        "prod", [self], params={"axis": dim, "keepdim": keepdim}
+    )
+    result = type(self)(track_time=self.track_time, tape=getattr(self, "_tape", None))
+    result.data = self.prod_(dim=dim, keepdim=keepdim)
+    result = finalize(result)
+    return _wrap_scalar(result)

--- a/src/common/tensors/backward_registry.py
+++ b/src/common/tensors/backward_registry.py
@@ -540,6 +540,64 @@ BACKWARD_RULES: Dict[str, Dict[str, Any]] = {
         "notes": "Same broadcasting mechanics as `sum`, scaled by 1/N.",
         "tags": ["reduction", "linear"],
     },
+    "prod": {
+        "arity": "unary",
+        "signature": "y = prod(x)",
+        "latex": r"y = \prod_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = prod(x, keepdim=True); gx = expand_to(g * y / x, x.shape)"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.prod(x, keepdim=True); "
+                "return expand_to(g * y / x, x.shape)"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Gradient of product; undefined when x contains zeros.",
+        "tags": ["reduction", "multiplicative"],
+    },
+    "max": {
+        "arity": "unary",
+        "signature": "y = max(x)",
+        "latex": r"y = \max_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = max(x, keepdim=True); m = where(x==y, 1, 0); c = sum(m, keepdim=True); gx = expand_to(g, x.shape) * m / c"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.max(x, keepdim=True); "
+                "m = AbstractTensor.where(x==y, 1, 0); "
+                "c = AbstractTensor.sum(m, keepdim=True); "
+                "return expand_to(g, x.shape) * m / c"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Split gradients equally among maximal elements.",
+        "tags": ["reduction", "nonsmooth"],
+    },
+    "min": {
+        "arity": "unary",
+        "signature": "y = min(x)",
+        "latex": r"y = \min_{i \in \mathcal{I}} x_i",
+        "backward": {
+            "x": "y = min(x, keepdim=True); m = where(x==y, 1, 0); c = sum(m, keepdim=True); gx = expand_to(g, x.shape) * m / c"
+        },
+        "python": {
+            "parameters": ["g", "x"],
+            "body": (
+                "y = AbstractTensor.min(x, keepdim=True); "
+                "m = AbstractTensor.where(x==y, 1, 0); "
+                "c = AbstractTensor.sum(m, keepdim=True); "
+                "return expand_to(g, x.shape) * m / c"
+            )
+        },
+        "domain": "x: any real",
+        "notes": "Split gradients equally among minimal elements.",
+        "tags": ["reduction", "nonsmooth"],
+    },
     "matmul": {
         "arity": "binary",
         "signature": "Y = matmul(A, B)  # ... x m x k  @  ... x k x n",

--- a/src/common/tensors/numpy_backend.py
+++ b/src/common/tensors/numpy_backend.py
@@ -133,11 +133,11 @@ class NumPyTensorOperations(AbstractTensor):
     def argmax_(self, dim=None, keepdim=False):
         arr = self.data
         if dim is None:
-            return int(np.argmax(arr))
+            return np.asarray(np.argmax(arr))
         idx = np.argmax(arr, axis=dim)
         if keepdim:
-            return np.expand_dims(idx, axis=dim)
-        return idx
+            idx = np.expand_dims(idx, axis=dim)
+        return np.asarray(idx)
     def where_(self, x, y):
         import numpy as np
         x = x.data if isinstance(x, AbstractTensor) else x
@@ -432,7 +432,7 @@ class NumPyTensorOperations(AbstractTensor):
 
     def max_(self, tensor=None, dim=None, keepdim=False):
         data = self._AbstractTensor__unwrap(tensor if tensor is not None else self.data)
-        return np.max(data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.max(data, axis=dim, keepdims=keepdim))
 
     def long_cast_(self, tensor):
         return self._AbstractTensor__unwrap(tensor).astype(np.int64)
@@ -700,18 +700,18 @@ class NumPyTensorOperations(AbstractTensor):
         return self.data.size
 
     def mean_(self, dim=None, keepdim=False):
-        return np.mean(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.mean(self.data, axis=dim, keepdims=keepdim))
 
     def sum_(self, dim=None, keepdim=False):
-        return np.sum(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.sum(self.data, axis=dim, keepdims=keepdim))
 
     def prod_(self, dim=None, keepdim=False):
         """Return the product of tensor elements along a dimension."""
         import numpy as np
-        return np.prod(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.prod(self.data, axis=dim, keepdims=keepdim))
 
     def min_(self, dim=None, keepdim=False):
-        return np.min(self.data, axis=dim, keepdims=keepdim)
+        return np.asarray(np.min(self.data, axis=dim, keepdims=keepdim))
 
     def pow_(self, exponent: float):
         return np.power(self.data, exponent)
@@ -753,7 +753,13 @@ class NumPyTensorOperations(AbstractTensor):
         return np.take(tensor, idx, axis=dim)
 
     def argmin_(self, dim=None, keepdim=False):
-        return np.argmin(self.data, axis=dim, keepdims=keepdim)
+        arr = self.data
+        if dim is None:
+            return np.asarray(np.argmin(arr))
+        idx = np.argmin(arr, axis=dim)
+        if keepdim:
+            idx = np.expand_dims(idx, axis=dim)
+        return np.asarray(idx)
 
     def nbytes_(self) -> int:
         return int(self.data.nbytes)

--- a/tests/autoautograd/test_reduction_autograd.py
+++ b/tests/autoautograd/test_reduction_autograd.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+from src.common.tensors.numpy_backend import NumPyTensorOperations as T
+from src.common.tensors.abstraction import AbstractScalar
+
+@pytest.mark.parametrize(
+    "op,expected",
+    [
+        ("sum", np.array([1.0, 1.0, 1.0])),
+        ("mean", np.array([1.0 / 3] * 3)),
+        ("prod", np.array([6.0, 3.0, 2.0])),
+        ("max", np.array([0.0, 0.0, 1.0])),
+        ("min", np.array([1.0, 0.0, 0.0])),
+    ],
+)
+def test_reduction_gradients_no_scalar_leak(op, expected):
+    x = T.tensor([1.0, 2.0, 3.0])
+    x.requires_grad_(True)
+    y = getattr(x, op)()
+    assert isinstance(y, AbstractScalar)
+    assert isinstance(y.data, np.ndarray)
+    assert y.numel() == 1
+    y.backward()
+    assert x.grad is not None
+    np.testing.assert_allclose(x.grad.data, expected)
+
+
+def test_arg_reductions_wrap_scalar():
+    x = T.tensor([1.0, 2.0, 3.0])
+    for op in ("argmax", "argmin"):
+        y = getattr(x, op)()
+        assert isinstance(y, AbstractScalar)
+        assert isinstance(y.data, np.ndarray)
+        assert y.numel() == 1


### PR DESCRIPTION
## Summary
- Introduce `AbstractScalar` wrapper for zero-dimensional tensors
- Wrap scalar results from reductions (`mean`, `sum`, `min`, `max`, `prod`, `argmax`, `argmin`) in `AbstractScalar`
- Ensure NumPy backend `argmax_` and `argmin_` always yield `np.ndarray`
- Add tests verifying scalar reductions return `AbstractScalar` and propagate gradients

## Testing
- `pytest tests/autoautograd/test_reduction_autograd.py tests/test_tensor_grad.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6079a965c832aa2fa8ddefdbf595a