### PR TITLE
Ensure SlotBackprop queues carry param schema for jobs

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -431,7 +431,9 @@ def pump_with_loss(
             fn=_route_fn,
             param_schema=FLUX_PARAM_SCHEMA,
         )
-        ctx.bp_queue.queue_job(None, job_route, tick=fft_tick, kind="main")
+        ctx.bp_queue.queue_job(
+            None, job_route, tick=fft_tick, kind="main", param_schema=FLUX_PARAM_SCHEMA
+        )
         logger.debug(
             "bp_queue.queue_job: tick=%d slot=%d kind=main job_id=%s residual=%s",
             fft_tick,
@@ -467,7 +469,9 @@ def pump_with_loss(
                 fn=_fft_fn,
                 param_schema=FLUX_PARAM_SCHEMA,
             )
-            ctx.bp_queue.queue_job(None, job_fft, tick=fft_tick, kind="spectral")
+            ctx.bp_queue.queue_job(
+                None, job_fft, tick=fft_tick, kind="spectral", param_schema=FLUX_PARAM_SCHEMA
+            )
             logger.debug(
                 "bp_queue.queue_job: tick=%d slot=%d kind=spectral job_id=%s residual=%s",
                 fft_tick,

--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -118,6 +118,9 @@ class SlotBackpropQueue:
             Which residual buffer to apply when the slot is processed.
             ``"main"`` (default) uses :attr:`main_residuals`; ``"spectral"``
             uses :attr:`spectral_residuals`.
+        param_schema:
+            Optional tuple of attribute names describing the parameter layout
+            for this job. If provided, it overrides ``job.param_schema``.
         """
 
         if not isinstance(job, _WBJob):

--- a/tests/autoautograd/test_fluxspring_param_schema_grad.py
+++ b/tests/autoautograd/test_fluxspring_param_schema_grad.py
@@ -41,7 +41,7 @@ def test_multi_attribute_param_schema_grad():
         fn=_fn,
         param_schema=("alpha", "w", "b"),
     )
-    mgr.queue_job(0, job)
+    mgr.queue_job(0, job, param_schema=FLUX_PARAM_SCHEMA)
     res = mgr.process_slot(0, sys=_sys_for_slot(wheels, 0))
     assert res is not None
     g = AT.get_tensor(res.grads_per_source_tensor)

--- a/tests/autoautograd/test_slot_backprop_param_schema_union.py
+++ b/tests/autoautograd/test_slot_backprop_param_schema_union.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring import ParamWheel
+from src.common.tensors.autoautograd.slot_backprop import SlotBackpropQueue
+from src.common.tensors.autoautograd.whiteboard_runtime import (
+    BatchSlices,
+    BatchVJPResult,
+    _WBJob,
+)
+
+
+def test_slot_backprop_param_schema_union():
+    # five scalar parameters, each with its own attribute
+    params = [AT.tensor(v) for v in (1.0, 2.0, 3.0, 4.0, 5.0)]
+    for p in params:
+        p.requires_grad_(True)
+    wheels = [
+        ParamWheel(params[0], lambda t: None, slots=1, label="n.ctrl.alpha"),
+        ParamWheel(params[1], lambda t: None, slots=1, label="n.ctrl.w"),
+        ParamWheel(params[2], lambda t: None, slots=1, label="n.ctrl.b"),
+        ParamWheel(params[3], lambda t: None, slots=1, label="n.ctrl.kappa"),
+        ParamWheel(params[4], lambda t: None, slots=1, label="n.ctrl.l0"),
+    ]
+    for w in wheels:
+        w.rotate(); w.bind_slot()
+    mgr = SlotBackpropQueue(wheels)
+
+    job1 = _WBJob(
+        job_id="j1",
+        op=None,
+        src_ids=(0, 1, 2),
+        residual=AT.tensor(1.0),
+        fn=lambda alpha, w_, b_: alpha * w_ + b_,
+        param_schema=("alpha", "w", "b"),
+    )
+    job2 = _WBJob(
+        job_id="j2",
+        op=None,
+        src_ids=(3, 4),
+        residual=AT.tensor(1.0),
+        fn=lambda kappa, l0: kappa * l0,
+        param_schema=("kappa", "l0"),
+    )
+    mgr.queue_job(0, job1, param_schema=("alpha", "w", "b"))
+    mgr.queue_job(0, job2, param_schema=("kappa", "l0"))
+
+    def _stub_vjp(*, sys, jobs, **_kw):
+        assert jobs[0].param_schema == ("alpha", "w", "b")
+        assert jobs[1].param_schema == ("kappa", "l0")
+        g = AT.tensor([2.0, 1.0, 1.0, 5.0, 4.0])
+        return BatchVJPResult(
+            slices=BatchSlices(
+                index_of={j.job_id: i for i, j in enumerate(jobs)},
+                job_ids=tuple(j.job_id for j in jobs),
+            ),
+            ys=tuple(AT.tensor(0.0) for _ in jobs),
+            grads_full=tuple(AT.tensor(0.0) for _ in jobs),
+            grads_per_source=tuple(() for _ in jobs),
+            grads_per_source_tensor=g,
+            param_grads_full=tuple(),
+            param_grads_tensor=None,
+        )
+
+    mgr.process_slot(0, sys=None, lr=1.0, run_vjp=_stub_vjp)
+
+    # Gradients should have been applied per wheel
+    assert wheels[0].params[0].item() == pytest.approx(-1.0)
+    assert wheels[1].params[0].item() == pytest.approx(1.0)
+    assert wheels[2].params[0].item() == pytest.approx(2.0)
+    assert wheels[3].params[0].item() == pytest.approx(-1.0)
+    assert wheels[4].params[0].item() == pytest.approx(1.0)
+

--- a/tests/autoautograd/test_slot_backprop_queue.py
+++ b/tests/autoautograd/test_slot_backprop_queue.py
@@ -44,8 +44,8 @@ def test_slot_backprop_queue_applies_gradients_per_slot(tmp_path):
             _WBJob(job_id="route", op=None, src_ids=(0,), residual=AT.tensor(0.5), fn=_route_fn),
             _WBJob(job_id="fft", op=None, src_ids=(1,), residual=AT.tensor(0.2), fn=_fft_fn),
         ]
-        mgr.queue_job(0, jobs[0])  # defaults to main queue
-        mgr.queue_job(0, jobs[1], kind="spectral")
+        mgr.queue_job(0, jobs[0], param_schema=("p",))  # defaults to main queue
+        mgr.queue_job(0, jobs[1], kind="spectral", param_schema=("p",))
 
         # Stub run_batched_vjp to emulate composite ops and return gradients
         def _stub_vjp(*, sys, jobs, **_kw):
@@ -108,8 +108,8 @@ def test_slot_backprop_queue_slot_keying():
     job_main = _WBJob(job_id="jm", op=None, src_ids=(0,), residual=AT.tensor(1.0), fn=lambda _: AT.tensor(0.0))
     job_spec = _WBJob(job_id="js", op=None, src_ids=(0,), residual=AT.tensor(2.0), fn=lambda _: AT.tensor(0.0))
 
-    mgr.queue_job(None, job_main, tick=tick, row_idx=row_main)
-    mgr.queue_job(None, job_spec, tick=tick, row_idx=row_spec, kind="spectral")
+    mgr.queue_job(None, job_main, tick=tick, row_idx=row_main, param_schema=("p",))
+    mgr.queue_job(None, job_spec, tick=tick, row_idx=row_spec, kind="spectral", param_schema=("p",))
 
     slot_main = (tick - row_main) % 4
     slot_spec = (tick - row_spec) % 4


### PR DESCRIPTION
## Summary
- document `param_schema` override in `SlotBackpropQueue.queue_job`
- pass explicit `param_schema` when enqueuing FluxSpring route/fft jobs
- update queueing tests and add coverage for mixed-schema slot backprop

## Testing
- `pytest tests/autoautograd/test_fluxspring_param_schema_grad.py tests/autoautograd/test_slot_backprop_queue.py tests/autoautograd/test_slot_backprop_param_schema_union.py tests/autoautograd/test_param_schema_union.py tests/test_grad_validation.py tests/test_zero_grad_logging.py tests/test_whiteboard_probes_logging.py tests/test_spring_async_toy_tensor_glist.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6bc6861bc832abaebeb9bc4225d1e