### PR TITLE
Ensure backward rules coerce scalar inputs

### DIFF
--- a/tests/test_backward_registry.py
+++ b/tests/test_backward_registry.py
@@ -1,16 +1,20 @@
 import numpy as np
+import pytest
 
-from src.common.tensors.abstraction import get_backward_tool
-from src.common.tensors.backward import BackwardRegistry
+from src.common.tensors.abstraction import AbstractTensor, get_backward_tool
+from src.common.tensors.backward import BackwardRegistry, BACKWARD_REGISTRY
 from src.common.tensors.backward_registry import T as transpose_helper
 from src.common.tensors.numpy_backend import NumPyTensorOperations as T
 
 
 def test_get_backward_tool_add():
     tool = get_backward_tool(['add'])
-    g1, g2 = tool(np.array([1.0, 2.0]), np.array([3.0, 3.0]), np.array([4.0, 5.0]))
-    assert np.allclose(g1, np.array([1.0, 2.0]))
-    assert np.allclose(g2, np.array([1.0, 2.0]))
+    g = T.tensor([1.0, 2.0])
+    x = T.tensor([3.0, 3.0])
+    y = T.tensor([4.0, 5.0])
+    g1, g2 = tool(g, x, y)
+    assert np.allclose(g1.data, np.array([1.0, 2.0]))
+    assert np.allclose(g2.data, np.array([1.0, 2.0]))
 
 
 def test_backward_pipeline_sequence():
@@ -24,7 +28,9 @@ def test_backward_pipeline_sequence():
     reg.register('f1', f1)
     reg.register('f2', f2)
     pipeline = reg.build(['f1', 'f2'])
-    assert pipeline(3) == 8
+    result = pipeline(3)
+    assert isinstance(result, AbstractTensor)
+    assert np.allclose(result.data, 8)
 
 
 def test_T_handles_1d_input():
@@ -32,3 +38,20 @@ def test_T_handles_1d_input():
     y = transpose_helper(x)
     assert y.shape == (3, 1)
     assert np.allclose(y.data, np.array([[1.0], [2.0], [3.0]]))
+
+
+def test_backward_wraps_scalar_inputs():
+    bw_add = BACKWARD_REGISTRY._methods["add"]
+    x = AbstractTensor.tensor([1.0, 2.0])
+    gx, gy = bw_add(1.0, x, 3.0)
+    assert isinstance(gx, AbstractTensor)
+    assert isinstance(gy, AbstractTensor)
+    assert np.allclose(gx.data, np.array([1.0, 1.0]))
+    assert np.allclose(gy.data, np.array(1.0))
+
+
+def test_backward_rejects_non_tensor_inputs():
+    bw_add = BACKWARD_REGISTRY._methods["add"]
+    x = AbstractTensor.tensor([1.0, 2.0])
+    with pytest.raises(TypeError):
+        bw_add(1.0, x, [1, 2])


### PR DESCRIPTION
## Summary
- Safeguard backward-function dispatch by converting scalar inputs to tensors and rejecting unsupported types
- Wrap registry functions to apply the coercion before execution
- Test scalar wrapping and TypeError diagnostics for non-tensor inputs

## Testing
- `pytest tests/test_backward_registry.py -q`
- `pytest tests/test_autograd_homemade.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c616d83f10832aaec394d3cf6903ff