### PR TITLE
Add spiral length helper and dynamic queue sizing

### DIFF
--- a/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
+++ b/src/common/tensors/autoautograd/fluxspring/demo_spectral_routing.py
@@ -15,7 +15,7 @@ from .spectral_readout import (
     gather_recent_windows,
     batched_bandpower_from_windows,
 )
-from . import fs_dec, register_param_wheels, ParamWheel, spiral_slot
+from . import fs_dec, register_param_wheels, ParamWheel, spiral_slot, required_spiral_len
 from .fs_harness import RingHarness, RingBuffer
 from .fs_types import (
     DECSpec,
@@ -554,12 +554,7 @@ def train_routing(
     out_buf = RingBuffer(AT.zeros((spec.spectral.win_len, B), dtype=float))
     tgt_buf = RingBuffer(AT.zeros((spec.spectral.win_len, B), dtype=float))
     hist_buf = RingBuffer(AT.zeros((spec.spectral.win_len, B), dtype=float))
-    bp_queue = SlotBackpropQueue(wheels)
-    if bp_queue.slots != spectral_cfg.win_len:
-        raise ValueError(
-            "train_routing: bp_queue.slots %d does not match spectral_cfg.win_len %d"
-            % (bp_queue.slots, spectral_cfg.win_len)
-        )
+    bp_queue = SlotBackpropQueue(wheels, slots=required_spiral_len(spec))
     ctx = RoutingState(
         spec=spec,
         harness=harness,

--- a/tests/autoautograd/test_required_spiral_len.py
+++ b/tests/autoautograd/test_required_spiral_len.py
@@ -1,0 +1,62 @@
+from src.common.tensors.abstraction import AbstractTensor as AT
+from src.common.tensors.autoautograd.fluxspring import (
+    FluxSpringSpec,
+    NodeSpec,
+    NodeCtrl,
+    LearnCtrl,
+    EdgeSpec,
+    EdgeCtrl,
+    EdgeTransport,
+    EdgeTransportLearn,
+    DECSpec,
+    SpectralCfg,
+    register_param_wheels,
+    required_spiral_len,
+)
+from src.common.tensors.autoautograd.slot_backprop import SlotBackpropQueue
+
+
+def _build_spec(win_len: int) -> FluxSpringSpec:
+    param = AT.tensor(1.0)
+    param.requires_grad_(True)
+    node = NodeSpec(
+        id=0,
+        p0=AT.get_tensor([0.0]),
+        v0=AT.get_tensor([0.0]),
+        mass=AT.tensor(1.0),
+        ctrl=NodeCtrl(w=param, learn=LearnCtrl(alpha=False, w=True, b=False)),
+        scripted_axes=[0],
+    )
+    edge = EdgeSpec(
+        src=0,
+        dst=0,
+        transport=EdgeTransport(learn=EdgeTransportLearn(False, False, False, False, False)),
+        ctrl=EdgeCtrl(learn=LearnCtrl(False, False, False)),
+    )
+    spectral = SpectralCfg(enabled=True, win_len=win_len)
+    return FluxSpringSpec(
+        version="t",
+        D=1,
+        nodes=[node],
+        edges=[edge],
+        faces=[],
+        dec=DECSpec(D0=[[0.0]], D1=[]),
+        spectral=spectral,
+    )
+
+
+def test_required_spiral_len_grows_with_delay():
+    spec = _build_spec(5)
+    base = required_spiral_len(spec)
+    assert base == 5
+    assert required_spiral_len(spec, extra_delay=3) == base + 3
+
+
+def test_wheels_and_queue_respect_required_len():
+    extra = 2
+    spec = _build_spec(4)
+    slots = required_spiral_len(spec, extra)
+    wheels = register_param_wheels(spec, extra_delay=extra)
+    assert all(len(w.versions()) == slots for w in wheels)
+    q = SlotBackpropQueue(wheels, slots=slots)
+    assert q.slots == slots


### PR DESCRIPTION
## Summary
- add `required_spiral_len` helper to compute spiral buffer length with optional extra delay
- allow `ParamWheel` and `SlotBackpropQueue` to grow until explicitly frozen
- size param wheels and backprop queue using `required_spiral_len` and cover with unit tests

## Testing
- `pytest tests/autoautograd/test_required_spiral_len.py tests/autoautograd/test_param_version_rings.py::test_param_wheels_sized_to_spectral_window tests/autoautograd/test_slot_backprop_queue.py tests/autoautograd/test_slot_backprop_queue_rows.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6daf5188c832aa4fa49979340094b