### PR TITLE
Fix missing gradients in spectral routing demo

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -584,8 +584,11 @@ def train_routing(
                 )
                 res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
                 if res is not None:
-                    g = getattr(res, "grads_per_source_tensor", None)
-                    if g is None or not bool(AT.get_tensor(g).any()):
+                    g_src = getattr(res, "grads_per_source_tensor", None)
+                    g_par = getattr(res, "param_grads_tensor", None)
+                    have_src = (g_src is not None and bool(AT.get_tensor(g_src).any()))
+                    have_par = (g_par is not None and bool(AT.get_tensor(g_par).any()))
+                    if not (have_src or have_par):
                         raise RuntimeError("whiteboard op produced no gradients")
                     ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
             tick += 1
@@ -619,8 +622,11 @@ def train_routing(
             )
             res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
             if res is not None:
-                g = getattr(res, "grads_per_source_tensor", None)
-                if g is None or not bool(AT.get_tensor(g).any()):
+                g_src = getattr(res, "grads_per_source_tensor", None)
+                g_par = getattr(res, "param_grads_tensor", None)
+                have_src = (g_src is not None and bool(AT.get_tensor(g_src).any()))
+                have_par = (g_par is not None and bool(AT.get_tensor(g_par).any()))
+                if not (have_src or have_par):
                     raise RuntimeError("whiteboard op produced no gradients")
                 ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1
@@ -637,8 +643,11 @@ def train_routing(
             )
             res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
             if res is not None:
-                g = getattr(res, "grads_per_source_tensor", None)
-                if g is None or not bool(AT.get_tensor(g).any()):
+                g_src = getattr(res, "grads_per_source_tensor", None)
+                g_par = getattr(res, "param_grads_tensor", None)
+                have_src = (g_src is not None and bool(AT.get_tensor(g_src).any()))
+                have_par = (g_par is not None and bool(AT.get_tensor(g_par).any()))
+                if not (have_src or have_par):
                     raise RuntimeError("whiteboard op produced no gradients")
                 ctx.log_buf.append({"tick": AT.tensor([float(mature_tick)])})
         tick += 1

--- a/src/common/tensors/autoautograd/whiteboard_runtime.py
+++ b/src/common/tensors/autoautograd/whiteboard_runtime.py
@@ -210,7 +210,7 @@ def run_op_and_grads_cached(
             job_id=f"{op_name}:{tuple(src_ids)}",
             op=None,
             src_ids=tuple(int(i) for i in src_ids),
-            residual=residual,
+            residual=(1.0 if residual is None else residual),
             param_lens=tuple(int(l) for l in (param_lens or [])),
             fn=_route_fn,
         )
@@ -244,7 +244,7 @@ def run_op_and_grads_cached(
             job_id=f"{op_name}:{tuple(src_ids)}",
             op=None,
             src_ids=tuple(int(i) for i in src_ids),
-            residual=residual,
+            residual=(1.0 if residual is None else residual),
             param_lens=tuple(win_len for _ in src_ids),
             fn=_fft_fn,
         )


### PR DESCRIPTION
## Summary
- default to unit residual in custom whiteboard ops so VJP never flattens
- allow `train_routing` to accept parameter-only gradients

## Testing
- `pytest tests/test_whiteboard_runtime_none_grads.py tests/test_gather_and_param_grads.py tests/test_zero_grad_logging.py tests/test_whiteboard_cache.py tests/test_grad_validation.py`

------
https://chatgpt.com/codex/tasks/task_e_68c61e6b0f60832aa10cf675ec56caaf