### PR TITLE
refactor slot selection into helper

### DIFF
--- a/src/common/tensors/autoautograd/slot_backprop.py
+++ b/src/common/tensors/autoautograd/slot_backprop.py
@@ -6,7 +6,7 @@ import logging
 
 from ..abstraction import AbstractTensor as AT
 from .whiteboard_runtime import run_batched_vjp, BatchVJPResult, _WBJob
-from .fluxspring import ParamWheel
+from .fluxspring import ParamWheel, spiral_slot
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class SlotBackpropQueue:
             Row index within the parameter tensor.
         """
 
-        return (tick - row_idx) % self.slots if self.slots else 0
+        return spiral_slot(tick, row_idx, self.slots)
 
     # ------------------------------------------------------------------
     def add_residual(


### PR DESCRIPTION
## Summary
- add `spiral_slot` helper to compute rotating parameter slots
- use `spiral_slot` in `ParamWheel` and `SlotBackpropQueue`
- test `spiral_slot` and update slot keying tests

## Testing
- `pytest tests/autoautograd/test_slot_backprop_queue.py tests/autoautograd/test_slot_backprop_param_schema_union.py tests/autoautograd/test_fluxspring_param_schema_grad.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6cf4fbc40832aaafdc9e76de7a700