### PR TITLE
Support per-job param schemas in whiteboard VJP

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -582,7 +582,7 @@ def train_routing(
                 sys = SimpleNamespace(
                     nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
                 )
-                res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
+                res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
                 if res is not None:
                     g_src = getattr(res, "grads_per_source_tensor", None)
                     g_par = getattr(res, "param_grads_tensor", None)
@@ -620,7 +620,7 @@ def train_routing(
             sys = SimpleNamespace(
                 nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
             if res is not None:
                 g_src = getattr(res, "grads_per_source_tensor", None)
                 g_par = getattr(res, "param_grads_tensor", None)
@@ -641,7 +641,7 @@ def train_routing(
             sys = SimpleNamespace(
                 nodes={i: SimpleNamespace(p=w.params[mature_slot]) for i, w in enumerate(ctx.wheels)}
             )
-            res = ctx.bp_queue.process_slot(mature_slot, sys=sys, node_attrs=FLUX_PARAM_SCHEMA)
+            res = ctx.bp_queue.process_slot(mature_slot, sys=sys)
             if res is not None:
                 g_src = getattr(res, "grads_per_source_tensor", None)
                 g_par = getattr(res, "param_grads_tensor", None)

--- a/tests/autoautograd/test_param_schema_union.py
+++ b/tests/autoautograd/test_param_schema_union.py
@@ -1,0 +1,50 @@
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp, _WBJob
+import pytest
+
+
+class _Node:
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            setattr(self, k, AT.tensor(v))
+        self.version = 0
+
+
+class _Sys:
+    def __init__(self):
+        self.nodes = {
+            0: _Node(alpha=1.0, w=2.0, b=3.0, kappa=0.0, l0=0.0),
+            1: _Node(alpha=0.0, w=0.0, b=0.0, kappa=4.0, l0=5.0),
+        }
+
+
+def test_param_schema_union_grads():
+    sys = _Sys()
+    job1 = _WBJob(
+        job_id="j1",
+        op=None,
+        src_ids=(0,),
+        residual=AT.tensor(1.0),
+        fn=lambda a, w, b: a * w + b,
+        param_schema=("alpha", "w", "b"),
+    )
+    job2 = _WBJob(
+        job_id="j2",
+        op=None,
+        src_ids=(1,),
+        residual=AT.tensor(1.0),
+        fn=lambda k, l: k * l,
+        param_schema=("kappa", "l0"),
+    )
+    res = run_batched_vjp(sys=sys, jobs=(job1, job2))
+    g = AT.get_tensor(res.grads_per_source_tensor)
+    assert float(g[0][0].item()) == pytest.approx(4.0)
+    assert float(g[0][1].item()) == pytest.approx(2.0)
+    assert float(g[0][2].item()) == pytest.approx(2.0)
+    assert float(g[0][3].item()) == pytest.approx(0.0)
+    assert float(g[0][4].item()) == pytest.approx(0.0)
+    assert float(g[1][0].item()) == pytest.approx(0.0)
+    assert float(g[1][1].item()) == pytest.approx(0.0)
+    assert float(g[1][2].item()) == pytest.approx(0.0)
+    assert float(g[1][3].item()) == pytest.approx(10.0)
+    assert float(g[1][4].item()) == pytest.approx(8.0)

--- a/tests/test_grad_validation.py
+++ b/tests/test_grad_validation.py
@@ -30,8 +30,8 @@ def test_grads_per_source_tensor_matches_reduction():
     import types
 
     sys = _Sys2()
-    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
-    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None, param_schema=("sphere",))
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None, param_schema=("sphere",))
     res = run_batched_vjp(sys=sys, jobs=(j0, j1))
     g = res.grads_per_source_tensor
     sums = tuple(float(x) for x in g.sum(dim=1))
@@ -43,9 +43,9 @@ def test_grads_full_consistent_with_stacked_tensor():
     import types
 
     sys = _Sys3()
-    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
-    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
-    j2 = types.SimpleNamespace(job_id="j2", op="__neg__", src_ids=(2,), residual=None)
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None, param_schema=("sphere",))
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None, param_schema=("sphere",))
+    j2 = types.SimpleNamespace(job_id="j2", op="__neg__", src_ids=(2,), residual=None, param_schema=("sphere",))
     res = run_batched_vjp(sys=sys, jobs=(j0, j1, j2))
     g = res.grads_per_source_tensor
     g0 = g[0]

--- a/tests/test_spring_async_toy_tensor_glist.py
+++ b/tests/test_spring_async_toy_tensor_glist.py
@@ -22,8 +22,8 @@ def test_run_batched_vjp_returns_tensor_per_source():
     from src.common.tensors.autoautograd.whiteboard_runtime import run_batched_vjp
 
     sys_obj = _Sys()
-    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None)
-    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None)
+    j0 = types.SimpleNamespace(job_id="j0", op="__neg__", src_ids=(0,), residual=None, param_schema=("sphere",))
+    j1 = types.SimpleNamespace(job_id="j1", op="__neg__", src_ids=(1,), residual=None, param_schema=("sphere",))
     res = run_batched_vjp(sys=sys_obj, jobs=(j0, j1))
     g = res.grads_per_source_tensor
     assert getattr(g, "shape", None)[0] == 2

--- a/tests/test_whiteboard_probes_logging.py
+++ b/tests/test_whiteboard_probes_logging.py
@@ -22,6 +22,7 @@ def test_whiteboard_runs_probes(monkeypatch, caplog):
         src_ids=(0,),
         residual=AbstractTensor.ones(1),
         fn=lambda x, residual=None, **kw: x,
+        param_schema=("sphere",),
     )
     monkeypatch.setenv("WHITEBOARD_PROBES", "1")
     with caplog.at_level(logging.INFO):

--- a/tests/test_zero_grad_logging.py
+++ b/tests/test_zero_grad_logging.py
@@ -22,6 +22,7 @@ def test_zero_grad_warning_truncates_union_ids(caplog):
         src_ids=tuple(range(10)),
         residual=None,
         fn=lambda x, residual=None, **kw: x,
+        param_schema=("sphere",),
     )
     with caplog.at_level(logging.DEBUG):
         wr.run_batched_vjp(sys=sys, jobs=(job,))


### PR DESCRIPTION
## Summary
- extend `_WBJob` with `param_schema`, `fn_args`, and `fn_kwargs`
- slice batched tensors by per-job schemas in `run_batched_vjp`
- allow `SlotBackpropQueue` to forward param schemas and drop global `node_attrs`
- add test for disjoint job schemas

## Testing
- `pytest tests/autoautograd/test_slot_backprop_queue.py tests/autoautograd/test_param_schema_union.py tests/test_zero_grad_logging.py tests/test_grad_validation.py tests/test_spring_async_toy_tensor_glist.py tests/test_whiteboard_probes_logging.py tests/test_whiteboard_runtime_none_grads.py tests/test_scheduling_module.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62b190454832a8bf5fa9060e3a456