### PR TITLE
Enable autograd probe logging in whiteboard runtime

### DIFF
--- a/tests/test_whiteboard_probes_logging.py
+++ b/tests/test_whiteboard_probes_logging.py
@@ -1,0 +1,29 @@
+import logging
+import src.common.tensors.autoautograd.whiteboard_runtime as wr
+from src.common.tensors.abstraction import AbstractTensor
+
+
+class _Node:
+    def __init__(self):
+        self.sphere = AbstractTensor.zeros(1, float)
+        self.version = 0
+
+
+class _Sys:
+    def __init__(self):
+        self.nodes = {0: _Node()}
+
+
+def test_whiteboard_runs_probes(monkeypatch, caplog):
+    sys = _Sys()
+    job = wr._WBJob(
+        job_id="j",
+        op=None,
+        src_ids=(0,),
+        residual=AbstractTensor.ones(1),
+        fn=lambda x, residual=None, **kw: x,
+    )
+    monkeypatch.setenv("WHITEBOARD_PROBES", "1")
+    with caplog.at_level(logging.INFO):
+        wr.run_batched_vjp(sys=sys, jobs=(job,))
+    assert any("running autograd probes" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- integrate autograd probe utilities into `run_batched_vjp`
- add test verifying probe logging when `WHITEBOARD_PROBES` is set

## Testing
- `pytest tests/test_whiteboard_runtime_none_grads.py tests/test_zero_grad_logging.py tests/test_grad_validation.py tests/test_gather_and_param_grads.py tests/test_whiteboard_cache.py tests/test_spring_async_toy_tensor_glist.py tests/test_scheduling_module.py tests/test_geometry_residual_no_impulse.py tests/autoautograd/test_slot_backprop_queue.py tests/test_whiteboard_probes_logging.py`
- `pytest tests/test_pool_whiteboard_scheduler.py::test_full_pipeline_with_tensor_pool -vv` *(fails: assert 21.0 == 0.0 ± 1.0e-12)*
- `pytest tests/test_pool_whiteboard_scheduler.py::test_cache_hits_with_tensor_pool -vv` *(fails: IndexError: tuple index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d5babf4832ab784662f70ec64f1