### PR TITLE
Add AbstractTensor.view reshape alias

### DIFF
--- a/src/common/tensors/abstraction.py
+++ b/src/common/tensors/abstraction.py
@@ -2935,6 +2935,7 @@ def _bind_and_wrap(mapping: Dict[str, Callable]) -> None:
 
 _bind_and_wrap({
     "reshape": _reshape_methods.reshape,
+    "view": _reshape_methods.view,
     "flatten": _reshape_methods.flatten,
     "transpose": _reshape_methods.transpose,
     "permute": _reshape_methods.permute,
@@ -3020,6 +3021,7 @@ def T(self) -> "AbstractTensor":
     return self.transpose(-2, -1)
 
 AbstractTensor.reshape = _reshape_methods.reshape
+AbstractTensor.view = _reshape_methods.view
 AbstractTensor.flatten = _reshape_methods.flatten
 AbstractTensor.transpose = _reshape_methods.transpose
 AbstractTensor.permute = _reshape_methods.permute


### PR DESCRIPTION
## Summary
- add a shared reshape dispatcher to support both reshape() and the new view() alias
- expose AbstractTensor.view so NumPy-backed tensors support PyTorch-style view semantics

## Testing
- pytest tests/test_autograd_reshape.py
- python -m src.common.tensors.autoautograd.fluxspring.demo_spectral_routing *(fails: whiteboard op produced no gradients)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6974ab8832a9f42dc9baecb4eb3