### PR TITLE
Avoid forward replay in FluxSpring spectral routing

### DIFF
--- a/tests/autoautograd/test_fluxspring_param_schema_grad.py
+++ b/tests/autoautograd/test_fluxspring_param_schema_grad.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring import ParamWheel
+from src.common.tensors.autoautograd.slot_backprop import SlotBackpropQueue
+from src.common.tensors.autoautograd.whiteboard_runtime import _WBJob
+from src.common.tensors.autoautograd.fluxspring.demo_spectral_routing import FLUX_PARAM_SCHEMA
+
+
+def _sys_for_slot(wheels, slot):
+    nodes = {}
+    for i, w in enumerate(wheels):
+        attrs = {name: AT.tensor(0.0) for name in FLUX_PARAM_SCHEMA}
+        attr = w.label.rsplit(".", 1)[-1]
+        attrs[attr] = w.params[slot]
+        nodes[i] = SimpleNamespace(**attrs)
+    return SimpleNamespace(nodes=nodes)
+
+
+def test_multi_attribute_param_schema_grad():
+    a = AT.tensor(1.0); a.requires_grad_(True)
+    w = AT.tensor(2.0); w.requires_grad_(True)
+    b = AT.tensor(3.0); b.requires_grad_(True)
+    wheels = [
+        ParamWheel(a, lambda t: None, slots=1, label="n.ctrl.alpha"),
+        ParamWheel(w, lambda t: None, slots=1, label="n.ctrl.w"),
+        ParamWheel(b, lambda t: None, slots=1, label="n.ctrl.b"),
+    ]
+    for wheel in wheels:
+        wheel.rotate(); wheel.bind_slot()
+    mgr = SlotBackpropQueue(wheels)
+
+    def _fn(alpha, w_, b_):
+        return alpha * w_ + b_
+
+    job = _WBJob(
+        job_id="train",
+        op=None,
+        src_ids=tuple(range(len(wheels))),
+        residual=AT.tensor(1.0),
+        fn=_fn,
+        param_schema=("alpha", "w", "b"),
+    )
+    mgr.queue_job(0, job)
+    res = mgr.process_slot(0, sys=_sys_for_slot(wheels, 0))
+    assert res is not None
+    g = AT.get_tensor(res.grads_per_source_tensor)
+    assert bool(g.any())

--- a/tests/autoautograd/test_fluxspring_single_forward.py
+++ b/tests/autoautograd/test_fluxspring_single_forward.py
@@ -1,0 +1,35 @@
+from src.common.tensors.autoautograd.fluxspring.demo_spectral_routing import (
+    build_spec,
+    generate_signals,
+    train_routing,
+)
+from src.common.tensors.autoautograd.fluxspring.fs_types import SpectralCfg, SpectralMetrics
+from src.common.tensors.autoautograd import fluxspring as fs
+
+
+def test_train_routing_single_forward(monkeypatch):
+    bands = [[0.0, 1.0]]
+    spectral_cfg = SpectralCfg(
+        enabled=False,
+        win_len=2,
+        hop_len=1,
+        tick_hz=2.0,
+        metrics=SpectralMetrics(bands=bands),
+    )
+    spec = build_spec(spectral_cfg)
+    sine_chunks, noise_frames = generate_signals(bands, 2, 2.0, frames=2)
+
+    calls = {"count": 0}
+    orig = fs.fs_dec._pump_tick
+
+    def _counting(*args, **kwargs):
+        calls["count"] += 1
+        return orig(*args, **kwargs)
+
+    monkeypatch.setattr(fs.fs_dec, "_pump_tick", _counting)
+
+    import pytest
+
+    with pytest.raises(RuntimeError):
+        train_routing(spec, spectral_cfg, sine_chunks, noise_frames)
+    assert calls["count"] == 2


### PR DESCRIPTION
## Summary
- cache `fs_dec.pump_tick` results inside whiteboard jobs so forward runs once
- reuse cached spectral metrics rather than recomputing on VJP replay

## Testing
- `pytest tests/autoautograd/test_fluxspring_param_schema_grad.py tests/autoautograd/test_slot_backprop_queue.py tests/autoautograd/test_param_schema_union.py tests/autoautograd/test_fluxspring_single_forward.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c62da8225c832a9462e713444867f2